### PR TITLE
Update write_VTK_data.f90

### DIFF
--- a/src/shared/write_VTK_data.f90
+++ b/src/shared/write_VTK_data.f90
@@ -224,7 +224,8 @@
   write(IOVTK,*) ""
 
   ! iflag field on global nodeset
-  allocate(mask_ibool(nglob),flag_val(nglob),stat=ier)
+  !allocate(mask_ibool(nglob),flag_val(nglob),stat=ier)
+  if (.not. allocated(mask_ibool)) allocate(mask_ibool(nglob),flag_val(nglob),stat=ier)
   if( ier /= 0 ) stop 'error allocating mask'
 
   mask_ibool = .false.


### PR DESCRIPTION
ON blue gene system with bgxlf90 compiler and -qsave on (default)

if ATTENUATION and SAVE_MESH_FILES are TRUE, the code exits since the variables are already allocated.
