### PR TITLE
fixed all the warnings given by the Portland and Cray compilers on a Cra...

### DIFF
--- a/flags.guess
+++ b/flags.guess
@@ -43,13 +43,13 @@ case $my_FC in
         # Cray Fortran
         #
         DEF_FFLAGS="-O3 -Onoaggress -Oipa0 -hfp2 -Ovector3 -Oscalar3 -Ocache2 -Ounroll2 -Ofusion2 -DFORCE_VECTORIZATION -p \$O" # turn on optimization; -Oaggress -Oipa4 would make it even more aggressive
-        # -eC -eD -ec -en -eI -ea -g -G0  # turn on full debugging and range checking
+        # -eC -eD -ec -en -eI -ea -g -G0 -M 1193 -M 1438 # turn on full debugging and range checking
         ;;
     pgf95|*/pgf95|pgf90|*/pgf90)
         #
         # Portland PGI
         #
-        DEF_FFLAGS="-fast -Mnobounds -Minline -Mneginfo -Mdclchk -Knoieee -Minform=warn -Mdaz -Mflushz -Mvect -DFORCE_VECTORIZATION"
+        DEF_FFLAGS="-fast -Mnobounds -Minline -Mneginfo -Mdclchk -Knoieee -Minform=inform -Mdaz -Mflushz -Mvect -DFORCE_VECTORIZATION -mcmodel=medium"
         # -Mbounds
         # -fastsse -tp amd64e -Msmart
         ;;

--- a/src/auxiliaries/combine_surf_data.f90
+++ b/src/auxiliaries/combine_surf_data.f90
@@ -59,7 +59,7 @@ program combine_surf_data
   integer,dimension(:),allocatable :: num_ibool
 
   logical :: HIGH_RESOLUTION_MESH,  FILE_ARRAY_IS_3D
-  integer :: ires, nspec_surf, npoint1, npoint2, ispec_surf, inx, iny, idim, ier
+  integer :: ires, nspec_surf, npoint1, npoint2, ispec_surf, inx, iny, idimval, ier
   integer,dimension(:), allocatable ::  ibelm_surf
 
 
@@ -99,7 +99,7 @@ program combine_surf_data
     indir= arg(4)
     outdir = arg(5)
     read(arg(6),*) ires
-    read(arg(7),*) idim
+    read(arg(7),*) idimval
   else
     read(arg(1),*) proc1
     read(arg(2),*) proc2
@@ -112,7 +112,7 @@ program combine_surf_data
     indir = arg(5)
     outdir = arg(6)
     read(arg(7),*) ires
-    read(arg(8),*) idim
+    read(arg(8),*) idimval
   endif
 
   if (ires == 0) then
@@ -125,7 +125,7 @@ program combine_surf_data
     iny = 1
   endif
 
-  if (idim == 0) then
+  if (idimval == 0) then
     FILE_ARRAY_IS_3D = .false.
   else
     FILE_ARRAY_IS_3D = .true.

--- a/src/auxiliaries/combine_vol_data.f90
+++ b/src/auxiliaries/combine_vol_data.f90
@@ -118,7 +118,7 @@
 
   call init()
   call world_size(sizeprocs)
-  if (sizeprocs .ne. 1) then
+  if (sizeprocs /= 1) then
     print *, "sequential program. Only mpirun -np 1 ..."
     call stop_all()
   endif

--- a/src/auxiliaries/convolve_source_timefunction.f90
+++ b/src/auxiliaries/convolve_source_timefunction.f90
@@ -40,11 +40,11 @@
 
   integer :: i,j,N_j,number_remove,nlines
 
-  double precision :: alpha,dt,tau_j,source,exponent,t1,t2,displ1,displ2,gamma,height,half_duration_triangle
+  double precision :: alpha,dt,tau_j,source,exponentval,t1,t2,displ1,displ2,gamma,height,half_duration_triangle
 
   logical :: triangle
 
-  double precision, dimension(:), allocatable :: time,sem,sem_fil
+  double precision, dimension(:), allocatable :: timeval,sem,sem_fil
 
 ! read file with number of lines in input
   open(unit=33,file='input_convolve_code.txt',status='old',action='read')
@@ -54,18 +54,18 @@
   close(33)
 
 ! allocate arrays
-  allocate(time(nlines),sem(nlines),sem_fil(nlines))
+  allocate(timeval(nlines),sem(nlines),sem_fil(nlines))
 
 ! read the input seismogram
   do i = 1,nlines
-    read(5,*) time(i),sem(i)
+    read(5,*) timeval(i),sem(i)
   enddo
 
 ! define a Gaussian with the right exponent to mimic a triangle of equivalent half duration
   alpha = SOURCE_DECAY_MIMIC_TRIANGLE/half_duration_triangle
 
 ! compute the time step
-  dt = time(2) - time(1)
+  dt = timeval(2) - timeval(1)
 
 ! number of integers for which the source wavelet is different from zero
   if(triangle) then
@@ -108,9 +108,9 @@
       else
 
 ! convolve with a Gaussian
-        exponent = alpha**2 * tau_j**2
-        if(exponent < 50.d0) then
-          source = alpha*exp(-exponent)/sqrt(PI)
+        exponentval = alpha**2 * tau_j**2
+        if(exponentval < 50.d0) then
+          source = alpha*exp(-exponentval)/sqrt(PI)
         else
           source = 0.d0
         endif
@@ -127,7 +127,7 @@
 ! compute number of samples to remove from end of seismograms
   number_remove = N_j + 1
   do i=1,nlines - number_remove
-    write(*,*) sngl(time(i)),' ',sngl(sem_fil(i))
+    write(*,*) sngl(timeval(i)),' ',sngl(sem_fil(i))
   enddo
 
   end program convolve_source_time_function

--- a/src/auxiliaries/create_movie_shakemap_AVS_DX_GMT.f90
+++ b/src/auxiliaries/create_movie_shakemap_AVS_DX_GMT.f90
@@ -81,7 +81,7 @@
 
   ! for sorting routine
   integer :: npointot,ilocnum,nglob,i,j,ielm,ieoff,ispecloc
-  integer, dimension(:), allocatable :: iglob,loc,ireorder
+  integer, dimension(:), allocatable :: iglob,locval,ireorder
   logical, dimension(:), allocatable :: ifseg,mask_point
   double precision, dimension(:), allocatable :: xp,yp,zp,xp_save,yp_save,zp_save,field_display
 
@@ -274,7 +274,7 @@
   npointot = NGNOD2D_FOUR_CORNERS_AVS_DX * nspectot_AVS_max
 
   ! allocate arrays for sorting routine
