### PR TITLE
fix: hold module info when compiling w/o adios on crays

### DIFF
--- a/flags.guess
+++ b/flags.guess
@@ -42,7 +42,7 @@ case $my_FC in
         #
         # Cray Fortran
         #
-        DEF_FFLAGS="-O3 -Onoaggress -Oipa0 -hfp2 -Ovector3 -Oscalar3 -Ocache2 -Ounroll2 -Ofusion2 -DFORCE_VECTORIZATION -p \$O" # turn on optimization; -Oaggress -Oipa4 would make it even more aggressive
+        DEF_FFLAGS="-O3 -Onoaggress -Oipa0 -hfp2 -Ovector3 -Oscalar3 -Ocache2 -Ounroll2 -Ofusion2 -DFORCE_VECTORIZATION -p \$O  -eF -em -rm" # turn on optimization; -Oaggress -Oipa4 would make it even more aggressive
         # -eC -eD -ec -en -eI -ea -g -G0  # turn on full debugging and range checking
         ;;
     pgf95|*/pgf95|pgf90|*/pgf90)

--- a/src/generate_databases/Makefile.in
+++ b/src/generate_databases/Makefile.in
@@ -232,13 +232,13 @@ $O/%.adios.o: %.f90 ${SHARED}constants.h
 	${MPIFCCOMPILE_CHECK} -c $(ADIOS_INC) $(FCFLAGS) $(MPI_INCLUDES) -o $@ $<
 
 $O/%.noadios.o: %.F90 
-	${FC} -c -o $@ $<
+	${FCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.noadios.o: %.f90 
-	${FC} -c -o $@ $<
+	${FCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.shared_noadios.o: ${SHARED}/%.f90 .FORCE
-	${MPIFC} -c -o $@ $<
+	${MPIFCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.shared_adios.o: ${SHARED}/%.f90 ${SHARED}/constants.h .FORCE
 	${MPIFC} -c $(ADIOS_INC) $(FCFLAGS) $(MPI_INCLUDES) -o $@ $<

--- a/src/meshfem3D/Makefile.in
+++ b/src/meshfem3D/Makefile.in
@@ -202,13 +202,13 @@ $O/%.adios.o: %.f90 ${SHARED}constants.h
 	${MPIFCCOMPILE_CHECK} -c $(ADIOS_INC) $(FCFLAGS) $(MPI_INCLUDES) -o $@ $<
 
 $O/%.noadios.o: %.F90 
-	${FC} -c -o $@ $<
+	${FCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.noadios.o: %.f90
-	${FC} -c -o $@ $<
+	${FCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.shared_noadios.o: ${SHARED}/%.f90 .FORCE
-	${MPIFC} -c -o $@ $<
+	${MPIFCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.shared_adios.o: ${SHARED}/%.f90 ${SHARED}/constants.h .FORCE
 	${MPIFC} -c $(ADIOS_INC) $(FCFLAGS) $(MPI_INCLUDES) -o $@ $<

--- a/src/specfem3D/Makefile.in
+++ b/src/specfem3D/Makefile.in
@@ -430,13 +430,13 @@ $O/%.adios.o: %.f90
 	${MPIFCCOMPILE_CHECK} -c $(ADIOS_INC) $(FCFLAGS) $(MPI_INCLUDES) -o $@ $<
 
 $O/%.noadios.o: %.F90 
-	${FC} -c -o $@ $<
+	${FCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.noadios.o: %.f90 
-	${FC} -c -o $@ $<
+	${FCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.shared_noadios.o: ${SHARED}/%.f90 .FORCE
-	${MPIFC} -c -o $@ $<
+	${MPIFCCOMPILE_CHECK} -c -o $@ $<
 
 $O/%.shared_adios.o: ${SHARED}/%.f90 ${SHARED}/constants.h .FORCE
 	${MPIFC} -c $(ADIOS_INC) $(FCFLAGS) $(MPI_INCLUDES) -o $@ $<


### PR DESCRIPTION
Bug report from Andreas Rietbrock on cig-seismo

Dear all,
I am trying to compile the latest specfem3d version on the new cray machine at Edinburgh. I get the following error message regarding the ADIOS module, which I do not want to use during the compilation stage. Any idea how to get rid of it. I am using the default compilation options for SPECFEM3D.
And now here is the error message:

ftn -c -o ../../obj/mesh/meshfem3D_adios_stubs.noadios.o meshfem3D_adios_stubs.f90

 use adios_manager_mod
     ^  
ftn-292 crayftn: ERROR SAVE_DATABASES_ADIOS, File = meshfem3D_adios_stubs.f90, Line = 12, Column = 7 
 "ADIOS_MANAGER_MOD" is specified as the module name on a USE statement, but the compiler cannot find it.

Cray Fortran : Version 8.2.6 (u82112f82278i82266p82476a82026e82015z82474)
Cray Fortran :               (x8241r82029w82012t8217b82047k82024)
Cray Fortran : Tue Aug 19, 2014  10:51:28
Cray Fortran : Compile time:  0.0040 seconds
Cray Fortran : 15 source lines
Cray Fortran : 1 errors, 0 warnings, 0 other messages, 0 ansi
Cray Fortran : "explain ftn-message number" gives more information about each message.
make[1]: **\* [../../obj/mesh/meshfem3D_adios_stubs.noadios.o] Error 1
make[1]: Leaving directory `/fs3/n03/n03/andreas/source/specfem3d/src/meshfem3D'
make: **\* [xmeshfem3D] Error 2
