### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ autom4te.cache
 config.log
 config.status
 config.h
-./Makefile
+/Makefile
 setup/constants.h
 setup/precision.h
 
@@ -17,9 +17,6 @@ src/generate_databases/*.mod
 src/meshfem3D/*.mod
 src/specfem3D/*.mod
 
-# sources
-src/cuda/specfem3D_gpu_cuda_method_stubs.c.bak
-
 # documentation
 manual_SPECFEM3D_Cartesian.aux
 manual_SPECFEM3D_Cartesian.bbl
@@ -30,4 +27,3 @@ doc/USER_MANUAL/manual_SPECFEM3D_Cartesian.out
 doc/USER_MANUAL/manual_SPECFEM3D_Cartesian.synctex.gz
 doc/USER_MANUAL/manual_SPECFEM3D_Cartesian.toc
 doc/USER_MANUAL/Schedule
-Makefile.org


### PR DESCRIPTION
Fixes the ignore path for the top-level `Makefile`.