-  allocate(iglob(npointot),loc(npointot), &
+  allocate(iglob(npointot),locval(npointot), &
           ifseg(npointot), &
           xp(npointot),yp(npointot),zp(npointot), &
           xp_save(npointot),yp_save(npointot),zp_save(npointot), &
@@ -538,7 +538,7 @@
 
       ! sort the list based upon coordinates to get rid of multiples
       print *,'sorting list of points'
-      call get_global_AVS(nspectot_AVS_max,xp,yp,zp,iglob,loc,ifseg,nglob,npointot, &
+      call get_global_AVS(nspectot_AVS_max,xp,yp,zp,iglob,locval,ifseg,nglob,npointot, &
            dble(minval(store_val_x(:))),dble(maxval(store_val_x(:))))
 
       ! print total number of points found
@@ -807,7 +807,7 @@ enddo ! it
   deallocate(store_val_uz)
 
   ! deallocate arrays for sorting routine
-  deallocate(iglob,loc)
+  deallocate(iglob,locval)
   deallocate(ifseg)
   deallocate(xp,yp,zp)
   deallocate(xp_save,yp_save,zp_save)
@@ -828,7 +828,7 @@ enddo ! it
 !=====================================================================
 !
 
-  subroutine get_global_AVS(nspec,xp,yp,zp,iglob,loc,ifseg,nglob,npointot,UTM_X_MIN,UTM_X_MAX)
+  subroutine get_global_AVS(nspec,xp,yp,zp,iglob,locval,ifseg,nglob,npointot,UTM_X_MIN,UTM_X_MAX)
 
 ! this routine MUST be in double precision to avoid sensitivity
 ! to roundoff errors in the coordinates of the points
@@ -844,7 +844,7 @@ enddo ! it
   double precision SMALLVALTOL
 
   integer npointot
-  integer iglob(npointot),loc(npointot)
+  integer iglob(npointot),locval(npointot)
   logical ifseg(npointot)
   double precision xp(npointot),yp(npointot),zp(npointot)
   integer nspec,nglob
@@ -874,7 +874,7 @@ enddo ! it
   do ispec=1,nspec
     ieoff=NGNOD2D_FOUR_CORNERS_AVS_DX*(ispec-1)
     do ilocnum=1,NGNOD2D_FOUR_CORNERS_AVS_DX
-      loc(ilocnum+ieoff)=ilocnum+ieoff
+      locval(ilocnum+ieoff)=ilocnum+ieoff
     enddo
   enddo
 
@@ -896,7 +896,7 @@ enddo ! it
     else
       call rank(zp(ioff),ind,ninseg(iseg))
     endif
-    call swap_all(loc(ioff),xp(ioff),yp(ioff),zp(ioff),iwork,work,ind,ninseg(iseg))
+    call swap_all(locval(ioff),xp(ioff),yp(ioff),zp(ioff),iwork,work,ind,ninseg(iseg))
     ioff=ioff+ninseg(iseg)
   enddo
 
@@ -932,7 +932,7 @@ enddo ! it
   ig=0
   do i=1,npointot
     if(ifseg(i)) ig=ig+1
-    iglob(loc(i))=ig
+    iglob(locval(i))=ig
   enddo
 
   nglob=ig

--- a/src/auxiliaries/model_update.f90
+++ b/src/auxiliaries/model_update.f90
@@ -124,7 +124,7 @@ program model_update
   !gradients in direction of steepest descent (= - kernels)
   real(kind=CUSTOM_REAL) :: min_vs_g, max_vs_g, min_vp_g, max_vp_g, min_rho_g, max_rho_g
   real(kind=CUSTOM_REAL) :: min_vp,min_vs,max_vp,max_vs,min_rho,max_rho, &
-                            max,minmax(4),vs_sum,vp_sum,rho_sum
+                            maxvalue,minmax(4),vs_sum,vp_sum,rho_sum
 
   integer :: i,j,k,ispec
 
@@ -165,12 +165,12 @@ program model_update
     call exit_MPI(myrank,'error step factor')
   endif
 
-  call sync_all()
+  call synchronize_all()
 
   ! reads in parameters and checks for some inconsistencies
   call initialize_simulation()
 
-  call sync_all()
+  call synchronize_all()
 
   ! reads in external mesh
   call read_mesh_databases()
@@ -188,7 +188,7 @@ program model_update
     print*,'NGLOB            ', NGLOB
   endif
 
-  call sync_all()
+  call synchronize_all()
 
   !! allocation
   ! model and kernel variables
@@ -549,10 +549,10 @@ program model_update
     minmax(3) = abs(min_vp_g)
     minmax(4) = abs(max_vp_g)
 
-    max = maxval(minmax)
-    step_length = step_fac/max
+    maxvalue = maxval(minmax)
+    step_length = step_fac/maxvalue
 
-    print*,'  step length : ',step_length,max
+    print*,'  step length : ',step_length,maxvalue
     print*
   endif
   tmp_step(1) = step_length
@@ -788,12 +788,12 @@ program model_update
   rmass_old = 0._CUSTOM_REAL
   rmass_old = rmass
 
-  call sync_all()
+  call synchronize_all()
 
   ! create mass matrix ONLY for the elastic case
   allocate(rmass_new(NGLOB))
 
-  call sync_all()
+  call synchronize_all()
 
   if( myrank == 0) then
     print*, '  ...creating mass matrix '
@@ -832,7 +832,7 @@ program model_update
   enddo ! nspec
 
 
-  call sync_all()
+  call synchronize_all()
 
   ! dummy allocations, arrays are not needed since the update here only works for elastic models
   allocate(rmass_acoustic_new(NGLOB))
@@ -913,7 +913,7 @@ program model_update
   enddo
 
 
-  call sync_all()
+  call synchronize_all()
 
   ! calculate min_resolved_period needed for attenuation model
   call check_mesh_resolution(myrank,NSPEC,NGLOB,ibool,&
@@ -922,7 +922,7 @@ program model_update
                             -1.0d0, model_speed_max,min_resolved_period, &
                             LOCAL_PATH,SAVE_MESH_FILES )
 
-  call sync_all()
+  call synchronize_all()
 
   ! saves binary mesh files for attenuation for the NEW model
   call create_name_database(prname_new,myrank,LOCAL_PATH_NEW)
@@ -938,7 +938,7 @@ program model_update
 
   !----------------------------
 
-  call sync_all()
+  call synchronize_all()
 
   if( myrank == 0 ) then
     print*,'external_mesh.bin new: ', prname_new

--- a/src/auxiliaries/smooth_vol_data.f90
+++ b/src/auxiliaries/smooth_vol_data.f90
@@ -145,7 +145,7 @@ program smooth_vol_data
   call world_rank(myrank)
 
   if (myrank == 0) print*,"smooth_vol_data:"
-  call sync_all()
+  call synchronize_all()
 
   ! reads arguments
   do i = 1, 5
@@ -234,7 +234,7 @@ program smooth_vol_data
     endif
     call exit_mpi(myrank,'Error total number of slices')
   endif
-  call sync_all()
+  call synchronize_all()
 
   ! GLL points weights
   call zwgljd(xigll,wxgll,NGLLX,GAUSSALPHA,GAUSSBETA)
@@ -523,7 +523,7 @@ program smooth_vol_data
   !enddo
 
   ! synchronizes
-  call sync_all()
+  call synchronize_all()
 
 
 !----------------------
@@ -732,7 +732,7 @@ program smooth_vol_data
   deallocate(dat_smooth)
 
   ! synchronizes
-  call sync_all()
+  call synchronize_all()
 
   ! the maximum value for the smoothed kernel
   norm = max_old

--- a/src/auxiliaries/sum_kernels.f90
+++ b/src/auxiliaries/sum_kernels.f90
@@ -124,7 +124,7 @@ program sum_kernels
     write(*,*)
     write(*,*) 'reading kernel list: '
   endif
-  call sync_all()
+  call synchronize_all()
 
   ! reads in event list
   nker=0
@@ -171,7 +171,7 @@ program sum_kernels
     endif
     call exit_mpi(myrank,'Error total number of slices')
   endif
-  call sync_all()
+  call synchronize_all()
 
   ! reads mesh file
   !
@@ -202,7 +202,7 @@ program sum_kernels
   endif
 
   ! synchronizes
-  call sync_all()
+  call synchronize_all()
 
   ! sums up kernels
   if( USE_ISO_KERNELS ) then

--- a/src/cuda/initialize_cuda.cu
+++ b/src/cuda/initialize_cuda.cu
@@ -93,8 +93,8 @@ void FC_FUNC_(initialize_cuda_device,
   // Gets number of GPU devices
   device_count = 0;
   cudaGetDeviceCount(&device_count);
-  // Do not check if command failed: 
-  // `exit_on_cuda_error` call cudaDevice/ThreadSynchronize. If multiple 
+  // Do not check if command failed:
+  // `exit_on_cuda_error` call cudaDevice/ThreadSynchronize. If multiple
   // MPI tasks access multiple GPUs per node, they will try to synchronize
   // GPU 0 and depending on the order of the calls error will be raised
   // when setting the device number. If MPS is enabled, some GPUs will silently

--- a/src/decompose_mesh/fault_scotch.f90
+++ b/src/decompose_mesh/fault_scotch.f90
@@ -263,10 +263,10 @@ CONTAINS
   end subroutine reorder_fault_elements_single
 
 ! ---------------------------------------------------------------------------------------------------
-  subroutine lex_order(xyz_c,loc,nspec)
+  subroutine lex_order(xyz_c,locval,nspec)
 
   integer, intent(in) :: nspec
-  integer, intent(out) :: loc(nspec)
+  integer, intent(out) :: locval(nspec)
   double precision, intent(in) :: xyz_c(3,nspec)
 
   double precision, dimension(nspec) :: work,xp,yp,zp
@@ -285,7 +285,7 @@ CONTAINS
 
   ! establish initial pointers
   do ispec=1,nspec
-    loc(ispec)=ispec
+    locval(ispec)=ispec
   enddo
 
   ifseg(:)=.false.
@@ -306,7 +306,7 @@ CONTAINS
       else
         call rank(zp(ioff),ind,ninseg(iseg))
       endif
-      call swap_all(loc(ioff),xp(ioff),yp(ioff),zp(ioff),iwork,work,ind,ninseg(iseg))
+      call swap_all(locval(ioff),xp(ioff),yp(ioff),zp(ioff),iwork,work,ind,ninseg(iseg))
       ioff=ioff+ninseg(iseg)
     enddo
 

--- a/src/generate_databases/create_regions_mesh.f90
+++ b/src/generate_databases/create_regions_mesh.f90
@@ -64,7 +64,7 @@
   real(kind=CUSTOM_REAL) :: model_speed_max,min_resolved_period
 
 ! initializes arrays
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*)
     write(IMAIN,*) '  ...allocating arrays '
@@ -80,7 +80,7 @@
 ! fills location and weights for Gauss-Lobatto-Legendre points, shape and derivations,
 ! returns jacobianstore,xixstore,...gammazstore
 ! and GLL-point locations in xstore,ystore,zstore
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...setting up jacobian '
     call flush_IMAIN()
@@ -100,7 +100,7 @@
 
 
 ! creates ibool index array for projection from local to global points
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...indexing global points'
     call flush_IMAIN()
@@ -117,7 +117,7 @@
 
   if (ANY_FAULT) then
    ! recalculate *store with faults closed
-    call sync_all()
+    call synchronize_all()
     if (myrank == 0) then
       write(IMAIN,*) '  ... resetting up jacobian in fault domains'
       call flush_IMAIN()
@@ -134,7 +134,7 @@
 
 
 ! sets up MPI interfaces between partitions
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...preparing MPI interfaces '
     call flush_IMAIN()
@@ -150,7 +150,7 @@
 
   !SURENDRA (setting up parallel fault)
   if (PARALLEL_FAULT .AND. ANY_FAULT) then
-    call sync_all()
+    call synchronize_all()
     !at this point (xyz)store_dummy are still open
     call fault_setup (ibool,nnodes_ext_mesh,nodes_coords_ext_mesh, &
                     xstore,ystore,zstore,nspec,nglob,myrank)
@@ -159,7 +159,7 @@
 
 
 ! sets up absorbing/free surface boundaries
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...setting up absorbing boundaries '
     call flush_IMAIN()
@@ -174,7 +174,7 @@
 
 ! sets up up Moho surface
   if( SAVE_MOHO_MESH ) then
-    call sync_all()
+    call synchronize_all()
     if( myrank == 0) then
       write(IMAIN,*) '  ...setting up Moho surface'
       call flush_IMAIN()
@@ -185,7 +185,7 @@
   endif
 
 ! sets material velocities
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...determining velocity model'
     call flush_IMAIN()
@@ -193,7 +193,7 @@
   call get_model(myrank)
 
 ! sets up acoustic-elastic-poroelastic coupling surfaces
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...detecting acoustic-elastic-poroelastic surfaces '
     call flush_IMAIN()
@@ -205,7 +205,7 @@
                         my_neighbours_ext_mesh)
 
 ! locates inner and outer elements
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...element inner/outer separation '
     call flush_IMAIN()
@@ -216,7 +216,7 @@
                                     ibool,SAVE_MESH_FILES)
 
 ! colors mesh if requested
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...element mesh coloring '
     call flush_IMAIN()
@@ -224,11 +224,11 @@
   call setup_color_perm(myrank,nspec,nglob,ibool,ANISOTROPY,SAVE_MESH_FILES)
 
 ! overwrites material parameters from external binary files
-  call sync_all()
+  call synchronize_all()
   call get_model_binaries(myrank,nspec,LOCAL_PATH)
 
 ! calculates damping profiles and auxiliary coefficients on all C-PML points
-  call sync_all()
+  call synchronize_all()
   if( PML_CONDITIONS ) then
      if( myrank == 0) then
         write(IMAIN,*) '  ...creating C-PML damping profiles '
@@ -238,7 +238,7 @@
   endif
 
 ! creates mass matrix
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...creating mass matrix '
     call flush_IMAIN()
@@ -246,7 +246,7 @@
   call create_mass_matrices(nglob_dummy,nspec,ibool,PML_CONDITIONS,STACEY_ABSORBING_CONDITIONS)
 
 ! saves the binary mesh files
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...saving databases'
     call flush_IMAIN()
@@ -270,7 +270,7 @@
 
 ! saves faults
   if( ANY_FAULT ) then
-    call sync_all()
+    call synchronize_all()
     if( myrank == 0) then
       write(IMAIN,*) '  ...saving fault databases'
       call flush_IMAIN()
@@ -281,7 +281,7 @@
 
 ! saves moho surface
   if( SAVE_MOHO_MESH ) then
-    call sync_all()
+    call synchronize_all()
     if( myrank == 0) then
       write(IMAIN,*) '  ...saving Moho surfaces'
       call flush_IMAIN()
@@ -290,13 +290,13 @@
   endif
 
 ! computes the approximate amount of memory needed to run the solver
-  call sync_all()
+  call synchronize_all()
   call memory_eval(nspec,nglob_dummy,maxval(nibool_interfaces_ext_mesh),num_interfaces_ext_mesh, &
                   APPROXIMATE_OCEAN_LOAD,memory_size)
   call max_all_dp(memory_size, max_memory_size)
 
 ! checks the mesh, stability and resolved period
-  call sync_all()
+  call synchronize_all()
   if( myrank == 0) then
     write(IMAIN,*) '  ...checking mesh resolution'
     call flush_IMAIN()
@@ -319,7 +319,7 @@
 
 ! saves binary mesh files for attenuation
   if( ATTENUATION ) then
-    call sync_all()
+    call synchronize_all()
     if( myrank == 0) then
       write(IMAIN,*) '  ...saving attenuation databases'
       call flush_IMAIN()

--- a/src/generate_databases/fault_generate_databases.f90
+++ b/src/generate_databases/fault_generate_databases.f90
@@ -290,7 +290,7 @@ subroutine setup_ibools(fdb,xstore,ystore,zstore,nspec,npointot)
   double precision, dimension(NGLLX,NGLLY,NGLLZ,nspec), intent(in) :: xstore,ystore,zstore
 
   double precision :: xp(npointot),yp(npointot),zp(npointot),xmin,xmax
-  integer :: loc(npointot)
+  integer :: locval(npointot)
   logical :: ifseg(npointot)
   integer :: ispec,k,igll,ie,je,ke,e
 
@@ -311,7 +311,7 @@ subroutine setup_ibools(fdb,xstore,ystore,zstore,nspec,npointot)
     enddo
   enddo
   allocate( fdb%ibool1(NGLLSQUARE,fdb%nspec) )
-  call get_global(fdb%nspec,xp,yp,zp,fdb%ibool1,loc,ifseg,fdb%nglob,npointot,xmin,xmax)
+  call get_global(fdb%nspec,xp,yp,zp,fdb%ibool1,locval,ifseg,fdb%nglob,npointot,xmin,xmax)
 
 ! xp,yp,zp need to be recomputed on side 2
 ! because they are generally not in the same order as on side 1,
@@ -331,7 +331,7 @@ subroutine setup_ibools(fdb,xstore,ystore,zstore,nspec,npointot)
     enddo
   enddo
   allocate( fdb%ibool2(NGLLSQUARE,fdb%nspec) )
-  call get_global(fdb%nspec,xp,yp,zp,fdb%ibool2,loc,ifseg,fdb%nglob,npointot,xmin,xmax)
+  call get_global(fdb%nspec,xp,yp,zp,fdb%ibool2,locval,ifseg,fdb%nglob,npointot,xmin,xmax)
 
 end subroutine setup_ibools
 

--- a/src/generate_databases/finalize_databases.f90
+++ b/src/generate_databases/finalize_databases.f90
@@ -41,7 +41,7 @@
 ! call sum_all_i(NGLOB_AB,nglob_total)
   call sum_all_dp(dble(NGLOB_AB),nglob_total)
 
-  call sync_all()
+  call synchronize_all()
   if(myrank == 0) then
     write(IMAIN,*)
     write(IMAIN,*) 'Repartition of elements:'
@@ -81,7 +81,7 @@
   do i = 1, num_interfaces_ext_mesh
      ibool_interfaces_ext_mesh_dummy(:,:) = ibool_interfaces_ext_mesh(1:max_nibool_interfaces_ext_mesh,:)
   enddo
-  call sync_all()
+  call synchronize_all()
   call detect_surface(NPROC,NGLOB_AB,NSPEC_AB,ibool, &
                         ispec_is_surface_external_mesh, &
                         iglob_is_surface_external_mesh, &
@@ -130,7 +130,7 @@
   endif
 
 ! synchronize all the processes to make sure everybody has finished
-  call sync_all()
+  call synchronize_all()
 
   end subroutine finalize_databases
 

--- a/src/generate_databases/generate_databases.f90
+++ b/src/generate_databases/generate_databases.f90
@@ -446,7 +446,7 @@
   endif
 
 ! makes sure processes are synchronized
-  call sync_all()
+  call synchronize_all()
 
   end subroutine gd_read_parameters
 

--- a/src/generate_databases/get_MPI.f90
+++ b/src/generate_databases/get_MPI.f90
@@ -75,7 +75,7 @@
   integer :: num_points1, num_points2
 
   ! assembly test
-  integer :: i,j,k,ispec,iglob,count,inum,ier
+  integer :: i,j,k,ispec,iglob,countval,inum,ier
   integer :: max_nibool_interfaces_ext_mesh
   integer,dimension(:),allocatable :: test_flag
   real(kind=CUSTOM_REAL), dimension(:),allocatable :: test_flag_cr
@@ -173,7 +173,7 @@
   if( ier /= 0 ) stop 'error allocating array test_flag etc.'
   test_flag(:) = 0
   test_flag_cr(:) = 0._CUSTOM_REAL
-  count = 0
+  countval = 0
   do ispec = 1, nspec
     ! sets flags on global points
     do k = 1, NGLLZ
@@ -183,7 +183,7 @@
           iglob = ibool(i,j,k,ispec)
 
           ! counts number of unique global points to set
-          if( test_flag(iglob) == 0 ) count = count+1
+          if( test_flag(iglob) == 0 ) countval = countval + 1
 
           ! sets identifier
           test_flag(iglob) = myrank + 1
@@ -192,7 +192,7 @@
       enddo
     enddo
   enddo
-  call sync_all()
+  call synchronize_all()
 
   ! collects contributions from different MPI partitions
   ! sets up MPI communications
@@ -200,15 +200,15 @@
   allocate(ibool_interfaces_dummy(max_nibool_interfaces_ext_mesh,num_interfaces_ext_mesh),stat=ier)
   if( ier /= 0 ) stop 'error allocating array ibool_interfaces_dummy'
 
-  count = 0
+  countval = 0
   do iinterface = 1, num_interfaces_ext_mesh
      ibool_interfaces_dummy(:,iinterface) = &
       ibool_interfaces_ext_mesh(1:max_nibool_interfaces_ext_mesh,iinterface)
-     count = count + nibool_interfaces_ext_mesh(iinterface)
+     countval = countval + nibool_interfaces_ext_mesh(iinterface)
   enddo
-  call sync_all()
+  call synchronize_all()
 
-  call sum_all_i(count,iglob)
+  call sum_all_i(countval,iglob)
   if( myrank == 0 ) then
     if( iglob /= ilocnum ) call exit_mpi(myrank,'error total global MPI interface points')
   endif

--- a/src/generate_databases/get_absorbing_boundary.f90
+++ b/src/generate_databases/get_absorbing_boundary.f90
@@ -78,10 +78,10 @@
 
   ! face corner locations
   real(kind=CUSTOM_REAL),dimension(NGNOD2D_FOUR_CORNERS) :: xcoord,ycoord,zcoord
-  integer  :: ispec,ispec2D,icorner,itop,iabs,iface,igll,i,j,igllfree,ifree
+  integer  :: ispec,ispec2D,icorner,itop,iabsval,iface,igll,i,j,igllfree,ifree
 
   ! abs face counter
-  iabs = 0
+  iabsval = 0
 
   ! xmin
   ijk_face(:,:,:) = 0
@@ -129,17 +129,17 @@
     enddo
 
     ! sets face infos
-    iabs = iabs + 1
-    abs_boundary_ispec(iabs) = ispec
+    iabsval = iabsval + 1
+    abs_boundary_ispec(iabsval) = ispec
 
     ! gll points -- assuming NGLLX = NGLLY = NGLLZ
     igll = 0
     do j=1,NGLLZ
       do i=1,NGLLX
         igll = igll+1
-        abs_boundary_ijk(:,igll,iabs) = ijk_face(:,i,j)
-        abs_boundary_jacobian2Dw(igll,iabs) = jacobian2Dw_face(i,j)
-        abs_boundary_normal(:,igll,iabs) = normal_face(:,i,j)
+        abs_boundary_ijk(:,igll,iabsval) = ijk_face(:,i,j)
+        abs_boundary_jacobian2Dw(igll,iabsval) = jacobian2Dw_face(i,j)
+        abs_boundary_normal(:,igll,iabsval) = normal_face(:,i,j)
       enddo
     enddo
 
@@ -191,17 +191,17 @@
     enddo
 
     ! sets face infos
-    iabs = iabs + 1
-    abs_boundary_ispec(iabs) = ispec
+    iabsval = iabsval + 1
+    abs_boundary_ispec(iabsval) = ispec
 
     ! gll points -- assuming NGLLX = NGLLY = NGLLZ
     igll = 0
     do j=1,NGLLZ
       do i=1,NGLLX
         igll = igll+1
-        abs_boundary_ijk(:,igll,iabs) = ijk_face(:,i,j)
-        abs_boundary_jacobian2Dw(igll,iabs) = jacobian2Dw_face(i,j)
-        abs_boundary_normal(:,igll,iabs) = normal_face(:,i,j)
+        abs_boundary_ijk(:,igll,iabsval) = ijk_face(:,i,j)
+        abs_boundary_jacobian2Dw(igll,iabsval) = jacobian2Dw_face(i,j)
+        abs_boundary_normal(:,igll,iabsval) = normal_face(:,i,j)
       enddo
     enddo
 
@@ -253,17 +253,17 @@
     enddo
 
     ! sets face infos
-    iabs = iabs + 1
-    abs_boundary_ispec(iabs) = ispec
+    iabsval = iabsval + 1
+    abs_boundary_ispec(iabsval) = ispec
 
     ! gll points -- assuming NGLLX = NGLLY = NGLLZ
     igll = 0
     do j=1,NGLLZ
       do i=1,NGLLY
         igll = igll+1
-        abs_boundary_ijk(:,igll,iabs) = ijk_face(:,i,j)
-        abs_boundary_jacobian2Dw(igll,iabs) = jacobian2Dw_face(i,j)
-        abs_boundary_normal(:,igll,iabs) = normal_face(:,i,j)
+        abs_boundary_ijk(:,igll,iabsval) = ijk_face(:,i,j)
+        abs_boundary_jacobian2Dw(igll,iabsval) = jacobian2Dw_face(i,j)
+        abs_boundary_normal(:,igll,iabsval) = normal_face(:,i,j)
       enddo
     enddo
 
@@ -315,17 +315,17 @@
     enddo
 
     ! sets face infos
-    iabs = iabs + 1
-    abs_boundary_ispec(iabs) = ispec
+    iabsval = iabsval + 1
+    abs_boundary_ispec(iabsval) = ispec
 
     ! gll points -- assuming NGLLX = NGLLY = NGLLZ
     igll = 0
     do j=1,NGLLY
       do i=1,NGLLX
         igll = igll+1
-        abs_boundary_ijk(:,igll,iabs) = ijk_face(:,i,j)
-        abs_boundary_jacobian2Dw(igll,iabs) = jacobian2Dw_face(i,j)
-        abs_boundary_normal(:,igll,iabs) = normal_face(:,i,j)
+        abs_boundary_ijk(:,igll,iabsval) = ijk_face(:,i,j)
+        abs_boundary_jacobian2Dw(igll,iabsval) = jacobian2Dw_face(i,j)
+        abs_boundary_normal(:,igll,iabsval) = normal_face(:,i,j)
       enddo
     enddo
 
@@ -377,17 +377,17 @@
     enddo
 
     ! sets face infos
-    iabs = iabs + 1
-    abs_boundary_ispec(iabs) = ispec
+    iabsval = iabsval + 1
+    abs_boundary_ispec(iabsval) = ispec
 
     ! gll points -- assuming NGLLX = NGLLY = NGLLZ
     igll = 0
     do j=1,NGLLY
       do i=1,NGLLX
         igll = igll+1
-        abs_boundary_ijk(:,igll,iabs) = ijk_face(:,i,j)
-        abs_boundary_jacobian2Dw(igll,iabs) = jacobian2Dw_face(i,j)
-        abs_boundary_normal(:,igll,iabs) = normal_face(:,i,j)
+        abs_boundary_ijk(:,igll,iabsval) = ijk_face(:,i,j)
+        abs_boundary_jacobian2Dw(igll,iabsval) = jacobian2Dw_face(i,j)
+        abs_boundary_normal(:,igll,iabsval) = normal_face(:,i,j)
       enddo
     enddo
 
@@ -479,17 +479,17 @@
          enddo
 
          ! adds face infos to absorbing boundary surface
-         iabs = iabs + 1
-         abs_boundary_ispec(iabs) = ispec
+         iabsval = iabsval + 1
+         abs_boundary_ispec(iabsval) = ispec
 
          ! gll points -- assuming NGLLX = NGLLY = NGLLZ
          igll = 0
          do j=1,NGLLY
            do i=1,NGLLX
              igll = igll+1
-             abs_boundary_ijk(:,igll,iabs) = ijk_face(:,i,j)
-             abs_boundary_jacobian2Dw(igll,iabs) = jacobian2Dw_face(i,j)
-             abs_boundary_normal(:,igll,iabs) = normal_face(:,i,j)
+             abs_boundary_ijk(:,igll,iabsval) = ijk_face(:,i,j)
+             abs_boundary_jacobian2Dw(igll,iabsval) = jacobian2Dw_face(i,j)
+             abs_boundary_normal(:,igll,iabsval) = normal_face(:,i,j)
            enddo
          enddo
        endif
@@ -531,17 +531,17 @@
          enddo
 
          ! adds face infos to absorbing boundary surface
-         iabs = iabs + 1
-         abs_boundary_ispec(iabs) = ispec
+         iabsval = iabsval + 1
+         abs_boundary_ispec(iabsval) = ispec
 
          ! gll points -- assuming NGLLX = NGLLY = NGLLZ
          igll = 0
          do j=1,NGLLY
            do i=1,NGLLX
              igll = igll+1
-             abs_boundary_ijk(:,igll,iabs) = ijk_face(:,i,j)
-             abs_boundary_jacobian2Dw(igll,iabs) = jacobian2Dw_face(i,j)
-             abs_boundary_normal(:,igll,iabs) = normal_face(:,i,j)
+             abs_boundary_ijk(:,igll,iabsval) = ijk_face(:,i,j)
+             abs_boundary_jacobian2Dw(igll,iabsval) = jacobian2Dw_face(i,j)
+             abs_boundary_normal(:,igll,iabsval) = normal_face(:,i,j)
            enddo
          enddo
        endif
@@ -572,17 +572,17 @@
     stop 'error number of free surface faces'
   endif
 
-  if( iabs /= num_abs_boundary_faces ) then
-    print*,'error number of absorbing faces:',iabs,num_abs_boundary_faces
+  if( iabsval /= num_abs_boundary_faces ) then
+    print*,'error number of absorbing faces:',iabsval,num_abs_boundary_faces
     stop 'error number of absorbing faces'
   endif
 
   call sum_all_i(num_free_surface_faces,itop)
-  call sum_all_i(num_abs_boundary_faces,iabs)
+  call sum_all_i(num_abs_boundary_faces,iabsval)
   if( myrank == 0 ) then
     write(IMAIN,*) '     absorbing boundary:'
     write(IMAIN,*) '     total number of free faces = ',itop
-    write(IMAIN,*) '     total number of faces = ',iabs
+    write(IMAIN,*) '     total number of faces = ',iabsval
     if((PML_CONDITIONS .and. PML_INSTEAD_OF_FREE_SURFACE) .or. &
        (STACEY_ABSORBING_CONDITIONS .and. STACEY_INSTEAD_OF_FREE_SURFACE)) then
        write(IMAIN,*) '     absorbing boundary includes free surface (i.e., top surface converted from free to absorbing)'

--- a/src/generate_databases/get_global.f90
+++ b/src/generate_databases/get_global.f90
@@ -24,7 +24,7 @@
 !
 !=====================================================================
 
-  subroutine get_global(nspec,xp,yp,zp,iglob,loc,ifseg,nglob,npointot,UTM_X_MIN,UTM_X_MAX)
+  subroutine get_global(nspec,xp,yp,zp,iglob,locval,ifseg,nglob,npointot,UTM_X_MIN,UTM_X_MAX)
 
 ! this routine MUST be in double precision to avoid sensitivity
 ! to roundoff errors in the coordinates of the points
@@ -40,7 +40,7 @@
 
   integer npointot
   integer nspec,nglob
-  integer iglob(npointot),loc(npointot)
+  integer iglob(npointot),locval(npointot)
   logical ifseg(npointot)
   double precision xp(npointot),yp(npointot),zp(npointot)
   double precision UTM_X_MIN,UTM_X_MAX
@@ -78,7 +78,7 @@
   do ispec=1,nspec
     ieoff=NGLLCUBE_local*(ispec-1)
     do ilocnum=1,NGLLCUBE_local
-      loc(ilocnum+ieoff)=ilocnum+ieoff
+      locval(ilocnum+ieoff)=ilocnum+ieoff
     enddo
   enddo
 
@@ -100,7 +100,7 @@
       else
         call rank(zp(ioff),ind,ninseg(iseg))
       endif
-      call swap_all(loc(ioff),xp(ioff),yp(ioff),zp(ioff),iwork,work,ind,ninseg(iseg))
+      call swap_all(locval(ioff),xp(ioff),yp(ioff),zp(ioff),iwork,work,ind,ninseg(iseg))
       ioff=ioff+ninseg(iseg)
     enddo
 
@@ -136,7 +136,7 @@
   ig=0
   do i=1,npointot
     if(ifseg(i)) ig=ig+1
-    iglob(loc(i))=ig
+    iglob(locval(i))=ig
   enddo
 
   nglob=ig

--- a/src/generate_databases/pml_set_local_dampingcoeff.f90
+++ b/src/generate_databases/pml_set_local_dampingcoeff.f90
@@ -273,7 +273,7 @@ subroutine pml_set_local_dampingcoeff(myrank,xstore,ystore,zstore)
      write(IMAIN,*)
   endif
 
-  call sync_all()
+  call synchronize_all()
 
   ! loops over all C-PML elements
   do ispec_CPML=1,nspec_cpml

--- a/src/generate_databases/read_partition_files.f90
+++ b/src/generate_databases/read_partition_files.f90
@@ -64,7 +64,7 @@
   if(myrank == 0) then
     write(IMAIN,*) '  external mesh points: ',num
   endif
-  call sync_all()
+  call synchronize_all()
 
 ! read physical properties of the materials
 ! added poroelastic properties and filled with 0 the last 10 entries for elastic/acoustic
@@ -90,7 +90,7 @@
   if(myrank == 0) then
     write(IMAIN,*) '  defined materials: ',nmat_ext_mesh
   endif
-  call sync_all()
+  call synchronize_all()
 
   allocate(undef_mat_prop(6,nundefMat_ext_mesh),stat=ier)
   if( ier /= 0 ) stop 'error allocating array undef_mat_prop'
@@ -106,7 +106,7 @@
   if(myrank == 0) then
     write(IMAIN,*) '  undefined materials: ',nundefMat_ext_mesh
   endif
-  call sync_all()
+  call synchronize_all()
 
 ! element indexing
   read(IIN) nelmnts_ext_mesh
@@ -133,7 +133,7 @@
   if(myrank == 0) then
     write(IMAIN,*) ' total number of spectral elements: ',num
   endif
-  call sync_all()
+  call synchronize_all()
 
 ! reads absorbing/free-surface boundaries
   read(IIN) boundary_number ,nspec2D_xmin
@@ -206,7 +206,7 @@
     write(IMAIN,*) '    ymin,ymax: ',num_ymin,num_ymax
     write(IMAIN,*) '    bottom,top: ',num_bottom,num_top
   endif
-  call sync_all()
+  call synchronize_all()
 
   ! reads number of C-PML elements in the global mesh
   nspec_cpml_tot = 0
@@ -216,7 +216,7 @@
   if(myrank == 0) then
      write(IMAIN,*) ' total number of C-PML elements in the global mesh: ',nspec_cpml_tot
   endif
-  call sync_all()
+  call synchronize_all()
 
   if( nspec_cpml_tot > 0 ) then
      ! reads number of C-PML elements in this partition
@@ -225,7 +225,7 @@
      if(myrank == 0) then
         write(IMAIN,*) '  number of C-PML spectral elements in this partition: ',nspec_cpml
      endif
-     call sync_all()
+     call synchronize_all()
 
      call sum_all_i(nspec_cpml,num_cpml)
 
@@ -307,7 +307,7 @@
   if(myrank == 0) then
     write(IMAIN,*) '  number of MPI partition interfaces: ',num
   endif
-  call sync_all()
+  call synchronize_all()
 
   ! optional moho
   if( SAVE_MOHO_MESH ) then
@@ -336,7 +336,7 @@
     if(myrank == 0) then
       write(IMAIN,*) '  moho surfaces: ',num_moho
     endif
-    call sync_all()
+    call synchronize_all()
   else
     ! allocate dummy array
     nspec2D_moho_ext = 0

--- a/src/generate_databases/read_partition_files_adios.F90
+++ b/src/generate_databases/read_partition_files_adios.F90
@@ -387,6 +387,6 @@ subroutine read_partition_files_adios()
     !write(IMAIN,*) '    bottom,top: ',num_bottom,num_top
     !write(IMAIN,*) '  number of MPI partition interfaces: ',num_int
   !endif
-  !call sync_all()
+  !call synchronize_all()
 
 end subroutine read_partition_files_adios

--- a/src/generate_databases/save_arrays_solver.f90
+++ b/src/generate_databases/save_arrays_solver.f90
@@ -497,7 +497,7 @@
   ! VTK file output
   if( DEBUG ) then
 
-    call sync_all()
+    call synchronize_all()
     if( myrank == 0) then
       write(IMAIN,*) '     saving debugging mesh files'
       call flush_IMAIN()

--- a/src/generate_databases/save_arrays_solver_adios.F90
+++ b/src/generate_databases/save_arrays_solver_adios.F90
@@ -516,32 +516,32 @@ subroutine save_arrays_solver_ext_mesh_adios(nspec, nglob,                   &
   call define_adios_scalar(group, groupsize, "", STRINGIFY_VAR(nspec2d_bottom))
   call define_adios_scalar(group, groupsize, "", STRINGIFY_VAR(nspec2d_top))
 
-  if (nspec2d_xmin .ne. 0) then
+  if (nspec2d_xmin /= 0) then
     local_dim = nspec2d_xmin_wmax
     call define_adios_global_array1D(group, groupsize, local_dim, &
                                      "", STRINGIFY_VAR(ibelm_xmin))
   endif
-  if (nspec2d_xmax .ne. 0) then
+  if (nspec2d_xmax /= 0) then
     local_dim = nspec2d_xmax_wmax
     call define_adios_global_array1D(group, groupsize, local_dim, &
                                      "", STRINGIFY_VAR(ibelm_xmax))
   endif
-  if (nspec2d_ymin .ne. 0) then
+  if (nspec2d_ymin /= 0) then
     local_dim = nspec2d_ymin_wmax
     call define_adios_global_array1D(group, groupsize, local_dim, &
                                      "", STRINGIFY_VAR(ibelm_ymin))
   endif
-  if (nspec2d_ymax .ne. 0) then
+  if (nspec2d_ymax /= 0) then
     local_dim = nspec2d_ymax_wmax
     call define_adios_global_array1D(group, groupsize, local_dim, &
                                      "", STRINGIFY_VAR(ibelm_ymax))
   endif
-  if (nspec2d_bottom .ne. 0) then
+  if (nspec2d_bottom /= 0) then
     local_dim = nspec2d_bottom_wmax
     call define_adios_global_array1D(group, groupsize, local_dim, &
                                      "", STRINGIFY_VAR(ibelm_bottom))
   endif
-  if (nspec2d_top .ne. 0) then
+  if (nspec2d_top /= 0) then
     local_dim = nspec2d_top_wmax
     call define_adios_global_array1D(group, groupsize, local_dim, &
                                      "", STRINGIFY_VAR(ibelm_top))
@@ -1018,32 +1018,32 @@ subroutine save_arrays_solver_ext_mesh_adios(nspec, nglob,                   &
   call adios_write(handle, STRINGIFY_VAR(nspec2d_bottom), ier)
   call adios_write(handle, STRINGIFY_VAR(nspec2d_top), ier)
 
-  if (nspec2d_xmin .ne. 0) then
+  if (nspec2d_xmin /= 0) then
       local_dim = nspec2d_xmin_wmax
       call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                        STRINGIFY_VAR(ibelm_xmin))
   endif
-  if (nspec2d_xmax .ne. 0) then
+  if (nspec2d_xmax /= 0) then
     local_dim = nspec2d_xmax_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(ibelm_xmax))
   endif
-  if (nspec2d_ymin .ne. 0) then
+  if (nspec2d_ymin /= 0) then
     local_dim = nspec2d_ymin_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(ibelm_ymin))
   endif
-  if (nspec2d_ymax .ne. 0) then
+  if (nspec2d_ymax /= 0) then
     local_dim = nspec2d_ymax_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(ibelm_ymax))
   endif
