### PR TITLE
Check for err.h and work around for AIX

### DIFF
--- a/configure
+++ b/configure
@@ -5906,6 +5906,15 @@ $as_echo "#define HAVE_XMMINTRIN 1" >>confdefs.h
 fi
 
 
+# AIX doesn't have err.h so we need to check
+ac_fn_c_check_header_mongrel "$LINENO" "err.h" "ac_cv_header_err_h" "$ac_includes_default"
+if test "x$ac_cv_header_err_h" = xyes; then :
+
+$as_echo "#define HAVE_ERR 1" >>confdefs.h
+
+fi
+
+
 ac_ext=${ac_fc_srcext-f}
 ac_compile='$FC -c $FCFLAGS $ac_fcflags_srcext conftest.$ac_ext >&5'
 ac_link='$FC -o conftest$ac_exeext $FCFLAGS $LDFLAGS $ac_fcflags_srcext conftest.$ac_ext $LIBS >&5'
@@ -8619,7 +8628,7 @@ do
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
     "setup/constants.h") CONFIG_FILES="$CONFIG_FILES setup/constants.h" ;;
     "setup/constants_tomography.h") CONFIG_FILES="$CONFIG_FILES setup/constants_tomography.h" ;;
-    "setup/constants_inverse_problem") CONFIG_FILES="$CONFIG_FILES setup/constants_inverse_problem" ;;
+    "setup/constants_inverse_problem.h") CONFIG_FILES="$CONFIG_FILES setup/constants_inverse_problem.h" ;;
     "setup/precision.h") CONFIG_FILES="$CONFIG_FILES setup/precision.h" ;;
     "setup/config.fh") CONFIG_FILES="$CONFIG_FILES setup/config.fh" ;;
     "${SCOTCH_DIR}/src/Makefile.inc") CONFIG_FILES="$CONFIG_FILES ${SCOTCH_DIR}/src/Makefile.inc" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -170,6 +170,8 @@ AC_PROG_CC
 AC_LANG_PUSH(C)
 AC_CHECK_HEADER(emmintrin.h,AC_DEFINE([HAVE_EMMINTRIN],[1],[Define if emmintrin.h]))
 AC_CHECK_HEADER(xmmintrin.h,AC_DEFINE([HAVE_XMMINTRIN],[1],[Define if xmmintrin.h]))
+# AIX doesn't have err.h so we need to check
+AC_CHECK_HEADER(err.h,      AC_DEFINE([HAVE_ERR],      [1],[Define if err.h]))
 AC_LANG_POP(C)
 
 

--- a/setup/config.h.in
+++ b/setup/config.h.in
@@ -17,6 +17,9 @@
 /* Define if emmintrin.h */
 #undef HAVE_EMMINTRIN
 
+/* Define if err.h */
+#undef HAVE_ERR
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 

--- a/src/generate_databases/parse_sep.c
+++ b/src/generate_databases/parse_sep.c
@@ -20,11 +20,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <regex.h>
+#ifdef HAVE_ERR
 #include "err.h"
-
 #define EXIT_ON_ERR(msg) \
     err(1, "%s(%d) -- %s: %s", __FILE__, __LINE__, __func__, msg);
-
+#else
+#define EXIT_ON_ERR(msg) \
+    printf("%s(%d) -- %s: %s", __FILE__, __LINE__, __func__, msg); exit(1);
+#endif
 
 /*****************************************************************************/
 /**

--- a/utils/bathy_sep_to_ascii/inc/check_errors.h
+++ b/utils/bathy_sep_to_ascii/inc/check_errors.h
@@ -17,14 +17,17 @@
 #ifndef _CHECK_ERRORS_H_
 #define _CHECK_ERRORS_H_
 
-#include "err.h"
-
-
 /**
  * \brief Macro to be called in case a function return an error code,
  *        print a message on stderr and exit.
  */
+#ifdef HAVE_ERR
+#include "err.h"
 #define EXIT_ON_ERR(msg) \
     err(1, "%s(%d) -- %s: %s", __FILE__, __LINE__, __func__, msg);
+#else
+#define EXIT_ON_ERR(msg) \
+    printf("%s(%d) -- %s: %s", __FILE__, __LINE__, __func__, msg); exit(1);
+#endif
 
 #endif /* end of include guard: _CHECK_ERRORS_H_ */

--- a/utils/bathy_sep_to_ascii/src/parse_sep.c
+++ b/utils/bathy_sep_to_ascii/src/parse_sep.c
@@ -19,7 +19,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <regex.h>
-#include "err.h"
 
 #include "parse_sep.h"
 #include "check_errors.h"


### PR DESCRIPTION
I was trying to compile specfem3d devel branch on AIX and I got stuck on the fact that the platform is missing err.h. So I introduced a check for and replaced the err macro from err.h by a smaller macro if err.h is not found.

Note that this has nothing to do with using the XL compiler I also have power hardware running linux and where the XL compiler is available. In this case err.h is present (part of glibc) so discriminating on the ground of the compiler used is not appropriate.
