### PR TITLE
Trick the implicit interface of the adios stub module by calling a dummy...

### DIFF
--- a/src/auxiliaries/bypass_implicit_interface.f90
+++ b/src/auxiliaries/bypass_implicit_interface.f90
@@ -1,0 +1,6 @@
+
+!=============================================================================
+!> Shut down warnings, for unused arguments due to the implicit interface
+subroutine dimitrize_args()
+end subroutine
+

--- a/src/auxiliaries/combine_vol_data_adios_stubs.f90
+++ b/src/auxiliaries/combine_vol_data_adios_stubs.f90
@@ -44,6 +44,10 @@ subroutine read_args_adios(arg, MAX_NUM_NODES, node_list, num_node,   &
   integer :: num_node, ires
   character(len=*) :: var_name, value_file_name, mesh_file_name, &
                                    outdir
+
+  call dimitrize_args(arg, MAX_NUM_NODES, node_list, num_node,   &
+                      var_name, value_file_name, mesh_file_name, &
+                      outdir, ires)
   call no_adios_err()
 end subroutine read_args_adios
 
@@ -53,6 +57,9 @@ subroutine init_adios(value_file_name, mesh_file_name, &
   ! Parameters
   character(len=*) :: value_file_name, mesh_file_name
   integer(kind=8) :: value_handle, mesh_handle
+
+  call dimitrize_args(value_file_name, mesh_file_name, &
+                      value_handle, mesh_handle)
   call no_adios_err()
 end subroutine init_adios
 
@@ -60,6 +67,8 @@ end subroutine init_adios
 subroutine clean_adios(value_handle, mesh_handle)
   ! Parameters
   integer(kind=8) :: value_handle, mesh_handle
+
+  call dimitrize_args(value_handle, mesh_handle)
   call no_adios_err()
 end subroutine clean_adios
 
@@ -70,6 +79,9 @@ subroutine read_scalars_adios_mesh(mesh_handle, iproc, NGLOB_AB, NSPEC_AB, &
   integer(kind=8) :: mesh_handle
   integer :: iproc
   integer :: NGLOB_AB, NSPEC_AB, ibool_offset, x_global_offset
+
+  call dimitrize_args(mesh_handle, iproc, NGLOB_AB, NSPEC_AB, &
+                      ibool_offset, x_global_offset)
   call no_adios_err()
 end subroutine read_scalars_adios_mesh
 
@@ -80,6 +92,9 @@ subroutine read_ibool_adios_mesh(mesh_handle, ibool_offset, &
   integer(kind=8) :: mesh_handle
   integer :: ibool_offset, NGLLX, NGLLY, NGLLZ, NSPEC_AB
   integer, dimension(:,:,:,:) :: ibool
+
+  call dimitrize_args(mesh_handle, ibool_offset, &
+                      NGLLX, NGLLY, NGLLZ, NSPEC_AB, ibool)
   call no_adios_err()
 end subroutine read_ibool_adios_mesh
 
@@ -91,6 +106,9 @@ subroutine read_coordinates_adios_mesh(mesh_handle, x_global_offset,  &
   integer(kind=8) :: mesh_handle
   integer :: x_global_offset, NGLOB_AB
   real(kind=CUSTOM_REAL),dimension(:) :: xstore, ystore, zstore
+
+  call dimitrize_args(mesh_handle, x_global_offset,  &
+                      NGLOB_AB, xstore, ystore, zstore)
   call no_adios_err()
 end subroutine read_coordinates_adios_mesh
 
@@ -102,6 +120,8 @@ subroutine read_double_values_adios(value_handle, var_name, ibool_offset, &
   character(len=*) :: var_name
   integer :: ibool_offset, NSPEC_AB
   double precision, dimension(:,:,:,:) :: dat
+
+  call dimitrize_args(value_handle, var_name, ibool_offset, NSPEC_AB, dat)
   call no_adios_err()
 end subroutine read_double_values_adios
 
@@ -113,6 +133,9 @@ subroutine read_float_values_adios(value_handle, var_name, ibool_offset, &
   character(len=*) :: var_name
   integer :: ibool_offset, NSPEC_AB
   real, dimension(:,:,:,:) :: dat
+
+  call dimitrize_args(value_handle, var_name, ibool_offset, &
+                      NSPEC_AB, dat)
   call no_adios_err()
 end subroutine read_float_values_adios
 

--- a/src/auxiliaries/rules.mk
+++ b/src/auxiliaries/rules.mk
@@ -187,6 +187,7 @@ combine_vol_data_auxiliaries_OBJECTS += \
 	$O/combine_vol_data_adios_impl.aux_adios.o
 else
 combine_vol_data_auxiliaries_OBJECTS += \
+	$O/bypass_implicit_interface.aux_noadios.o \
 	$O/adios_manager_stubs.shared_noadios.o \
 	$O/combine_vol_data_adios_stubs.aux_noadios.o
 endif
@@ -271,7 +272,7 @@ $O/adios_helpers.shared_adios.o: \
 	$O/adios_helpers_definitions.shared_adios.o \
 	$O/adios_helpers_writers.shared_adios.o
 else
-$O/combine_vol_data.aux.o: $O/combine_vol_data_impl.aux.o $O/combine_vol_data_adios_stubs.aux_noadios.o
+$O/combine_vol_data.aux.o: $O/combine_vol_data_impl.aux.o $O/combine_vol_data_adios_stubs.aux_noadios.o $O/bypass_implicit_interface.aux_noadios.o
 endif
 
 


### PR DESCRIPTION
... function with no interface. Deal with unused variable warnings when not configuring with ADIOS>