-  if (nspec2d_bottom .ne. 0) then
+  if (nspec2d_bottom /= 0) then
     local_dim = nspec2d_bottom_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(ibelm_bottom))
   endif
-  if (nspec2d_top .ne. 0) then
+  if (nspec2d_top /= 0) then
     local_dim = nspec2d_top_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(ibelm_top))

--- a/src/generate_databases/setup_color_perm.f90
+++ b/src/generate_databases/setup_color_perm.f90
@@ -96,7 +96,7 @@
       call exit_MPI(myrank, 'maxval(perm) should be max(num_phase_ispec_..)')
 
     ! sorts array according to permutation
-    call sync_all()
+    call synchronize_all()
     if(myrank == 0) then
       write(IMAIN,*) '     mesh permutation:'
     endif

--- a/src/generate_databases/setup_mesh.f90
+++ b/src/generate_databases/setup_mesh.f90
@@ -56,7 +56,7 @@
   max_memory_size = max_memory_size_request
 
 ! make sure everybody is synchronized
-  call sync_all()
+  call synchronize_all()
 
 ! main working routine to create all the regions of the mesh
   if(myrank == 0) then
@@ -94,6 +94,6 @@
   deallocate(xstore,ystore,zstore)
 
 ! make sure everybody is synchronized
-  call sync_all()
+  call synchronize_all()
 
   end subroutine setup_mesh

--- a/src/meshfem3D/check_mesh_quality.f90
+++ b/src/meshfem3D/check_mesh_quality.f90
@@ -200,7 +200,7 @@
 
   enddo
 
-  call sync_all()
+  call synchronize_all()
 
   call min_all_dp(distance_min,distance_min_MPI)
   call max_all_dp(distance_max,distance_max_MPI)

--- a/src/meshfem3D/create_visual_files.f90
+++ b/src/meshfem3D/create_visual_files.f90
@@ -164,7 +164,7 @@
 
   endif
 
-  call sync_all()
+  call synchronize_all()
 
   end subroutine create_visual_files
 

--- a/src/meshfem3D/get_global.f90
+++ b/src/meshfem3D/get_global.f90
@@ -24,7 +24,7 @@
 !
 !=====================================================================
 
-  subroutine get_global(nspec,xp,yp,zp,iglob,loc,ifseg,nglob,npointot,UTM_X_MIN,UTM_X_MAX)
+  subroutine get_global(nspec,xp,yp,zp,iglob,locval,ifseg,nglob,npointot,UTM_X_MIN,UTM_X_MAX)
 
 ! this routine MUST be in double precision to avoid sensitivity
 ! to roundoff errors in the coordinates of the points
@@ -40,7 +40,7 @@
 
   integer npointot
   integer nspec,nglob
-  integer iglob(npointot),loc(npointot)
+  integer iglob(npointot),locval(npointot)
   logical ifseg(npointot)
   double precision xp(npointot),yp(npointot),zp(npointot)
   double precision UTM_X_MIN,UTM_X_MAX
@@ -72,7 +72,7 @@
   do ispec=1,nspec
     ieoff=NGLLCUBE_M*(ispec-1)
     do ilocnum=1,NGLLCUBE_M
-      loc(ilocnum+ieoff)=ilocnum+ieoff
+      locval(ilocnum+ieoff)=ilocnum+ieoff
     enddo
   enddo
 
@@ -94,7 +94,7 @@
     else
       call rank(zp(ioff),ind,ninseg(iseg))
     endif
-    call swap_all(loc(ioff),xp(ioff),yp(ioff),zp(ioff),iwork,work,ind,ninseg(iseg))
+    call swap_all(locval(ioff),xp(ioff),yp(ioff),zp(ioff),iwork,work,ind,ninseg(iseg))
     ioff=ioff+ninseg(iseg)
   enddo
 
@@ -130,7 +130,7 @@
   ig=0
   do i=1,npointot
     if(ifseg(i)) ig=ig+1
-    iglob(loc(i))=ig
+    iglob(locval(i))=ig
   enddo
 
   nglob=ig

