### PR TITLE
Fix building in serial.

### DIFF
--- a/src/generate_databases/Makefile.in
+++ b/src/generate_databases/Makefile.in
@@ -238,7 +238,7 @@ $O/%.noadios.o: %.f90
 	${FC} -c -o $@ $<
 
 $O/%.shared_noadios.o: ${SHARED}/%.f90 .FORCE
-	${MPIFC} -c -o $@ $<
+	${FC} -c -o $@ $<
 
 $O/%.shared_adios.o: ${SHARED}/%.f90 ${SHARED}/constants.h .FORCE
 	${MPIFC} -c $(ADIOS_INC) $(FCFLAGS) $(MPI_INCLUDES) -o $@ $<
@@ -255,7 +255,7 @@ $O/%.shared_adios.o: ${SHARED}/%.F90 ${SHARED}/constants.h .FORCE
 ###
 
 $O/%.o: %.f90 $(SHARED)constants.h
-	${MPIFCCOMPILE_CHECK} -c -o $@ $<
+	${FCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.shared.o: $(SHARED)%.f90 $(SHARED)constants.h .FORCE
 	${FCCOMPILE_CHECK} -c -o $@ $<

--- a/src/generate_databases/generate_databases.f90
+++ b/src/generate_databases/generate_databases.f90
@@ -189,7 +189,6 @@
   subroutine generate_databases
 
   use adios_manager_mod
-  use mpi
   use generate_databases_par
 
   implicit none

--- a/src/meshfem3D/Makefile.in
+++ b/src/meshfem3D/Makefile.in
@@ -208,7 +208,7 @@ $O/%.noadios.o: %.f90
 	${FC} -c -o $@ $<
 
 $O/%.shared_noadios.o: ${SHARED}/%.f90 .FORCE
-	${MPIFC} -c -o $@ $<
+	${FC} -c -o $@ $<
 
 $O/%.shared_adios.o: ${SHARED}/%.f90 ${SHARED}/constants.h .FORCE
 	${MPIFC} -c $(ADIOS_INC) $(FCFLAGS) $(MPI_INCLUDES) -o $@ $<
@@ -224,7 +224,7 @@ $O/%.shared_adios.o: ${SHARED}/%.F90 ${SHARED}/constants.h .FORCE
 ###
 
 $O/%.shared.o: $(SHARED)%.f90 $(SHARED)constants.h .FORCE
-	${MPIFCCOMPILE_CHECK} -c -o $@ $<
+	${FCCOMPILE_CHECK} -c -o $@ $<
 
 ###
 ### C compilation
@@ -305,7 +305,7 @@ $O/read_topo_bathy_file.o: ${SHARED}constants.h ${SHARED}/read_topo_bathy_file.f
 	${FCCOMPILE_CHECK} -c -o $O/read_topo_bathy_file.o ${SHARED}/read_topo_bathy_file.f90
 
 $O/create_regions_mesh.o: ${SHARED}constants.h create_regions_mesh.f90
-	${MPIFCCOMPILE_CHECK} -c -o $O/create_regions_mesh.o create_regions_mesh.f90
+	${FCCOMPILE_CHECK} -c -o $O/create_regions_mesh.o create_regions_mesh.f90
 
 $O/create_name_database.o: ${SHARED}constants.h create_name_database.f90
 	${FCCOMPILE_CHECK} -c -o $O/create_name_database.o create_name_database.f90

--- a/src/meshfem3D/create_regions_mesh.f90
+++ b/src/meshfem3D/create_regions_mesh.f90
@@ -42,7 +42,6 @@ contains
 
     ! create the different regions of the mesh
   use adios_manager_mod
-  use mpi
 
     implicit none
 

--- a/src/shared/adios_manager_stubs.f90
+++ b/src/shared/adios_manager_stubs.f90
@@ -6,13 +6,11 @@ module adios_manager_mod
 contains
 
 subroutine no_adios_err()
-  use mpi
-
   implicit none
 
-  integer :: myrank, code, ier
+  integer :: myrank, code
 
-  call MPI_Comm_rank(MPI_COMM_WORLD, myrank, ier)
+  call world_rank(myrank)
   if (myrank == 0) then
     print *, "----------------------------------------------------"
     print *, "Not configure to be compile with ADIOS."
@@ -20,7 +18,7 @@ subroutine no_adios_err()
     print *, "or reconfigure using --with-adios."
     print *, "----------------------------------------------------"
   endif
-  call MPI_Abort(MPI_COMM_WORLD, code, ier)
+  call stop_all()
 end subroutine
 
 !==============================================================================

--- a/src/shared/safe_alloc_mod.f90
+++ b/src/shared/safe_alloc_mod.f90
@@ -110,15 +110,14 @@ contains
 !>
 subroutine check_alloc_err(ier, usr_msg)
   use iso_fortran_env, only : error_unit
-  use mpi
 
   integer, intent(in) :: ier
   character(len=*), intent(in), optional :: usr_msg
 
-  integer :: myrank, mpi_er
+  integer :: myrank
 
   if(ier /= 0) then
-    call MPI_Comm_rank(MPI_COMM_WORLD, myrank, mpi_er)
+    call world_rank(myrank)
     if (present(usr_msg)) then
       write(error_unit, "('Process ', i6.6, " // &
                         "': Allocation error. ', A)") myrank, usr_msg
@@ -126,8 +125,7 @@ subroutine check_alloc_err(ier, usr_msg)
       write(error_unit, "('Process ', i6.6, ': Allocation error. " // &
                         " No user message specified.')") myrank
     endif
-    !call exit(ier)
-    call MPI_Abort(MPI_COMM_WORLD, ier, mpi_er)
+    call stop_all()
   endif
 end subroutine check_alloc_err
 
@@ -135,15 +133,14 @@ end subroutine check_alloc_err
 !>
 subroutine check_dealloc_err(ier, usr_msg)
   use iso_fortran_env, only : error_unit
-  use mpi
 
   integer, intent(in) :: ier
   character(len=*), intent(in), optional :: usr_msg
 
-  integer :: myrank, mpi_er
+  integer :: myrank
 
   if(ier /= 0) then
-    call MPI_Comm_rank(MPI_COMM_WORLD, myrank, mpi_er)
+    call world_rank(myrank)
     if (present(usr_msg)) then
       write(error_unit, "('Process ', i6.6, " // &
                         "': Deallocation error. ', A)") myrank, usr_msg
@@ -151,8 +148,7 @@ subroutine check_dealloc_err(ier, usr_msg)
       write(error_unit, "('Process ', i6.6, ': Deallocation error. " // &
                         " No user message specified.')") myrank
     endif
-    !call exit(ier)
-    call MPI_Abort(MPI_COMM_WORLD, ier, mpi_er)
+    call stop_all()
   endif
 end subroutine check_dealloc_err
 

--- a/src/specfem3D/Makefile.in
+++ b/src/specfem3D/Makefile.in
@@ -436,7 +436,7 @@ $O/%.noadios.o: %.f90
 	${FC} -c -o $@ $<
 
 $O/%.shared_noadios.o: ${SHARED}/%.f90 .FORCE
-	${MPIFC} -c -o $@ $<
+	${FC} -c -o $@ $<
 
 $O/%.shared_adios.o: ${SHARED}/%.f90 ${SHARED}/constants.h .FORCE
 	${MPIFC} -c $(ADIOS_INC) $(FCFLAGS) $(MPI_INCLUDES) -o $@ $<


### PR DESCRIPTION
I was working on #84 and realized that things won't build without MPI: `./configure --without-mpi`.

That's because a few files don't use the MPI wrappers and use the MPI compiler which isn't necessary.