--- a/src/meshfem3D/meshfem3D.f90
+++ b/src/meshfem3D/meshfem3D.f90
@@ -801,7 +801,7 @@
   npointot = nspec * NGLLCUBE_M
 
 ! make sure everybody is synchronized
-  call sync_all()
+  call synchronize_all()
 
 ! use dynamic allocation to allocate memory for arrays
   allocate(ibool(NGLLX_M,NGLLY_M,NGLLZ_M,nspec),stat=ier)
@@ -833,7 +833,7 @@
   endif
 
 ! make sure everybody is synchronized
-  call sync_all()
+  call synchronize_all()
 
 !--- print number of points and elements in the mesh
 
@@ -882,7 +882,7 @@
   endif
 
 ! synchronize all the processes to make sure everybody has finished
-  call sync_all()
+  call synchronize_all()
 
   end subroutine meshfem3D
 

--- a/src/meshfem3D/save_databases_adios.F90
+++ b/src/meshfem3D/save_databases_adios.F90
@@ -660,7 +660,7 @@ subroutine save_databases_adios(LOCAL_PATH, myrank, sizeprocs, &
   local_dim = nspec2d_xmin_wmax
   call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                    STRINGIFY_VAR(ibelm_xmin))
-  if (nspec2d_xmin .ne. 0) then
+  if (nspec2d_xmin /= 0) then
     local_dim = NGNOD2D * nspec2d_xmin_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(nodes_ibelm_xmin))
@@ -668,7 +668,7 @@ subroutine save_databases_adios(LOCAL_PATH, myrank, sizeprocs, &
   local_dim = nspec2d_xmax_wmax
   call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                    STRINGIFY_VAR(ibelm_xmax))
-  if (nspec2d_xmax .ne. 0) then
+  if (nspec2d_xmax /= 0) then
     local_dim = NGNOD2D * nspec2d_xmax_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(nodes_ibelm_xmax))
@@ -676,7 +676,7 @@ subroutine save_databases_adios(LOCAL_PATH, myrank, sizeprocs, &
   local_dim = nspec2d_ymin_wmax
   call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                    STRINGIFY_VAR(ibelm_ymin))
-  if (nspec2d_ymin .ne. 0) then
+  if (nspec2d_ymin /= 0) then
     local_dim = NGNOD2D * nspec2d_ymin_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(nodes_ibelm_ymin))
@@ -684,7 +684,7 @@ subroutine save_databases_adios(LOCAL_PATH, myrank, sizeprocs, &
   local_dim = nspec2d_ymax_wmax
   call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                    STRINGIFY_VAR(ibelm_ymax))
-  if (nspec2d_ymax .ne. 0) then
+  if (nspec2d_ymax /= 0) then
   local_dim = NGNOD2D * nspec2d_ymax_wmax
   call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                    STRINGIFY_VAR(nodes_ibelm_ymax))
@@ -692,7 +692,7 @@ subroutine save_databases_adios(LOCAL_PATH, myrank, sizeprocs, &
   local_dim = nspec2d_bottom_wmax
   call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                    STRINGIFY_VAR(ibelm_bottom))
-  if (nspec2d_bottom .ne. 0) then
+  if (nspec2d_bottom /= 0) then
     local_dim = NGNOD2D * nspec2d_bottom_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(nodes_ibelm_bottom))
@@ -700,7 +700,7 @@ subroutine save_databases_adios(LOCAL_PATH, myrank, sizeprocs, &
   local_dim = nspec2d_top_wmax
   call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                    STRINGIFY_VAR(ibelm_top))
-  if (nspec2d_top .ne. 0) then
+  if (nspec2d_top /= 0) then
     local_dim = NGNOD2D * nspec2d_top_wmax
     call write_adios_global_1d_array(handle, myrank, sizeprocs, local_dim, &
                                      STRINGIFY_VAR(nodes_ibelm_top))

--- a/src/shared/adios_manager.F90
+++ b/src/shared/adios_manager.F90
@@ -62,7 +62,7 @@ subroutine adios_cleanup()
   integer :: adios_err
 
   call world_rank(myrank)
-  call sync_all()
+  call synchronize_all()
 
   call adios_finalize (myrank, adios_err)
 

--- a/src/shared/detect_surface.f90
+++ b/src/shared/detect_surface.f90
@@ -264,7 +264,7 @@
   real(kind=CUSTOM_REAL) :: min_dist,normal(NDIM)
   integer, dimension(:), allocatable :: valence_external_mesh
 
-  integer :: ispec,i,j,k,iglob,ier,count
+  integer :: ispec,i,j,k,iglob,ier,countval
   integer :: iface,icorner
   logical, dimension(:),allocatable :: ispec_has_points
 
@@ -344,7 +344,7 @@
 ! determines spectral elements containing surface points
 ! (only counts element outer faces, no planes inside element)
   ispec_has_points(:) = .false.
-  count = 0
+  countval = 0
   do ispec = 1, nspec
 
     ! loops over GLL points not on edges or corners, but inside faces
@@ -372,7 +372,7 @@
               call ds_set_cross_section_flags(nspec,ispec_is_surface_external_mesh, &
                                             nglob,iglob_is_surface_external_mesh, &
                                             i,j,k,ispec,ibool, &
-                                            valence_external_mesh,count)
+                                            valence_external_mesh,countval)
             endif
 
           endif
@@ -530,7 +530,7 @@
   subroutine ds_set_cross_section_flags(nspec,ispec_is_surface_external_mesh, &
                                         nglob,iglob_is_surface_external_mesh, &
                                         i,j,k,ispec,ibool, &
-                                        valence_external_mesh,count)
+                                        valence_external_mesh,countval)
 
   ! put this into separate subroutine to compile faster, otherwise compilers will try to unroll all do loops
 
@@ -541,7 +541,7 @@
   ! global indexing
   integer :: nglob,nspec
   integer, dimension(NGLLX,NGLLY,NGLLZ,nspec):: ibool
-  integer :: i,j,k,ispec,count
+  integer :: i,j,k,ispec,countval
 
   integer, dimension(nglob) :: valence_external_mesh
 
@@ -596,7 +596,7 @@
   ! sets flag for element to indicate that it has a face on surface
   if( has_face ) then
     ispec_is_surface_external_mesh(ispec) = .true.
-    count = count+1
+    countval = countval + 1
   endif
 
   end subroutine ds_set_cross_section_flags
@@ -699,7 +699,7 @@
 !local parameters
   real(kind=CUSTOM_REAL) :: min_dist,distance
   integer, dimension(:), allocatable :: valence_external_mesh
-  integer :: ispec,i,j,k,iglob,ier,count
+  integer :: ispec,i,j,k,iglob,ier,countval
   real(kind=CUSTOM_REAL),parameter :: TOLERANCE_DISTANCE = 0.9
 
 ! detecting surface points/elements (based on valence check on NGLL points) for external mesh
@@ -745,7 +745,7 @@
 
 
 ! determines spectral elements containing points on surface
-  count = 0
+  countval = 0
   do ispec = 1, nspec
     ! loops over GLL points not on edges or corners, but inside faces
     do k = 1, NGLLZ
@@ -755,7 +755,7 @@
           ! considers only points in same process or, if point is shared between two processes,
           ! only with higher process ranks than itself
           if (valence_external_mesh(iglob) == myrank+1 .or. valence_external_mesh(iglob) > 2*(myrank+1) ) then
-            if( iglob_is_image_surface(iglob) .eqv. .false. ) count = count+1
+            if( iglob_is_image_surface(iglob) .eqv. .false. ) countval = countval + 1
             iglob_is_image_surface(iglob) = .true.
             ispec_is_image_surface(ispec) = .true.
           endif
@@ -763,7 +763,7 @@
       enddo
     enddo
   enddo ! nspec
-  num_iglob_image_surface = count
+  num_iglob_image_surface = countval
 
   end subroutine detect_surface_PNM_image
 

--- a/src/shared/get_attenuation_model.f90
+++ b/src/shared/get_attenuation_model.f90
@@ -657,7 +657,7 @@
   ! local parameters
   double precision :: f1, f2
   double precision :: exp1, exp2
-  double precision :: dexp
+  double precision :: dexpval
   integer :: i
   double precision, parameter :: PI = 3.14159265358979d0
 
@@ -670,9 +670,9 @@
   exp2 = log10(f2)
 
   ! equally spaced in log10 frequency
-  dexp = (exp2-exp1) / ((nsls*1.0d0) - 1)
+  dexpval = (exp2-exp1) / ((nsls*1.0d0) - 1)
   do i = 1,nsls
-     tau_s(i) = 1.0 / (PI * 2.0d0 * 10**(exp1 + (i - 1)* 1.0d0 *dexp))
+     tau_s(i) = 1.0 / (PI * 2.0d0 * 10**(exp1 + (i - 1)* 1.0d0 *dexpval))
   enddo
 
   end subroutine get_attenuation_tau_sigma
@@ -914,7 +914,7 @@
 
   ! Internal
   integer i, iterations, err,prnt
-  double precision f1, f2, exp1,exp2, min_value !, dexp
+  double precision f1, f2, exp1,exp2, min_value !, dexpval
   integer, parameter :: nf = 100
   double precision, dimension(nf) :: f
   double precision, parameter :: PI = 3.14159265358979d0
@@ -951,9 +951,9 @@
   enddo
 
   ! Set the Tau_sigma (tau_s) to be equally spaced in log10 frequency
-!  dexp = (exp2-exp1) / ((n*1.0d0) - 1)
+!  dexpval = (exp2-exp1) / ((n*1.0d0) - 1)
 !  do i = 1,n
-!     tau_s(i) = 1.0 / (PI * 2.0d0 * 10**(exp1 + (i - 1)* 1.0d0 *dexp))
+!     tau_s(i) = 1.0 / (PI * 2.0d0 * 10**(exp1 + (i - 1)* 1.0d0 *dexpval))
 !  enddo
 
 

--- a/src/shared/netlib_specfun_erf.f90
+++ b/src/shared/netlib_specfun_erf.f90
@@ -24,7 +24,7 @@
 !
 !=====================================================================
 
-  subroutine calerf(ARG,RESULT,JINT)
+  subroutine calerf(ARG,RESULT,jintval)
 
 !------------------------------------------------------------------
 !
@@ -49,12 +49,12 @@
 !   routine.  The function subprograms invoke  CALERF  with the
 !   statement
 !
-!          call CALERF(ARG,RESULT,JINT)
+!          call CALERF(ARG,RESULT,jintval)
 !
 !   where the parameter usage is as follows
 !
 !      Function                     Parameters for CALERF
-!       call              ARG                  Result          JINT
+!       call              ARG                  Result          jintval
 !
 !     ERF(ARG)      ANY REAL ARGUMENT         ERF(ARG)          0
 !
@@ -113,7 +113,7 @@
 
   implicit none
 
-  integer I,JINT
+  integer I,jintval
   double precision A,ARG,B,C,D,DEL,FOUR,HALF,P,ONE,Q,RESULT,SIXTEEN,SQRPI, &
        TWO,THRESHOLD,X,XBIG,XDEN,XHUGE,XINF,XMAX,XNEG,XNUM,XSMALL, &
        Y,YSQ,ZERO
@@ -182,8 +182,8 @@
       enddo
 
       RESULT = X * (XNUM + A(4)) / (XDEN + B(4))
-      if (JINT  /=  0) RESULT = ONE - RESULT
-      if (JINT  ==  2) RESULT = EXP(YSQ) * RESULT
+      if (jintval  /=  0) RESULT = ONE - RESULT
+      if (jintval  ==  2) RESULT = EXP(YSQ) * RESULT
       goto 800
 
 !------------------------------------------------------------------
@@ -199,7 +199,7 @@
       enddo
 
       RESULT = (XNUM + C(8)) / (XDEN + D(8))
-      if (JINT  /=  2) then
+      if (jintval  /=  2) then
          YSQ = AINT(Y*SIXTEEN)/SIXTEEN
          DEL = (Y-YSQ)*(Y+YSQ)
          RESULT = EXP(-YSQ*YSQ) * EXP(-DEL) * RESULT
@@ -211,7 +211,7 @@
    else
       RESULT = ZERO
       if (Y >= XBIG) then
-         if (JINT /= 2 .OR. Y >= XMAX) goto 300
+         if (jintval /= 2 .OR. Y >= XMAX) goto 300
          if (Y >= XHUGE) then
             RESULT = SQRPI / Y
             goto 300
@@ -228,7 +228,7 @@
 
       RESULT = YSQ *(XNUM + P(5)) / (XDEN + Q(5))
       RESULT = (SQRPI -  RESULT) / Y
-      if (JINT /= 2) then
+      if (jintval /= 2) then
          YSQ = AINT(Y*SIXTEEN)/SIXTEEN
          DEL = (Y-YSQ)*(Y+YSQ)
          RESULT = EXP(-YSQ*YSQ) * EXP(-DEL) * RESULT
@@ -238,10 +238,10 @@
 !------------------------------------------------------------------
 !  Fix up for negative argument, erf, etc.
 !------------------------------------------------------------------
-  300 if (JINT == 0) then
+  300 if (jintval == 0) then
       RESULT = (HALF - RESULT) + HALF
       if (X < ZERO) RESULT = -RESULT
-   else if (JINT == 1) then
+   else if (jintval == 1) then
       if (X < ZERO) RESULT = TWO - RESULT
    else
       if (X < ZERO) then
@@ -271,11 +271,11 @@
 
   implicit none
 
-  integer JINT
+  integer jintval
   double precision X, RESULT
 
-  JINT = 0
-  call calerf(X,RESULT,JINT)
+  jintval = 0
+  call calerf(X,RESULT,jintval)
   netlib_specfun_erf = RESULT
 
   end function netlib_specfun_erf

--- a/src/shared/parallel.f90
+++ b/src/shared/parallel.f90
@@ -63,7 +63,7 @@
 !----
 !
 
-  subroutine sync_all()
+  subroutine synchronize_all()
 
 ! standard include of the MPI library
   use :: mpi
@@ -74,25 +74,25 @@
 
   call MPI_BARRIER(MPI_COMM_WORLD,ier)
 
-  end subroutine sync_all
+  end subroutine synchronize_all
 
 !
 !----
 !
 
-  subroutine bcast_all_i(buffer, count)
+  subroutine bcast_all_i(buffer, countval)
 
 ! standard include of the MPI library
   use :: mpi
 
   implicit none
 
-  integer count
-  integer, dimension(count) :: buffer
+  integer countval
+  integer, dimension(countval) :: buffer
 
   integer ier
 
-  call MPI_BCAST(buffer,count,MPI_INTEGER,0,MPI_COMM_WORLD,ier)
+  call MPI_BCAST(buffer,countval,MPI_INTEGER,0,MPI_COMM_WORLD,ier)
 
   end subroutine bcast_all_i
 
@@ -100,7 +100,7 @@
 !----
 !
 
-  subroutine bcast_all_cr(buffer, count)
+  subroutine bcast_all_cr(buffer, countval)
 
 ! standard include of the MPI library
   use :: mpi
@@ -110,12 +110,12 @@
   include "constants.h"
   include "precision.h"
 
-  integer count
-  real(kind=CUSTOM_REAL), dimension(count) :: buffer
+  integer countval
+  real(kind=CUSTOM_REAL), dimension(countval) :: buffer
 
   integer ier
 
-  call MPI_BCAST(buffer,count,CUSTOM_MPI_TYPE,0,MPI_COMM_WORLD,ier)
+  call MPI_BCAST(buffer,countval,CUSTOM_MPI_TYPE,0,MPI_COMM_WORLD,ier)
 
   end subroutine bcast_all_cr
 
@@ -123,19 +123,19 @@
 !----
 !
 
-  subroutine bcast_all_dp(buffer, count)
+  subroutine bcast_all_dp(buffer, countval)
 
 ! standard include of the MPI library
   use :: mpi
 
   implicit none
 
-  integer count
-  double precision, dimension(count) :: buffer
+  integer countval
+  double precision, dimension(countval) :: buffer
 
   integer ier
 
-  call MPI_BCAST(buffer,count,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ier)
+  call MPI_BCAST(buffer,countval,MPI_DOUBLE_PRECISION,0,MPI_COMM_WORLD,ier)
 
   end subroutine bcast_all_dp
 
@@ -143,7 +143,7 @@
 !----
 !
 
-  subroutine bcast_all_r(buffer, count)
+  subroutine bcast_all_r(buffer, countval)
 
 ! standard include of the MPI library
   use :: mpi
@@ -153,12 +153,12 @@
   include "constants.h"
   include "precision.h"
 
-  integer count
-  real, dimension(count) :: buffer
+  integer countval
+  real, dimension(countval) :: buffer
 
   integer ier
 
-  call MPI_BCAST(buffer,count,MPI_REAL,0,MPI_COMM_WORLD,ier)
+  call MPI_BCAST(buffer,countval,MPI_REAL,0,MPI_COMM_WORLD,ier)
 
   end subroutine bcast_all_r
 
@@ -352,17 +352,17 @@
 !----
 !
 
-  subroutine world_size(size)
+  subroutine world_size(sizeval)
 
 ! standard include of the MPI library
   use :: mpi
 
   implicit none
 
-  integer size
+  integer sizeval
   integer ier
 
-  call MPI_COMM_SIZE(MPI_COMM_WORLD,size,ier)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD,sizeval,ier)
 
   end subroutine world_size
 
@@ -539,25 +539,25 @@
 !----
 !
 
-  subroutine max_allreduce_i(buffer,count)
+  subroutine max_allreduce_i(buffer,countval)
 
   use mpi
 
   implicit none
 
-  integer :: count
-  integer,dimension(count),intent(inout) :: buffer
+  integer :: countval
+  integer,dimension(countval),intent(inout) :: buffer
 
   ! local parameters
   integer :: ier
-  integer,dimension(count) :: send
+  integer,dimension(countval) :: send
 
   ! seems not to be supported on all kind of MPI implementations...
-  !call MPI_ALLREDUCE(MPI_IN_PLACE, buffer, count, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD, ier)
+  !call MPI_ALLREDUCE(MPI_IN_PLACE, buffer, countval, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD, ier)
 
   send(:) = buffer(:)
 
-  call MPI_ALLREDUCE(send, buffer, count, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD, ier)
+  call MPI_ALLREDUCE(send, buffer, countval, MPI_INTEGER, MPI_MAX, MPI_COMM_WORLD, ier)
   if( ier /= 0 ) stop 'Allreduce to get max values failed.'
 
   end subroutine max_allreduce_i

--- a/src/shared/serial.f90
+++ b/src/shared/serial.f90
@@ -54,8 +54,8 @@
 !----
 !
 
-  subroutine sync_all()
-  end subroutine sync_all
+  subroutine synchronize_all()
+  end subroutine synchronize_all
 
 !
 !----

--- a/src/shared/sort_array_coordinates.f90
+++ b/src/shared/sort_array_coordinates.f90
@@ -26,7 +26,7 @@
 
 ! subroutines to sort MPI buffers to assemble between chunks
 
-  subroutine sort_array_coordinates(npointot,x,y,z,ibool,iglob,loc,ifseg, &
+  subroutine sort_array_coordinates(npointot,x,y,z,ibool,iglob,locval,ifseg, &
                                     nglob,ind,ninseg,iwork,work)
 
 ! this routine MUST be in double precision to avoid sensitivity
@@ -40,7 +40,7 @@
 
   integer npointot,nglob
 
-  integer ibool(npointot),iglob(npointot),loc(npointot)
+  integer ibool(npointot),iglob(npointot),locval(npointot)
   integer ind(npointot),ninseg(npointot)
   logical ifseg(npointot)
   double precision x(npointot),y(npointot),z(npointot)
@@ -53,7 +53,7 @@
 
 ! establish initial pointers
   do ipoin=1,npointot
-    loc(ipoin)=ipoin
+    locval(ipoin)=ipoin
   enddo
 
 ! define a tolerance, normalized radius is 1., so let's use a small value
@@ -84,7 +84,7 @@
 
     endif
 
-    call swap_all_buffers(ibool(ioff),loc(ioff), &
+    call swap_all_buffers(ibool(ioff),locval(ioff), &
             x(ioff),y(ioff),z(ioff),iwork,work,ind,ninseg(iseg))
 
     ioff=ioff+ninseg(iseg)
@@ -121,7 +121,7 @@
   ig=0
   do i=1,npointot
     if(ifseg(i)) ig=ig+1
-    iglob(loc(i))=ig
+    iglob(locval(i))=ig
   enddo
 
   nglob=ig

--- a/src/specfem3D/compute_forces_acoustic_calling_routine.f90
+++ b/src/specfem3D/compute_forces_acoustic_calling_routine.f90
@@ -135,6 +135,10 @@ subroutine compute_forces_acoustic()
           ! handles adjoint runs coupling between adjoint potential and adjoint elastic wavefield
           ! adjoint definition: \partial_t^2 \bfs^\dagger=-\frac{1}{\rho}\bfnabla\phi^\dagger
           call compute_coupling_acoustic_el(NSPEC_AB,NGLOB_AB, &
+!! DK DK: beware: function or procedure arguments that contain a calculation produce a memory copy
+!! DK DK: created by the compiler; The code is fine, but the hidden copy may slow it down.
+!! DK DK: here is the warning from the Cray compiler:
+!! DK DK: ftn-1438 crayftn: This argument produces a copy in to a temporary variable.
                               ibool,-accel,potential_dot_dot_acoustic, &
                               num_coupling_ac_el_faces, &
                               coupling_ac_el_ispec,coupling_ac_el_ijk, &

--- a/src/specfem3D/compute_forces_viscoelastic_calling_routine.F90
+++ b/src/specfem3D/compute_forces_viscoelastic_calling_routine.F90
@@ -126,6 +126,10 @@ subroutine compute_forces_viscoelastic()
            ! handles adjoint runs coupling between adjoint potential and adjoint elastic wavefield
            ! adoint definition: pressure^\dagger=potential^\dagger
            call compute_coupling_viscoelastic_ac(NSPEC_AB,NGLOB_AB, &
+!! DK DK: beware: function or procedure arguments that contain a calculation produce a memory copy
+!! DK DK: created by the compiler; The code is fine, but the hidden copy may slow it down.
+!! DK DK: here is the warning from the Cray compiler:
+!! DK DK: ftn-1438 crayftn: This argument produces a copy in to a temporary variable.
                               ibool,accel,-potential_acoustic, &
                               num_coupling_ac_el_faces, &
                               coupling_ac_el_ispec,coupling_ac_el_ijk, &

--- a/src/specfem3D/create_color_image.f90
+++ b/src/specfem3D/create_color_image.f90
@@ -124,7 +124,7 @@
   integer,dimension(:),allocatable :: iglob_coord,ispec_coord
   logical,dimension(:),allocatable:: ispec_is_image_surface,iglob_is_image_surface
   integer :: num_iglob_image_surface
-  integer :: count,loc(1),irank
+  integer :: countval,locval(1),irank
   !character(len=256) :: vtkfilename
   integer :: zoom_factor = 4
   logical :: zoom
@@ -171,7 +171,7 @@
            ispec_coord(num_iglob_image_surface),stat=ier )
   if( ier /= 0 ) call exit_mpi(myrank,'error allocating xyz image coordinates')
 
-  count=0
+  countval=0
   do ispec=1,NSPEC_AB
     if( ispec_is_image_surface(ispec) ) then
       do k=1,NGLLZ
@@ -179,16 +179,16 @@
           do i=1,NGLLX
             iglob = ibool(i,j,k,ispec)
             if( iglob_is_image_surface(iglob) ) then
-              count = count+1
+              countval = countval + 1
               ! coordinates with respect to horizontal and vertical direction
-              xcoord(count)= xstore(iglob)*section_hdirx &
+              xcoord(countval)= xstore(iglob)*section_hdirx &
                                 + ystore(iglob)*section_hdiry &
                                 + zstore(iglob)*section_hdirz
-              zcoord(count)= xstore(iglob)*section_vdirx &
+              zcoord(countval)= xstore(iglob)*section_vdirx &
                                 + ystore(iglob)*section_vdiry &
                                 + zstore(iglob)*section_vdirz
-              iglob_coord(count) = iglob
-              ispec_coord(count) = ispec
+              iglob_coord(countval) = iglob
+              ispec_coord(countval) = ispec
 
               ! reset iglob flag
               iglob_is_image_surface(iglob) = .false.
@@ -199,7 +199,7 @@
     endif
   enddo
 
-  if( count /= num_iglob_image_surface) call exit_mpi(myrank,'error image point number')
+  if( countval /= num_iglob_image_surface) call exit_mpi(myrank,'error image point number')
 
   ! horizontal size of the image
   xmin_color_image_loc = minval( xcoord(:) )
@@ -354,8 +354,8 @@
     ! selects entries
     do i=1,NX_IMAGE_color
       ! note: minimum location will be between 1 and NPROC
-      loc = minloc(dist_pixel_recv(i,:))
-      irank = loc(1) - 1
+      locval = minloc(dist_pixel_recv(i,:))
+      irank = locval(1) - 1
       ! store only own best points
       if( irank == myrank .and. dist_pixel_recv(i,irank) < HUGEVAL) then
         ! increases count

--- a/src/specfem3D/fault_solver_kinematic.f90
+++ b/src/specfem3D/fault_solver_kinematic.f90
@@ -208,7 +208,7 @@ subroutine BC_KINFLT_set_single(bc,MxA,V,D,iflt)
   real(kind=CUSTOM_REAL), dimension(3,bc%nglob) :: T
   real(kind=CUSTOM_REAL), dimension(3,bc%nglob) :: dD,dV,dA,dV_free
   real(kind=CUSTOM_REAL) :: t1,t2
-  real(kind=CUSTOM_REAL) :: half_dt,time
+  real(kind=CUSTOM_REAL) :: half_dt,timeval
 
   if (bc%nspec > 0) then !Surendra : for parallel faults
 
@@ -226,7 +226,7 @@ subroutine BC_KINFLT_set_single(bc,MxA,V,D,iflt)
     dA = rotate(bc,dA,1)
 
     ! Time marching
-    time = it*bc%dt
+    timeval = it*bc%dt
     ! Slip_rate step "it_kin"
     it_kin = bc%kin_it*nint(bc%kin_dt/bc%dt)
     ! (nint : fortran round (nearest whole number) ,
@@ -266,8 +266,8 @@ subroutine BC_KINFLT_set_single(bc,MxA,V,D,iflt)
     ! bc%V : Imposed a priori and read from slip rate snapshots (from time reversal)
     !        Linear interpolation between consecutive kinematic time steps.
     !        V will be given at each time step.
-    bc%V(1,:) = ( (t2 - time)*bc%v_kin_t1(1,:) + (time - t1)*bc%v_kin_t2(1,:) )/ bc%kin_dt
-    bc%V(2,:) = ( (t2 - time)*bc%v_kin_t1(2,:) + (time - t1)*bc%v_kin_t2(2,:) )/ bc%kin_dt
+    bc%V(1,:) = ( (t2 - timeval)*bc%v_kin_t1(1,:) + (timeval - t1)*bc%v_kin_t2(1,:) )/ bc%kin_dt
+    bc%V(2,:) = ( (t2 - timeval)*bc%v_kin_t1(2,:) + (timeval - t1)*bc%v_kin_t2(2,:) )/ bc%kin_dt
 
     !dV_free = dV_predictor + (dt/2)*dA_free
     dV_free(1,:) = dV(1,:) + half_dt*dA(1,:)

--- a/src/specfem3D/finalize_simulation.f90
+++ b/src/specfem3D/finalize_simulation.f90
@@ -287,6 +287,6 @@
   endif
 
 ! synchronize all the processes to make sure everybody has finished
-  call sync_all()
+  call synchronize_all()
 
   end subroutine finalize_simulation

--- a/src/specfem3D/initialize_simulation.f90
+++ b/src/specfem3D/initialize_simulation.f90
@@ -359,7 +359,7 @@
         call exit_MPI(myrank,'error in compiled parameters STACEY_INSTEAD_OF_FREE_SURFACE, please recompile solver')
      endif
   endif
-  call sync_all()
+  call synchronize_all()
 
   ! checks directories
   if( myrank == 0 ) then
@@ -472,7 +472,7 @@
   call initialize_cuda_device(myrank,ncuda_devices)
 
   ! collects min/max of local devices found for statistics
-  call sync_all()
+  call synchronize_all()
   call min_all_i(ncuda_devices,ncuda_devices_min)
   call max_all_i(ncuda_devices,ncuda_devices_max)
 

--- a/src/specfem3D/iterate_time.F90
+++ b/src/specfem3D/iterate_time.F90
@@ -67,7 +67,7 @@
 !
 
 ! synchronize all processes to make sure everybody is ready to start time loop
-  call sync_all()
+  call synchronize_all()
   if(myrank == 0) write(IMAIN,*) 'All processes are synchronized before time loop'
 
   if(myrank == 0) then

--- a/src/specfem3D/locate_receivers.f90
+++ b/src/specfem3D/locate_receivers.f90
@@ -239,7 +239,7 @@
       call bcast_all_dp(eta_receiver,nrec)
       call bcast_all_dp(gamma_receiver,nrec)
       call bcast_all_dp(nu,NDIM*NDIM*nrec)
-      call sync_all()
+      call synchronize_all()
       ! user output
       if( myrank == 0 ) then
         ! elapsed time since beginning of mesh generation
@@ -780,7 +780,7 @@
   endif ! of if (.not. FASTER_RECEIVERS_POINTS_ONLY)
 
   ! synchronize all the processes to make sure all the estimates are available
-  call sync_all()
+  call synchronize_all()
   ! for MPI version, gather information from all the nodes
   if (myrank/=0) then ! gather information from other processors (one at a time)
      call send_i(ispec_selected_rec, nrec,0,0)
@@ -985,7 +985,7 @@
   deallocate(final_distance_all)
 
   ! synchronize all the processes to make sure everybody has finished
-  call sync_all()
+  call synchronize_all()
 
   end subroutine locate_receivers
 

--- a/src/specfem3D/make_gravity.f90
+++ b/src/specfem3D/make_gravity.f90
@@ -403,7 +403,7 @@
 !-------------------------------------------------------------------------------------------------
 !
 
-  subroutine intgrl(sum,r,nir,ner,f,s1,s2,s3)
+  subroutine intgrl(sumval,r,nir,ner,f,s1,s2,s3)
 
 ! Computes the integral of f[i]*r[i]*r[i] from i=nir to i=ner for
 ! radii values as in model PREM_an640
@@ -413,7 +413,7 @@
 ! Argument variables
   integer ner,nir
   double precision f(640),r(640),s1(640),s2(640)
-  double precision s3(640),sum
+  double precision s3(640),sumval
 
 ! Local variables
   double precision, parameter :: third = 1.0d0/3.0d0
@@ -433,14 +433,14 @@
 
   call deriv(f,yprime,n,r,ndis,kdis,s1,s2,s3)
   nir1 = nir + 1
-  sum = 0.0d0
+  sumval = 0.0d0
   do i=nir1,ner
     j = i-1
     rji = r(i) - r(j)
     s1l = s1(j)
     s2l = s2(j)
     s3l = s3(j)
-    sum = sum + r(j)*r(j)*rji*(f(j) &
+    sumval = sumval + r(j)*r(j)*rji*(f(j) &
               + rji*(0.5d0*s1l + rji*(third*s2l + rji*0.25d0*s3l))) &
               + 2.0d0*r(j)*rji*rji*(0.5d0*f(j) + rji*(third*s1l + rji*(0.25d0*s2l + rji*fifth*s3l))) &
               + rji*rji*rji*(third*f(j) + rji*(0.25d0*s1l + rji*(fifth*s2l + rji*sixth*s3l)))

--- a/src/specfem3D/pml_compute_accel_contribution.f90
+++ b/src/specfem3D/pml_compute_accel_contribution.f90
@@ -125,7 +125,7 @@ subroutine pml_compute_accel_contribution_elastic(ispec,ispec_CPML,displ,veloc,r
               rmemory_displ_elastic(3,i,j,k,ispec_CPML,2) = coef0_y * rmemory_displ_elastic(3,i,j,k,ispec_CPML,2) &
                   + displ(3,iglob) * time_nplus1 * coef1_y &
                   + displ_old(3,iglob) * time_n * coef2_y
-           end if
+           endif
 
            if (singularity_type_5 == 0) then
               rmemory_displ_elastic(1,i,j,k,ispec_CPML,3) = coef0_z * rmemory_displ_elastic(1,i,j,k,ispec_CPML,3) &
@@ -154,7 +154,7 @@ subroutine pml_compute_accel_contribution_elastic(ispec,ispec_CPML,displ,veloc,r
               rmemory_displ_elastic(3,i,j,k,ispec_CPML,3) = coef0_z * rmemory_displ_elastic(3,i,j,k,ispec_CPML,3) &
                    + displ(3,iglob) * time_nplus1**2 * coef1_z &
                    + displ_old(3,iglob) * time_n**2 * coef2_z
-           end if
+           endif
 
            accel_elastic_CPML(1,i,j,k) =  wgllcube * rhol * jacobianl * &
                 ( A_1 * veloc(1,iglob) + A_2 * displ(1,iglob) + &
@@ -272,7 +272,7 @@ subroutine pml_compute_accel_contribution_acoustic(ispec,ispec_CPML,potential_ac
              rmemory_potential_acoustic(i,j,k,ispec_CPML,2) = coef0_y * rmemory_potential_acoustic(i,j,k,ispec_CPML,2) + &
                     coef1_y * time_nplus1 * potential_acoustic(iglob) + &
                     coef2_y * time_n * potential_acoustic_old(iglob)
-           end if
+           endif
 
            if (singularity_type_5 == 0) then
              rmemory_potential_acoustic(i,j,k,ispec_CPML,3) = coef0_z * rmemory_potential_acoustic(i,j,k,ispec_CPML,3) + &
@@ -285,7 +285,7 @@ subroutine pml_compute_accel_contribution_acoustic(ispec,ispec_CPML,potential_ac
              rmemory_potential_acoustic(i,j,k,ispec_CPML,3) = coef0_z * rmemory_potential_acoustic(i,j,k,ispec_CPML,3) + &
                     coef1_z * time_nplus1**2 * potential_acoustic(iglob) + &
                     coef2_z * time_n**2 * potential_acoustic_old(iglob)
-           end if
+           endif
 
            potential_dot_dot_acoustic_CPML(i,j,k) =  wgllcube * kappal_inv * jacobianl * &
                  ( A_1 * potential_dot_acoustic(iglob) + A_2 * potential_acoustic(iglob) + &
@@ -440,7 +440,7 @@ end subroutine read_potential_on_pml_interface
 !=====================================================================
 !
 subroutine l_parameter_computation( &
-               time, deltat, &
+               timeval, deltat, &
                kappa_x, beta_x, alpha_x, &
                kappa_y, beta_y, alpha_y, &
                kappa_z, beta_z, alpha_z, &
@@ -458,7 +458,7 @@ subroutine l_parameter_computation( &
 
   implicit none
 
-  real(kind=CUSTOM_REAL), intent(in) :: time,deltat
+  real(kind=CUSTOM_REAL), intent(in) :: timeval,deltat
   real(kind=CUSTOM_REAL), intent(in) :: kappa_x,beta_x,alpha_x, &
                                         kappa_y,beta_y,alpha_y, &
                                         kappa_z,beta_z,alpha_z
@@ -533,7 +533,7 @@ subroutine l_parameter_computation( &
                * (beta_x - alpha_z) * (beta_y - alpha_z) * (beta_z - alpha_z) &
                / (alpha_0 - alpha_z) / (alpha_0 - alpha_z)
 
-       A_3 = bar_A_3 + time * bar_A_4
+       A_3 = bar_A_3 + timeval * bar_A_4
        A_4 = - bar_A_4
        A_5 = bar_A_5
 
@@ -559,7 +559,7 @@ subroutine l_parameter_computation( &
                * (beta_x - alpha_0) * (beta_y - alpha_0) * (beta_z - alpha_0) &
                / (alpha_y - alpha_0)
 
-       A_3 = bar_A_3 + time * bar_A_5
+       A_3 = bar_A_3 + timeval * bar_A_5
        A_4 = bar_A_4
        A_5 = - bar_A_5
 
@@ -586,7 +586,7 @@ subroutine l_parameter_computation( &
                / (alpha_x - alpha_0)
 
        A_3 = bar_A_3
-       A_4 = bar_A_4 + time * bar_A_5
+       A_4 = bar_A_4 + timeval * bar_A_5
        A_5 = - bar_A_5
 
        singularity_type_4 = 0
@@ -612,13 +612,13 @@ subroutine l_parameter_computation( &
        bar_A_5 = bar_A_0 * alpha_0**2 / 2._CUSTOM_REAL &
                * (beta_x - alpha_0) * (beta_y - alpha_0) * (beta_z - alpha_0)
 
-       A_3 = bar_A_3 + time * bar_A_4 + time**2 * bar_A_5
-       A_4 = - bar_A_4 - 2._CUSTOM_REAL * time * bar_A_5
+       A_3 = bar_A_3 + timeval * bar_A_4 + timeval**2 * bar_A_5
+       A_4 = - bar_A_4 - 2._CUSTOM_REAL * timeval * bar_A_5
        A_5 = bar_A_5
 
        singularity_type_4 = 1
        singularity_type_5 = 2
-     end if
+     endif
 
   else if ( CPML_region_local == CPML_XY_ONLY ) then
 
@@ -662,14 +662,14 @@ subroutine l_parameter_computation( &
        bar_A_4 = bar_A_0 * alpha_0**2 * (beta_x - alpha_0) * (beta_y - alpha_0)
        bar_A_5 = 0._CUSTOM_REAL
 
-       A_3 = bar_A_3 + time * bar_A_4
+       A_3 = bar_A_3 + timeval * bar_A_4
        A_4 = -bar_A_4
        A_5 = bar_A_5
 
        singularity_type_4 = 1
        singularity_type_5 = 0
 
-    end if
+    endif
 
   else if ( CPML_region_local == CPML_XZ_ONLY ) then
 
@@ -712,14 +712,14 @@ subroutine l_parameter_computation( &
        bar_A_4 = 0._CUSTOM_REAL
        bar_A_5 = bar_A_0 * alpha_0**2 * (beta_x - alpha_0) * (beta_z - alpha_0)
 
-       A_3 = bar_A_3 + time * bar_A_5
+       A_3 = bar_A_3 + timeval * bar_A_5
        A_4 = bar_A_4
        A_5 = -bar_A_5
 
        singularity_type_4 = 0
        singularity_type_5 = 1
 
-    end if
+    endif
 
   else if ( CPML_region_local == CPML_YZ_ONLY ) then
 
@@ -763,13 +763,13 @@ subroutine l_parameter_computation( &
        bar_A_5 = bar_A_0 * alpha_0**2 * (beta_y - alpha_0) * (beta_z - alpha_0)
 
        A_3 = bar_A_3
-       A_4 = bar_A_4 + time * bar_A_5
+       A_4 = bar_A_4 + timeval * bar_A_5
        A_5 = -bar_A_5
 
        singularity_type_4 = 0
        singularity_type_5 = 1
 
-    end if
+    endif
 
   else if ( CPML_region_local == CPML_X_ONLY ) then
 
@@ -834,7 +834,7 @@ subroutine l_parameter_computation( &
      singularity_type_4 = 0
      singularity_type_5 = 0
 
-  end if
+  endif
 
   bb = alpha_x
   coef0_x = exp(-bb * deltat)
@@ -845,7 +845,7 @@ subroutine l_parameter_computation( &
      else
         coef1_x = (1._CUSTOM_REAL - exp(-bb * deltat/2._CUSTOM_REAL) ) / bb
         coef2_x = (1._CUSTOM_REAL - exp(-bb * deltat/2._CUSTOM_REAL) ) * exp(-bb * deltat/2._CUSTOM_REAL) / bb
-     end if
+     endif
   else
      if ( FIRST_ORDER_CONVOLUTION ) then
         coef1_x = deltat
@@ -853,7 +853,7 @@ subroutine l_parameter_computation( &
      else
         coef1_x = deltat/2._CUSTOM_REAL
         coef2_x = deltat/2._CUSTOM_REAL
-     end if
+     endif
   endif
 
   bb = alpha_y
@@ -865,7 +865,7 @@ subroutine l_parameter_computation( &
      else
         coef1_y = (1._CUSTOM_REAL - exp(-bb * deltat/2._CUSTOM_REAL) ) / bb
         coef2_y = (1._CUSTOM_REAL - exp(-bb * deltat/2._CUSTOM_REAL) ) * exp(-bb * deltat/2._CUSTOM_REAL) / bb
-     end if
+     endif
   else
      if ( FIRST_ORDER_CONVOLUTION ) then
         coef1_y = deltat
@@ -873,7 +873,7 @@ subroutine l_parameter_computation( &
      else
         coef1_y = deltat/2._CUSTOM_REAL
         coef2_y = deltat/2._CUSTOM_REAL
-     end if
+     endif
   endif
 
   bb = alpha_z
@@ -885,7 +885,7 @@ subroutine l_parameter_computation( &
      else
         coef1_z = (1._CUSTOM_REAL - exp(-bb * deltat/2._CUSTOM_REAL) ) / bb
         coef2_z = (1._CUSTOM_REAL - exp(-bb * deltat/2._CUSTOM_REAL) ) * exp(-bb * deltat/2._CUSTOM_REAL) / bb
-     end if
+     endif
   else
      if ( FIRST_ORDER_CONVOLUTION ) then
         coef1_z = deltat
@@ -893,7 +893,7 @@ subroutine l_parameter_computation( &
      else
         coef1_z = deltat/2._CUSTOM_REAL
         coef2_z = deltat/2._CUSTOM_REAL
-     end if
+     endif
   endif
 
 end subroutine l_parameter_computation

--- a/src/specfem3D/pml_compute_memory_variables.f90
+++ b/src/specfem3D/pml_compute_memory_variables.f90
@@ -145,7 +145,7 @@ subroutine pml_compute_memory_variables_elastic(ispec,ispec_CPML,tempx1,tempy1,t
                      + PML_duy_dxl(i,j,k) * coef1_2 + PML_duy_dxl_old(i,j,k) * coef2_2
               rmemory_duz_dxl_z(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_duz_dxl_z(i,j,k,ispec_CPML,2) &
                      + PML_duz_dxl(i,j,k) * coef1_2 + PML_duz_dxl_old(i,j,k) * coef2_2
-            elseif(singularity_type_2 == 1)then
+            else if(singularity_type_2 == 1)then
               rmemory_dux_dxl_x(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_dux_dxl_x(i,j,k,ispec_CPML,2) &
                      + PML_dux_dxl(i,j,k) * time_nplus1 * coef1_2 + PML_dux_dxl_old(i,j,k) * time_n * coef2_2
               rmemory_duy_dxl_y(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_duy_dxl_y(i,j,k,ispec_CPML,2) &
@@ -163,14 +163,14 @@ subroutine pml_compute_memory_variables_elastic(ispec,ispec_CPML,tempx1,tempy1,t
                      + PML_duy_dxl(i,j,k) * coef1_3 + PML_duy_dxl_old(i,j,k) * coef2_3
               rmemory_duz_dxl_z(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duz_dxl_z(i,j,k,ispec_CPML,3) &
                      + PML_duz_dxl(i,j,k) * coef1_3 + PML_duz_dxl_old(i,j,k) * coef2_3
-            elseif(singularity_type_3 == 1)then
+            else if(singularity_type_3 == 1)then
               rmemory_dux_dxl_x(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dux_dxl_x(i,j,k,ispec_CPML,3) &
                      + PML_dux_dxl(i,j,k) * time_nplus1 * coef1_3 + PML_dux_dxl_old(i,j,k) * time_n * coef2_3
               rmemory_duy_dxl_y(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duy_dxl_y(i,j,k,ispec_CPML,3) &
                      + PML_duy_dxl(i,j,k) * time_nplus1 * coef1_3 + PML_duy_dxl_old(i,j,k) * time_n * coef2_3
               rmemory_duz_dxl_z(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duz_dxl_z(i,j,k,ispec_CPML,3) &
                      + PML_duz_dxl(i,j,k) * time_nplus1 * coef1_3 + PML_duz_dxl_old(i,j,k) * time_n * coef2_3
-            elseif(singularity_type_3 == 2)then
+            else if(singularity_type_3 == 2)then
               rmemory_dux_dxl_x(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dux_dxl_x(i,j,k,ispec_CPML,3) &
                      + PML_dux_dxl(i,j,k) * time_nplus1**2 * coef1_3 + PML_dux_dxl_old(i,j,k) * time_n**2 * coef2_3
               rmemory_duy_dxl_y(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duy_dxl_y(i,j,k,ispec_CPML,3) &
@@ -202,7 +202,7 @@ subroutine pml_compute_memory_variables_elastic(ispec,ispec_CPML,tempx1,tempy1,t
                      + PML_duy_dyl(i,j,k) * coef1_2 + PML_duy_dyl_old(i,j,k) * coef2_2
               rmemory_duz_dyl_z(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_duz_dyl_z(i,j,k,ispec_CPML,2) &
                      + PML_duz_dyl(i,j,k) * coef1_2 + PML_duz_dyl_old(i,j,k) * coef2_2
-            elseif(singularity_type_2 == 1)then
+            else if(singularity_type_2 == 1)then
               rmemory_dux_dyl_x(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_dux_dyl_x(i,j,k,ispec_CPML,2) &
                      + PML_dux_dyl(i,j,k) * time_nplus1 * coef1_2 + PML_dux_dyl_old(i,j,k) * time_n * coef2_2
               rmemory_duy_dyl_y(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_duy_dyl_y(i,j,k,ispec_CPML,2) &
@@ -220,14 +220,14 @@ subroutine pml_compute_memory_variables_elastic(ispec,ispec_CPML,tempx1,tempy1,t
                      + PML_duy_dyl(i,j,k) * coef1_3 + PML_duy_dyl_old(i,j,k) * coef2_3
               rmemory_duz_dyl_z(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duz_dyl_z(i,j,k,ispec_CPML,3) &
                      + PML_duz_dyl(i,j,k) * coef1_3 + PML_duz_dyl_old(i,j,k) * coef2_3
-            elseif(singularity_type_3 == 1)then
+            else if(singularity_type_3 == 1)then
               rmemory_dux_dyl_x(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dux_dyl_x(i,j,k,ispec_CPML,3) &
                      + PML_dux_dyl(i,j,k) * time_nplus1 * coef1_3 + PML_dux_dyl_old(i,j,k) * time_n * coef2_3
               rmemory_duy_dyl_y(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duy_dyl_y(i,j,k,ispec_CPML,3) &
                      + PML_duy_dyl(i,j,k) * time_nplus1 * coef1_3 + PML_duy_dyl_old(i,j,k) * time_n * coef2_3
               rmemory_duz_dyl_z(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duz_dyl_z(i,j,k,ispec_CPML,3) &
                      + PML_duz_dyl(i,j,k) * time_nplus1 * coef1_3 + PML_duz_dyl_old(i,j,k) * time_n * coef2_3
-            elseif(singularity_type_3 == 2)then
+            else if(singularity_type_3 == 2)then
               rmemory_dux_dyl_x(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dux_dyl_x(i,j,k,ispec_CPML,3) &
                      + PML_dux_dyl(i,j,k) * time_nplus1**2 * coef1_3 + PML_dux_dyl_old(i,j,k) * time_n**2 * coef2_3
               rmemory_duy_dyl_y(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duy_dyl_y(i,j,k,ispec_CPML,3) &
@@ -259,7 +259,7 @@ subroutine pml_compute_memory_variables_elastic(ispec,ispec_CPML,tempx1,tempy1,t
                      + PML_duy_dzl(i,j,k) * coef1_2 + PML_duy_dzl_old(i,j,k) * coef2_2
               rmemory_duz_dzl_z(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_duz_dzl_z(i,j,k,ispec_CPML,2) &
                      + PML_duz_dzl(i,j,k) * coef1_2 + PML_duz_dzl_old(i,j,k) * coef2_2
-            elseif(singularity_type_2 == 1) then
+            else if(singularity_type_2 == 1) then
               rmemory_dux_dzl_x(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_dux_dzl_x(i,j,k,ispec_CPML,2) &
                      + PML_dux_dzl(i,j,k) * time_nplus1 * coef1_2 + PML_dux_dzl_old(i,j,k) * time_n * coef2_2
               rmemory_duy_dzl_y(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_duy_dzl_y(i,j,k,ispec_CPML,2) &
@@ -277,14 +277,14 @@ subroutine pml_compute_memory_variables_elastic(ispec,ispec_CPML,tempx1,tempy1,t
                      + PML_duy_dzl(i,j,k) * coef1_3 + PML_duy_dzl_old(i,j,k) * coef2_3
               rmemory_duz_dzl_z(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duz_dzl_z(i,j,k,ispec_CPML,3) &
                      + PML_duz_dzl(i,j,k) * coef1_3 + PML_duz_dzl_old(i,j,k) * coef2_3
-            elseif(singularity_type_3 == 1) then
+            else if(singularity_type_3 == 1) then
               rmemory_dux_dzl_x(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dux_dzl_x(i,j,k,ispec_CPML,3) &
                      + PML_dux_dzl(i,j,k) * time_nplus1 * coef1_3 + PML_dux_dzl_old(i,j,k) * time_n * coef2_3
               rmemory_duy_dzl_y(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duy_dzl_y(i,j,k,ispec_CPML,3) &
                      + PML_duy_dzl(i,j,k) * time_nplus1 * coef1_3 + PML_duy_dzl_old(i,j,k) * time_n * coef2_3
               rmemory_duz_dzl_z(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duz_dzl_z(i,j,k,ispec_CPML,3) &
                      + PML_duz_dzl(i,j,k) * time_nplus1 * coef1_3 + PML_duz_dzl_old(i,j,k) * time_n * coef2_3
-            elseif(singularity_type_3 == 2) then
+            else if(singularity_type_3 == 2) then
               rmemory_dux_dzl_x(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dux_dzl_x(i,j,k,ispec_CPML,3) &
                      + PML_dux_dzl(i,j,k) * time_nplus1**2 * coef1_3 + PML_dux_dzl_old(i,j,k) * time_n**2 * coef2_3
               rmemory_duy_dzl_y(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_duy_dzl_y(i,j,k,ispec_CPML,3) &
@@ -509,7 +509,7 @@ subroutine pml_compute_memory_variables_acoustic(ispec,ispec_CPML,temp1,temp2,te
             if(singularity_type_2 == 0)then
               rmemory_dpotential_dxl(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_dpotential_dxl(i,j,k,ispec_CPML,2) + &
                      coef1_2 * PML_dpotential_dxl(i,j,k) + coef2_2 * PML_dpotential_dxl_old(i,j,k)
-            elseif(singularity_type_2 == 1)then
+            else if(singularity_type_2 == 1)then
               rmemory_dpotential_dxl(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_dpotential_dxl(i,j,k,ispec_CPML,2) + &
                      coef1_2 * time_nplus1 * PML_dpotential_dxl(i,j,k) + &
                      coef2_2 * time_n * PML_dpotential_dxl_old(i,j,k)
@@ -520,11 +520,11 @@ subroutine pml_compute_memory_variables_acoustic(ispec,ispec_CPML,temp1,temp2,te
             if(singularity_type_3 == 0)then
               rmemory_dpotential_dxl(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dpotential_dxl(i,j,k,ispec_CPML,3) + &
                      coef1_3 * PML_dpotential_dxl(i,j,k) + coef2_3 * PML_dpotential_dxl_old(i,j,k)
-            elseif(singularity_type_3 == 1)then
+            else if(singularity_type_3 == 1)then
               rmemory_dpotential_dxl(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dpotential_dxl(i,j,k,ispec_CPML,3) + &
                      coef1_3 * time_nplus1 * PML_dpotential_dxl(i,j,k) + &
                      coef2_3 * time_n * PML_dpotential_dxl_old(i,j,k)
-            elseif(singularity_type_3 == 2)then
+            else if(singularity_type_3 == 2)then
               rmemory_dpotential_dxl(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dpotential_dxl(i,j,k,ispec_CPML,3) + &
                      coef1_3 * time_nplus1**2 * PML_dpotential_dxl(i,j,k) + &
                      coef2_3 * time_n**2 * PML_dpotential_dxl_old(i,j,k)
@@ -545,7 +545,7 @@ subroutine pml_compute_memory_variables_acoustic(ispec,ispec_CPML,temp1,temp2,te
             if(singularity_type_2 == 0)then
               rmemory_dpotential_dyl(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_dpotential_dyl(i,j,k,ispec_CPML,2) + &
                      coef1_2 * PML_dpotential_dyl(i,j,k) + coef2_2 * PML_dpotential_dyl_old(i,j,k)
-            elseif(singularity_type_2 == 1)then
+            else if(singularity_type_2 == 1)then
               rmemory_dpotential_dyl(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_dpotential_dyl(i,j,k,ispec_CPML,2) + &
                      coef1_2 * time_nplus1 * PML_dpotential_dyl(i,j,k) + &
                      coef2_2 * time_n * PML_dpotential_dyl_old(i,j,k)
@@ -556,11 +556,11 @@ subroutine pml_compute_memory_variables_acoustic(ispec,ispec_CPML,temp1,temp2,te
             if(singularity_type_3 == 0)then
               rmemory_dpotential_dyl(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dpotential_dyl(i,j,k,ispec_CPML,3) + &
                      coef1_3 * PML_dpotential_dyl(i,j,k) + coef2_3 * PML_dpotential_dyl_old(i,j,k)
-            elseif(singularity_type_3 == 1)then
+            else if(singularity_type_3 == 1)then
               rmemory_dpotential_dyl(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dpotential_dyl(i,j,k,ispec_CPML,3) + &
                      coef1_3 * time_nplus1 * PML_dpotential_dyl(i,j,k) + &
                      coef2_3 * time_n * PML_dpotential_dyl_old(i,j,k)
-            elseif(singularity_type_3 == 2)then
+            else if(singularity_type_3 == 2)then
               rmemory_dpotential_dyl(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dpotential_dyl(i,j,k,ispec_CPML,3) + &
                      coef1_3 * time_nplus1**2 * PML_dpotential_dyl(i,j,k) + &
                      coef2_3 * time_n**2 * PML_dpotential_dyl_old(i,j,k)
@@ -581,7 +581,7 @@ subroutine pml_compute_memory_variables_acoustic(ispec,ispec_CPML,temp1,temp2,te
             if(singularity_type_2 == 0)then
               rmemory_dpotential_dzl(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_dpotential_dzl(i,j,k,ispec_CPML,2) + &
                      coef1_2 * PML_dpotential_dzl(i,j,k) + coef2_2 * PML_dpotential_dzl_old(i,j,k)
-            elseif(singularity_type_2 == 1)then
+            else if(singularity_type_2 == 1)then
               rmemory_dpotential_dzl(i,j,k,ispec_CPML,2) = coef0_2 * rmemory_dpotential_dzl(i,j,k,ispec_CPML,2) + &
                      coef1_2 * time_nplus1 * PML_dpotential_dzl(i,j,k) + &
                      coef2_2 * time_n * PML_dpotential_dzl_old(i,j,k)
@@ -592,11 +592,11 @@ subroutine pml_compute_memory_variables_acoustic(ispec,ispec_CPML,temp1,temp2,te
             if(singularity_type_3 == 0)then
               rmemory_dpotential_dzl(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dpotential_dzl(i,j,k,ispec_CPML,3) + &
                      coef1_3 * PML_dpotential_dzl(i,j,k) + coef2_3 * PML_dpotential_dzl_old(i,j,k)
-            elseif(singularity_type_3 == 1)then
+            else if(singularity_type_3 == 1)then
               rmemory_dpotential_dzl(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dpotential_dzl(i,j,k,ispec_CPML,3) + &
                      coef1_3 * time_nplus1 * PML_dpotential_dzl(i,j,k) + &
                      coef2_3 * time_n * PML_dpotential_dzl_old(i,j,k)
-            elseif(singularity_type_3 == 2)then
+            else if(singularity_type_3 == 2)then
               rmemory_dpotential_dzl(i,j,k,ispec_CPML,3) = coef0_3 * rmemory_dpotential_dzl(i,j,k,ispec_CPML,3) + &
                      coef1_3 * time_nplus1**2 * PML_dpotential_dzl(i,j,k) + &
                      coef2_3 * time_n**2 * PML_dpotential_dzl_old(i,j,k)
@@ -804,7 +804,7 @@ end subroutine pml_compute_memory_variables_elastic_acoustic
 !
 !=====================================================================
 !
-subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y,beta_y,alpha_y,kappa_z,beta_z,alpha_z, &
+subroutine lijk_parameter_computation(timeval,deltat,kappa_x,beta_x,alpha_x,kappa_y,beta_y,alpha_y,kappa_z,beta_z,alpha_z, &
                                       CPML_region_local,index_ijk,A_0,A_1,A_2,A_3,&
                                       coef0_1,coef1_1,coef2_1,coef0_2,coef1_2,coef2_2,&
                                       coef0_3,coef1_3,coef2_3,singularity_type_2,singularity_type_3)
@@ -814,7 +814,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
 
   implicit none
 
-  real(kind=CUSTOM_REAL), intent(in) :: time,deltat
+  real(kind=CUSTOM_REAL), intent(in) :: timeval,deltat
   real(kind=CUSTOM_REAL), intent(in) :: kappa_x,beta_x,alpha_x, &
                                         kappa_y,beta_y,alpha_y, &
                                         kappa_z,beta_z,alpha_z
@@ -841,7 +841,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
     CPML_XZ_ONLY_TEMP = CPML_XZ_ONLY
     CPML_YZ_ONLY_TEMP = CPML_YZ_ONLY
     CPML_XYZ_TEMP = CPML_XYZ
-  elseif(index_ijk == 132)then
+  else if(index_ijk == 132)then
     CPML_X_ONLY_TEMP = CPML_X_ONLY
     CPML_Y_ONLY_TEMP = CPML_Z_ONLY
     CPML_Z_ONLY_TEMP = CPML_Y_ONLY
@@ -849,7 +849,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
     CPML_XZ_ONLY_TEMP = CPML_XY_ONLY
     CPML_YZ_ONLY_TEMP = CPML_YZ_ONLY
     CPML_XYZ_TEMP = CPML_XYZ
-  elseif(index_ijk == 231)then
+  else if(index_ijk == 231)then
     CPML_X_ONLY_TEMP = CPML_Z_ONLY
     CPML_Y_ONLY_TEMP = CPML_Y_ONLY
     CPML_Z_ONLY_TEMP = CPML_X_ONLY
@@ -883,7 +883,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       singularity_type_2 = 0  ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
       singularity_type_3 = 0  ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-    elseif(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL .and. abs(alpha_x-beta_z) >= 1.e-5_CUSTOM_REAL &
+    else if(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL .and. abs(alpha_x-beta_z) >= 1.e-5_CUSTOM_REAL &
           .and. abs(alpha_y-beta_z) >= 1.e-5_CUSTOM_REAL)then
       !----------------A1,2,3-------------------------
       alpha_0 = max(alpha_x,alpha_y)
@@ -898,14 +898,14 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       bar_A_3 = - bar_A_0 * (beta_z - alpha_z) * (beta_z-beta_x) * (beta_z-beta_y) / &
                 ((beta_z-alpha_0) * (beta_z-alpha_0))
 
-      A_1 = bar_A_1 + time * bar_A_2
+      A_1 = bar_A_1 + timeval * bar_A_2
       A_2 = - bar_A_2
       A_3 = bar_A_3
 
       singularity_type_2 = 1 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
       singularity_type_3 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-    elseif(abs(alpha_x-alpha_y) >= 1.e-5_CUSTOM_REAL .and. abs(alpha_x-beta_z) < 1.e-5_CUSTOM_REAL &
+    else if(abs(alpha_x-alpha_y) >= 1.e-5_CUSTOM_REAL .and. abs(alpha_x-beta_z) < 1.e-5_CUSTOM_REAL &
           .and. abs(alpha_y-beta_z) >= 1.e-5_CUSTOM_REAL)then
       !----------------A1,2,3-------------------------
       alpha_0 = max(alpha_x,beta_z)
@@ -920,14 +920,14 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       bar_A_3 = bar_A_0 * (alpha_0 - alpha_z) * (alpha_0-beta_x) * (alpha_0-beta_y) / &
                 (alpha_0-alpha_y)
 
-      A_1 = bar_A_1 + time * bar_A_3
+      A_1 = bar_A_1 + timeval * bar_A_3
       A_2 = bar_A_2
       A_3 = -bar_A_3
 
       singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
       singularity_type_3 = 1 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-    elseif(abs(alpha_x-alpha_y) >= 1.e-5_CUSTOM_REAL .and. abs(alpha_x-beta_z) >= 1.e-5_CUSTOM_REAL &
+    else if(abs(alpha_x-alpha_y) >= 1.e-5_CUSTOM_REAL .and. abs(alpha_x-beta_z) >= 1.e-5_CUSTOM_REAL &
           .and. abs(alpha_y-beta_z) < 1.e-5_CUSTOM_REAL)then
       !----------------A1,2,3-------------------------
       alpha_0 = max(alpha_y,beta_z)
@@ -943,13 +943,13 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
                 (alpha_0-alpha_x)
 
       A_1 = bar_A_1
-      A_2 = bar_A_2 + time * bar_A_3
+      A_2 = bar_A_2 + timeval * bar_A_3
       A_3 = - bar_A_3
 
       singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
       singularity_type_3 = 1 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-    elseif(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL .and. abs(alpha_x-beta_z) < 1.e-5_CUSTOM_REAL &
+    else if(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL .and. abs(alpha_x-beta_z) < 1.e-5_CUSTOM_REAL &
           .and. abs(alpha_y-beta_z) < 1.e-5_CUSTOM_REAL)then
       !----------------A1,2,3-------------------------
       alpha_0 = max(alpha_x,alpha_y,beta_z)
@@ -959,8 +959,8 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
                 -2._CUSTOM_REAL * alpha_0 * (alpha_z + beta_x + beta_y))
       bar_A_3 = bar_A_0 * (-0.5_CUSTOM_REAL) * (alpha_0 - alpha_z) * (alpha_0-beta_x) * (alpha_0-beta_y)
 
-      A_1 = bar_A_1 + time * bar_A_2 + time**2 * bar_A_3
-      A_2 = - bar_A_2 - 2._CUSTOM_REAL * time * bar_A_3
+      A_1 = bar_A_1 + timeval * bar_A_2 + timeval**2 * bar_A_3
+      A_2 = - bar_A_2 - 2._CUSTOM_REAL * timeval * bar_A_3
       A_3 = bar_A_3
 
       singularity_type_2 = 1 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
@@ -969,7 +969,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
     else
       stop 'error in lijk_parameter_computation'
     endif
-  elseif(CPML_region_local == CPML_YZ_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_YZ_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = kappa_y / kappa_z
     A_0 = bar_A_0
@@ -990,7 +990,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
       singularity_type_3 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-    elseif( abs(alpha_y-beta_z) < 1.e-5_CUSTOM_REAL)then
+    else if( abs(alpha_y-beta_z) < 1.e-5_CUSTOM_REAL)then
       !----------------A1,2,3-------------------------
       alpha_0 = max(alpha_y,beta_z)
 
@@ -999,7 +999,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       bar_A_3 = bar_A_0 * (alpha_0 - alpha_z) * (alpha_0-beta_y)
 
       A_1 = bar_A_1
-      A_2 = bar_A_2 + time * bar_A_3
+      A_2 = bar_A_2 + timeval * bar_A_3
       A_3 = - bar_A_3
 
       singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
@@ -1008,7 +1008,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
     else
       stop 'error in lijk_parameter_computation'
     endif
-  elseif(CPML_region_local == CPML_XZ_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_XZ_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = kappa_x / kappa_z
     A_0 = bar_A_0
@@ -1029,7 +1029,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
       singularity_type_3 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-    elseif(abs(alpha_x-beta_z) < 1.e-5_CUSTOM_REAL)then
+    else if(abs(alpha_x-beta_z) < 1.e-5_CUSTOM_REAL)then
       !----------------A1,2,3-------------------------
       alpha_0 = max(alpha_x,beta_z)
 
@@ -1037,7 +1037,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       bar_A_2 = 0._CUSTOM_REAL
       bar_A_3 = bar_A_0 * (alpha_0 - alpha_z) * (alpha_0-beta_x)
 
-      A_1 = bar_A_1 + time * bar_A_3
+      A_1 = bar_A_1 + timeval * bar_A_3
       A_2 = bar_A_2
       A_3 = -bar_A_3
 
@@ -1048,7 +1048,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       stop 'error in lijk_parameter_computation'
     endif
 
-  elseif(CPML_region_local == CPML_XY_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_XY_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = kappa_x * kappa_y
     A_0 = bar_A_0
@@ -1069,7 +1069,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
       singularity_type_3 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-    elseif(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL)then
+    else if(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL)then
       !----------------A1,2,3-------------------------
       alpha_0 = max(alpha_x,alpha_y)
 
@@ -1077,7 +1077,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
       bar_A_2 = bar_A_0 * (alpha_0 - beta_x) * (alpha_0 - beta_y)
       bar_A_3 = 0._CUSTOM_REAL
 
-      A_1 = bar_A_1 + time * bar_A_2
+      A_1 = bar_A_1 + timeval * bar_A_2
       A_2 = - bar_A_2
       A_3 = bar_A_3
 
@@ -1087,7 +1087,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
     else
       stop 'error in lijk_parameter_computation'
     endif
-  elseif(CPML_region_local == CPML_X_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_X_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = kappa_x
     A_0 = bar_A_0
@@ -1103,7 +1103,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
     singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
     singularity_type_3 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-  elseif(CPML_region_local == CPML_Y_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_Y_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = kappa_y
     A_0 = bar_A_0
@@ -1119,7 +1119,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
     singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
     singularity_type_3 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-  elseif(CPML_region_local == CPML_Z_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_Z_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = 1._CUSTOM_REAL / kappa_z
     A_0 = bar_A_0
@@ -1147,7 +1147,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
      else
         coef1_1 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) / bb
         coef2_1 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) * exp(- bb * deltat / 2._CUSTOM_REAL) / bb
-     end if
+     endif
   else
      if ( FIRST_ORDER_CONVOLUTION ) then
         coef1_1 = deltat
@@ -1155,7 +1155,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
      else
         coef1_1 = deltat / 2._CUSTOM_REAL
         coef2_1 = deltat / 2._CUSTOM_REAL
-     end if
+     endif
   endif
 
   bb = alpha_y
@@ -1167,7 +1167,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
      else
         coef1_2 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) / bb
         coef2_2 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) * exp(- bb * deltat / 2._CUSTOM_REAL) / bb
-     end if
+     endif
   else
      if ( FIRST_ORDER_CONVOLUTION ) then
         coef1_2 = deltat
@@ -1175,7 +1175,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
      else
         coef1_2 = deltat / 2._CUSTOM_REAL
         coef2_2 = deltat / 2._CUSTOM_REAL
-     end if
+     endif
   endif
 
   bb = beta_z
@@ -1187,7 +1187,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
      else
         coef1_3 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) / bb
         coef2_3 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) * exp(- bb * deltat / 2._CUSTOM_REAL) / bb
-     end if
+     endif
   else
      if ( FIRST_ORDER_CONVOLUTION ) then
         coef1_3 = deltat
@@ -1195,7 +1195,7 @@ subroutine lijk_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y
      else
         coef1_3 = deltat / 2._CUSTOM_REAL
         coef2_3 = deltat / 2._CUSTOM_REAL
-     end if
+     endif
   endif
 
 end subroutine lijk_parameter_computation
@@ -1228,37 +1228,37 @@ subroutine lx_parameter_computation(deltat,kappa_x,beta_x,alpha_x, &
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_x - beta_x)
 
-  elseif(CPML_region_local == CPML_YZ_ONLY)then
+  else if(CPML_region_local == CPML_YZ_ONLY)then
   !----------------A0-------------------------
     A_0 = 1._CUSTOM_REAL
   !----------------A1-------------------------
     A_1 = 0._CUSTOM_REAL
 
-  elseif(CPML_region_local == CPML_XZ_ONLY)then
+  else if(CPML_region_local == CPML_XZ_ONLY)then
   !----------------A0-------------------------
     A_0 = kappa_x
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_x - beta_x)
 
-  elseif(CPML_region_local == CPML_XY_ONLY)then
+  else if(CPML_region_local == CPML_XY_ONLY)then
   !----------------A0-------------------------
     A_0 = kappa_x
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_x - beta_x)
 
-  elseif(CPML_region_local == CPML_X_ONLY)then
+  else if(CPML_region_local == CPML_X_ONLY)then
   !----------------A0-------------------------
     A_0 = kappa_x
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_x - beta_x)
 
-  elseif(CPML_region_local == CPML_Y_ONLY)then
+  else if(CPML_region_local == CPML_Y_ONLY)then
   !----------------A0-------------------------
     A_0 = 1._CUSTOM_REAL
   !----------------A1-------------------------
     A_1 = 0._CUSTOM_REAL
 
-  elseif(CPML_region_local == CPML_Z_ONLY)then
+  else if(CPML_region_local == CPML_Z_ONLY)then
   !----------------A0-------------------------
     A_0 = 1._CUSTOM_REAL
   !----------------A1-------------------------
@@ -1306,37 +1306,37 @@ subroutine ly_parameter_computation(deltat,kappa_y,beta_y,alpha_y, &
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_y - beta_y)
 
-  elseif(CPML_region_local == CPML_YZ_ONLY)then
+  else if(CPML_region_local == CPML_YZ_ONLY)then
   !----------------A0-------------------------
     A_0 = kappa_y
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_y - beta_y)
 
-  elseif(CPML_region_local == CPML_XZ_ONLY)then
+  else if(CPML_region_local == CPML_XZ_ONLY)then
   !----------------A0-------------------------
     A_0 = 1._CUSTOM_REAL
   !----------------A1-------------------------
     A_1 = 0._CUSTOM_REAL
 
-  elseif(CPML_region_local == CPML_XY_ONLY)then
+  else if(CPML_region_local == CPML_XY_ONLY)then
   !----------------A0-------------------------
     A_0 = kappa_y
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_y - beta_y)
 
-  elseif(CPML_region_local == CPML_X_ONLY)then
+  else if(CPML_region_local == CPML_X_ONLY)then
   !----------------A0-------------------------
     A_0 = 1._CUSTOM_REAL
   !----------------A1-------------------------
     A_1 = 0._CUSTOM_REAL
 
-  elseif(CPML_region_local == CPML_Y_ONLY)then
+  else if(CPML_region_local == CPML_Y_ONLY)then
   !----------------A0-------------------------
     A_0 = kappa_y
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_y - beta_y)
 
-  elseif(CPML_region_local == CPML_Z_ONLY)then
+  else if(CPML_region_local == CPML_Z_ONLY)then
   !----------------A0-------------------------
     A_0 = 1._CUSTOM_REAL
   !----------------A1-------------------------
@@ -1388,37 +1388,37 @@ subroutine lz_parameter_computation(deltat,kappa_z,beta_z,alpha_z, &
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_z - beta_z)
 
-  elseif(CPML_region_local == CPML_YZ_ONLY)then
+  else if(CPML_region_local == CPML_YZ_ONLY)then
   !----------------A0-------------------------
     A_0 = kappa_z
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_z - beta_z)
 
-  elseif(CPML_region_local == CPML_XZ_ONLY)then
+  else if(CPML_region_local == CPML_XZ_ONLY)then
   !----------------A0-------------------------
     A_0 = kappa_z
   !----------------A1-------------------------
     A_1 = - A_0 * (alpha_z - beta_z)
 
-  elseif(CPML_region_local == CPML_XY_ONLY)then
+  else if(CPML_region_local == CPML_XY_ONLY)then
   !----------------A0-------------------------
     A_0 = 1._CUSTOM_REAL
   !----------------A1-------------------------
     A_1 = 0._CUSTOM_REAL
 
-  elseif(CPML_region_local == CPML_X_ONLY)then
+  else if(CPML_region_local == CPML_X_ONLY)then
   !----------------A0-------------------------
     A_0 = 1._CUSTOM_REAL
   !----------------A1-------------------------
     A_1 = 0._CUSTOM_REAL
 
-  elseif(CPML_region_local == CPML_Y_ONLY)then
+  else if(CPML_region_local == CPML_Y_ONLY)then
   !----------------A0-------------------------
     A_0 = 1._CUSTOM_REAL
   !----------------A1-------------------------
     A_1 = 0._CUSTOM_REAL
 
-  elseif(CPML_region_local == CPML_Z_ONLY)then
+  else if(CPML_region_local == CPML_Z_ONLY)then
   !----------------A0-------------------------
     A_0 = kappa_z
   !----------------A1-------------------------
@@ -1441,7 +1441,7 @@ end subroutine lz_parameter_computation
 !
 !=====================================================================
 !
-subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_x,kappa_y,beta_y,alpha_y, &
+subroutine lxy_interface_parameter_computation(timeval,deltat,kappa_x,beta_x,alpha_x,kappa_y,beta_y,alpha_y, &
                                       CPML_region_local,index_ijk,A_0,A_1,A_2,&
                                       coef0_1,coef1_1,coef2_1,coef0_2,coef1_2,coef2_2,&
                                       singularity_type_2)
@@ -1451,7 +1451,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
 
   implicit none
 
-  real(kind=CUSTOM_REAL), intent(in) :: time,deltat
+  real(kind=CUSTOM_REAL), intent(in) :: timeval,deltat
   real(kind=CUSTOM_REAL), intent(in) :: kappa_x,beta_x,alpha_x, &
                                         kappa_y,beta_y,alpha_y
   integer, intent(in) :: CPML_region_local,index_ijk
@@ -1498,14 +1498,14 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
 
       singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-    elseif(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL)then
+    else if(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL)then
       !----------------A1,2-------------------------
       alpha_0 = max(alpha_x,alpha_y)
 
       bar_A_1 = bar_A_0 * (-2._CUSTOM_REAL * alpha_0 + (beta_x + beta_y))
       bar_A_2 = bar_A_0 * (alpha_0 - beta_x) * (alpha_0 - beta_y)
 
-      A_1 = bar_A_1 + time * bar_A_2
+      A_1 = bar_A_1 + timeval * bar_A_2
       A_2 = - bar_A_2
 
       singularity_type_2 = 1 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
@@ -1513,7 +1513,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
     else
       stop 'error in lxy_interface_parameter_computation'
     endif
-  elseif(CPML_region_local == CPML_YZ_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_YZ_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = kappa_y
     A_0 = bar_A_0
@@ -1526,7 +1526,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
 
     singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-  elseif(CPML_region_local == CPML_XZ_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_XZ_ONLY_TEMP)then
 
   !----------------A0-------------------------
     bar_A_0 = kappa_x
@@ -1540,7 +1540,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
 
     singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-  elseif(CPML_region_local == CPML_XY_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_XY_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = kappa_x * kappa_y
     A_0 = bar_A_0
@@ -1558,14 +1558,14 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
 
       singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-    elseif(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL)then
+    else if(abs(alpha_x-alpha_y) < 1.e-5_CUSTOM_REAL)then
       !----------------A1,2,3-------------------------
       alpha_0 = max(alpha_x,alpha_y)
 
       bar_A_1 = bar_A_0 * (-2._CUSTOM_REAL * alpha_0 + (beta_x + beta_y))
       bar_A_2 = bar_A_0 * (alpha_0 - beta_x) * (alpha_0 - beta_y)
 
-      A_1 = bar_A_1 + time * bar_A_2
+      A_1 = bar_A_1 + timeval * bar_A_2
       A_2 = - bar_A_2
 
       singularity_type_2 = 1 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
@@ -1573,7 +1573,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
     else
       stop 'error in lxy_interface_parameter_computation'
     endif
-  elseif(CPML_region_local == CPML_X_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_X_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = kappa_x
     A_0 = bar_A_0
@@ -1586,7 +1586,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
 
     singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-  elseif(CPML_region_local == CPML_Y_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_Y_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = kappa_y
     A_0 = bar_A_0
@@ -1599,7 +1599,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
 
     singularity_type_2 = 0 ! 0 means no singularity, 1 means first order singularity, 2 means second order singularity
 
-  elseif(CPML_region_local == CPML_Z_ONLY_TEMP)then
+  else if(CPML_region_local == CPML_Z_ONLY_TEMP)then
   !----------------A0-------------------------
     bar_A_0 = 1._CUSTOM_REAL
     A_0 = bar_A_0
@@ -1627,7 +1627,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
      else
         coef1_1 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) / bb
         coef2_1 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) * exp(- bb * deltat / 2._CUSTOM_REAL) / bb
-     end if
+     endif
   else
      if ( FIRST_ORDER_CONVOLUTION ) then
         coef1_1 = deltat
@@ -1635,7 +1635,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
      else
         coef1_1 = deltat / 2._CUSTOM_REAL
         coef2_1 = deltat / 2._CUSTOM_REAL
-     end if
+     endif
   endif
 
   bb = alpha_y
@@ -1647,7 +1647,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
      else
         coef1_2 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) / bb
         coef2_2 = ( 1._CUSTOM_REAL - exp(- bb * deltat / 2._CUSTOM_REAL) ) * exp(- bb * deltat / 2._CUSTOM_REAL) / bb
-     end if
+     endif
   else
      if ( FIRST_ORDER_CONVOLUTION ) then
         coef1_2 = deltat
@@ -1655,7 +1655,7 @@ subroutine lxy_interface_parameter_computation(time,deltat,kappa_x,beta_x,alpha_
      else
         coef1_2 = deltat / 2._CUSTOM_REAL
         coef2_2 = deltat / 2._CUSTOM_REAL
-     end if
+     endif
   endif
 
 end subroutine lxy_interface_parameter_computation

--- a/src/specfem3D/prepare_timerun.F90
+++ b/src/specfem3D/prepare_timerun.F90
@@ -130,7 +130,7 @@
   endif
 
   ! synchronize all the processes
-  call sync_all()
+  call synchronize_all()
 
   end subroutine prepare_timerun
 
@@ -240,7 +240,7 @@
 
   ! synchronize all the processes before assembling the mass matrix
   ! to make sure all the nodes have finished to read their databases
-  call sync_all()
+  call synchronize_all()
 
   ! the mass matrix needs to be assembled with MPI here once and for all
   if(ACOUSTIC_SIMULATION) then
@@ -727,7 +727,7 @@
       write(IMAIN,*)
       call flush_IMAIN()
     endif
-    call sync_all()
+    call synchronize_all()
 
     ! checks that 8-node mesh elements are used (27-node elements are not supported)
     if( NGNOD /= NGNOD_EIGHT_CORNERS) &
@@ -1332,7 +1332,7 @@
   endif
 
   ! synchronizes processes
-  !call sync_all()
+  !call synchronize_all()
 
   ! prepares needed receiver array for adjoint runs
   if( SIMULATION_TYPE == 2 .or. SIMULATION_TYPE == 3 ) &
@@ -1365,7 +1365,7 @@
   endif
 
   ! synchronizes processes
-  call sync_all()
+  call synchronize_all()
 
   ! sends initial data to device
 
@@ -1387,7 +1387,7 @@
   endif
 
   ! synchronizes processes
-  call sync_all()
+  call synchronize_all()
 
   ! outputs GPU usage to files for all processes
   call output_free_device_memory(myrank)

--- a/src/specfem3D/setup_sources_receivers.f90
+++ b/src/specfem3D/setup_sources_receivers.f90
@@ -57,7 +57,7 @@
   endif
 
   ! synchronizes processes
-  call sync_all()
+  call synchronize_all()
 
   end subroutine setup_sources_receivers
 
@@ -347,7 +347,7 @@
            LATITUDE_MIN, LATITUDE_MAX, LONGITUDE_MIN, LONGITUDE_MAX)
 
     if(nrec < 1) call exit_MPI(myrank,'need at least one receiver')
-    call sync_all()
+    call synchronize_all()
 
   else
     call get_value_string(rec_filename, 'solver.STATIONS', &
@@ -357,7 +357,7 @@
     call station_filter(SUPPRESS_UTM_PROJECTION,UTM_PROJECTION_ZONE,myrank,rec_filename,filtered_rec_filename,nrec, &
            LATITUDE_MIN, LATITUDE_MAX, LONGITUDE_MIN, LONGITUDE_MAX)
     if (nrec < 1) call exit_MPI(myrank, 'adjoint simulation needs at least one receiver')
-    call sync_all()
+    call synchronize_all()
   endif
 
   if(myrank == 0) then

--- a/src/specfem3D/write_seismograms.f90
+++ b/src/specfem3D/write_seismograms.f90
@@ -656,7 +656,7 @@
 
 
   integer irec,irec_local
-  integer idim,jdim,irecord,isample
+  integer idimval,jdimval,irecord,isample
 
   character(len=4) chn
   character(len=1) component
@@ -672,20 +672,20 @@
     ! save three components of displacement vector
     irecord = 1
 
-    do idim = 1, 3
-      do jdim = idim, 3
+    do idimval = 1, 3
+      do jdimval = idimval, 3
 
-        if(idim == 1 .and. jdim == 1) then
+        if(idimval == 1 .and. jdimval == 1) then
           chn = 'SNN'
-        else if(idim == 1 .and. jdim == 2) then
+        else if(idimval == 1 .and. jdimval == 2) then
           chn = 'SEN'
-        else if(idim == 1 .and. jdim == 3) then
+        else if(idimval == 1 .and. jdimval == 3) then
           chn = 'SEZ'
-        else if(idim == 2 .and. jdim == 2) then
+        else if(idimval == 2 .and. jdimval == 2) then
           chn = 'SEE'
-        else if(idim == 2 .and. jdim == 3) then
+        else if(idimval == 2 .and. jdimval == 3) then
           chn = 'SNZ'
-        else if(idim == 3 .and. jdim == 3) then
+        else if(idimval == 3 .and. jdimval == 3) then
           chn = 'SZZ'
         else
           call exit_MPI(myrank,'incorrect channel value')
@@ -719,9 +719,9 @@
           if(irecord == 1) then
             ! distinguish between single and double precision for reals
             if(CUSTOM_REAL == SIZE_REAL) then
-              write(IOUT,*) sngl(dble(isample-1)*DT - t0),' ',seismograms(jdim,idim,irec_local,isample)
+              write(IOUT,*) sngl(dble(isample-1)*DT - t0),' ',seismograms(jdimval,idimval,irec_local,isample)
             else
-              write(IOUT,*) dble(isample-1)*DT - t0,' ',seismograms(jdim,idim,irec_local,isample)
+              write(IOUT,*) dble(isample-1)*DT - t0,' ',seismograms(jdimval,idimval,irec_local,isample)
             endif
           else
             call exit_MPI(myrank,'incorrect record label')
@@ -730,8 +730,8 @@
 
         close(IOUT)
 
-      enddo ! jdim
-    enddo ! idim
+      enddo ! jdimval
+    enddo ! idimval
   enddo ! irec_local
 
   end subroutine write_adj_seismograms2_to_file


### PR DESCRIPTION
...y at ORNL.

In particular, renamed all the variables or functions that had the same name as Fortran intrinsics
(although that is correct in Fortran, it can be confusing and it also confuses syntax highlighting,
and the Portland compiler prints a warning for each of them)
