### PR TITLE
Allow multiple external tomography files

### DIFF
--- a/DATA/Par_file
+++ b/DATA/Par_file
@@ -1,1 +1,1 @@
-../EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
+/import/c1/ERTHQUAK/bhchow/REPOS/FORKED/specfem3d/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file

--- a/DATA/Par_file
+++ b/DATA/Par_file
@@ -1,1 +1,1 @@
-/import/c1/ERTHQUAK/bhchow/REPOS/FORKED/specfem3d/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
+../EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file

--- a/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
+++ b/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
@@ -65,8 +65,19 @@ NGNOD                           = 8
 #   aniso,external,gll,salton_trough,tomo,SEP,coupled,...
 MODEL                           = default
 
-# path for external tomographic models files
+# path for external tomographic models files if 'MODEL'=='tomo'
 TOMOGRAPHY_PATH                 = DATA/tomo_files/
+
+# Number of Tomography Files (1 < NFILES_TOMO < infinity)
+# - Dictates the number of external tomography files SPECFEM looks for. 
+#   Each file may represent a different subset of your model (e.g., different 
+#   depth levels)
+# - Only required if 'MODEL'=='tomo'. Files should be stored in TOMOGRAPHY_PATH
+# - Files should be named 'tomography_model_1.xyz', 'tomography_model_2.xyz'... 
+#   'tomography_model_{NFILES_TOMO}.xyz'. 
+# - Smaller numbers represent shallower depths (i.e., 1 should include surface)
+NFILES_TOMO                     = 1
+
 # if you are using a SEP model (oil-industry format)
 SEP_MODEL_DIRECTORY             = DATA/my_SEP_model/
 

--- a/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
+++ b/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
@@ -68,14 +68,13 @@ MODEL                           = default
 # path for external tomographic models files if 'MODEL'=='tomo'
 TOMOGRAPHY_PATH                 = DATA/tomo_files/
 
-# Number of Tomography Files (1 < NFILES_TOMO < infinity)
-# - Dictates the number of external tomography files SPECFEM looks for. 
-#   Each file may represent a different subset of your model (e.g., different 
-#   depth levels)
-# - Only required if 'MODEL'=='tomo'. Files should be stored in TOMOGRAPHY_PATH
-# - Files should be named 'tomography_model_1.xyz', 'tomography_model_2.xyz'... 
+# NFILES_TOMO [Number of Tomography Files (1 < NFILES_TOMO < infinity)]
+# - Dictates the number of external tomography files if 'MODEL' == 'tomo'
+# - Files should be stored in TOMOGRAPHY_PATH and named: 
+#   'tomography_model_01.xyz', 'tomography_model_02.xyz'...
 #   'tomography_model_{NFILES_TOMO}.xyz'. 
-# - Smaller numbers represent shallower depths (i.e., 1 should include surface)
+# - Model indices correspond to regions in mesh;
+#   For internal mesher, 'model 01' corresponds to the bottom of the mesh
 NFILES_TOMO                     = 1
 
 # if you are using a SEP model (oil-industry format)

--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -45,9 +45,6 @@
   ! for external tomography:
   ! (regular spaced, xyz-block file in ascii)
 
-  ! number of external tomographic models
-  integer :: NFILES_TOMO
-
   ! models dimensions
   double precision  :: END_X,END_Y,END_Z
 
@@ -143,7 +140,7 @@
   character(len=MAX_STRING_LEN*2) :: tomo_filename
   character(len=MAX_STRING_LEN) :: filename
   character(len=MAX_STRING_LEN) :: string_read
-  character(len=5) :: file_number
+  character(len=5) :: filenumber
   integer :: nmaterials
   ! data format
   logical :: has_q_values
@@ -175,8 +172,8 @@
       ! note: since we have no undefined materials, we cannot access undef_mat_prop(:,:) to read in values
       ! uses default name
       ! filenames are e.g.,: 'tomography_model_01.xyz' ... 'tomography_model_{NFILES_TOMO}.xyz'
-      write(file_number, '(I2.2)'), iundef
-      filename = 'tomography_model_' // trim(file_number) // '.xyz'
+      write(filenumber, '(I2.2)'), iundef
+      filename = 'tomography_model_' // trim(filenumber) // '.xyz'
     else
       ! checks if associated material is a tomography model
       if (trim(undef_mat_prop(2,iundef)) /= 'tomography') cycle
@@ -377,6 +374,7 @@ end subroutine init_tomography_files
   integer :: irecord,ier,iundef,imat
   character(len=MAX_STRING_LEN*2) :: tomo_filename
   character(len=MAX_STRING_LEN) :: filename
+  character(len=5) :: filenumber
   character(len=MAX_STRING_LEN) :: string_read
   integer :: nmaterials
   logical :: has_q_values
@@ -397,8 +395,8 @@ end subroutine init_tomography_files
       ! note: since we have no undefined materials, we cannot access undef_mat_prop(:,:) to read in values
       ! uses default name
       ! filenames are e.g.,: 'tomography_model_01.xyz' ... 'tomography_model_{NFILES_TOMO}.xyz'
-      write(file_number, '(I2.2)'), iundef
-      filename = 'tomography_model_' // trim(file_number) // '.xyz'
+      write(filenumber, '(I2.2)'), iundef
+      filename = 'tomography_model_' // trim(filenumber) // '.xyz'
     else
       ! checks if associated material is a tomography model
       if (trim(undef_mat_prop(2,iundef)) /= 'tomography') cycle

--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -164,8 +164,9 @@
   if (ier /= 0) stop 'Error allocating array materials_with_q'
   materials_with_q(:) = .false.
 
-  ! loops over number of undefined materials
-  do iundef = 1, nmaterials
+  ! loops over number of undefined materials in negative order so that smaller
+  ! numbers correspond to shallower depths
+  do iundef = nmaterials, 1, -1
 
     ! sets filename
     if (nundefMat_ext_mesh == 0 .and. IMODEL == IMODEL_TOMO) then
@@ -175,8 +176,10 @@
       ! filenames are e.g.,: 'tomography_model_01.xyz' ... 
       !                      'tomography_model_02.xyz' ...
       !                      'tomography_model_{NFILES_TOMO}.xyz'
-      ! Note the leading '0' before a two digit value. Assuming Users won't 
-      ! have more than 99 separate tomography models
+      ! - NOTE: the leading '0' before a two digit value. Assuming Users won't 
+      !   have more than 99 separate tomography models
+      ! - NOTE: The first model corresponds to the bottom of the mesh 
+      !   (i.e., element 1). Larger numbers correspond to shallower depths
       write(filenumber, '(I2.2)'), iundef
       filename = 'tomography_model_' // trim(filenumber) // '.xyz'
     else
@@ -393,6 +396,7 @@ end subroutine init_tomography_files
   endif
 
   imat = 0
+
   do iundef = 1, nmaterials
 
     ! sets filename
@@ -403,8 +407,10 @@ end subroutine init_tomography_files
       ! filenames are e.g.,: 'tomography_model_01.xyz' ... 
       !                      'tomography_model_02.xyz' ...
       !                      'tomography_model_{NFILES_TOMO}.xyz'
-      ! Note the leading '0' before a two digit value. Assuming Users won't 
-      ! have more than 99 separate tomography models
+      ! - NOTE: the leading '0' before a two digit value. Assuming Users won't 
+      !   have more than 99 separate tomography models
+      ! - NOTE: The first model corresponds to the bottom of the mesh 
+      !   (i.e., element 1). Larger numbers correspond to shallower depths
       write(filenumber, '(I2.2)'), iundef
       filename = 'tomography_model_' // trim(filenumber) // '.xyz'
     else

--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -131,7 +131,7 @@
 
   use constants, only: MAX_STRING_LEN,IIN,IMAIN
 
-  use generate_databases_par, only: TOMOGRAPHY_PATH,undef_mat_prop,nundefMat_ext_mesh
+  use generate_databases_par, only: TOMOGRAPHY_PATH,NFILES_TOMO,undef_mat_prop,nundefMat_ext_mesh
 
   use model_tomography_par
 
@@ -143,6 +143,7 @@
   character(len=MAX_STRING_LEN*2) :: tomo_filename
   character(len=MAX_STRING_LEN) :: filename
   character(len=MAX_STRING_LEN) :: string_read
+  character(len=5) :: file_number
   integer :: nmaterials
   ! data format
   logical :: has_q_values
@@ -157,7 +158,7 @@
 
   ! checks if we over-impose a tomography model by Par_file setting: MODEL = tomo
   if (nundefMat_ext_mesh == 0 .and. IMODEL == IMODEL_TOMO) then
-    nmaterials = 1
+    nmaterials = NFILES_TOMO
   endif
 
   ! data format flag
@@ -173,7 +174,9 @@
     if (nundefMat_ext_mesh == 0 .and. IMODEL == IMODEL_TOMO) then
       ! note: since we have no undefined materials, we cannot access undef_mat_prop(:,:) to read in values
       ! uses default name
-      filename = 'tomography_model.xyz'
+      ! filenames are e.g.,: 'tomography_model_01.xyz' ... 'tomography_model_{NFILES_TOMO}.xyz'
+      write(file_number, '(I2.2)'), iundef
+      filename = 'tomography_model_' // trim(file_number) // '.xyz'
     else
       ! checks if associated material is a tomography model
       if (trim(undef_mat_prop(2,iundef)) /= 'tomography') cycle
@@ -270,9 +273,6 @@
 
   enddo
 
-  ! number of external tomographic models
-  NFILES_TOMO = ifiles_tomo
-
   ! user output
   if (myrank_tomo == 0) then
     write(IMAIN,*)
@@ -363,7 +363,7 @@ end subroutine init_tomography_files
 
   use constants, only: MAX_STRING_LEN,IIN,IMAIN
 
-  use generate_databases_par, only: TOMOGRAPHY_PATH,undef_mat_prop,nundefMat_ext_mesh
+  use generate_databases_par, only: TOMOGRAPHY_PATH,NFILES_TOMO,undef_mat_prop,nundefMat_ext_mesh
 
   use model_tomography_par
 
@@ -386,7 +386,7 @@ end subroutine init_tomography_files
 
   ! checks if we over-impose a tomography model by Par_file setting: MODEL = tomo
   if (nundefMat_ext_mesh == 0 .and. IMODEL == IMODEL_TOMO) then
-    nmaterials = 1
+    nmaterials = NFILES_TOMO
   endif
 
   imat = 0
@@ -396,7 +396,9 @@ end subroutine init_tomography_files
     if (nundefMat_ext_mesh == 0 .and. IMODEL == IMODEL_TOMO) then
       ! note: since we have no undefined materials, we cannot access undef_mat_prop(:,:) to read in values
       ! uses default name
-      filename = 'tomography_model.xyz'
+      ! filenames are e.g.,: 'tomography_model_01.xyz' ... 'tomography_model_{NFILES_TOMO}.xyz'
+      write(file_number, '(I2.2)'), iundef
+      filename = 'tomography_model_' // trim(file_number) // '.xyz'
     else
       ! checks if associated material is a tomography model
       if (trim(undef_mat_prop(2,iundef)) /= 'tomography') cycle

--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -169,9 +169,14 @@
 
     ! sets filename
     if (nundefMat_ext_mesh == 0 .and. IMODEL == IMODEL_TOMO) then
-      ! note: since we have no undefined materials, we cannot access undef_mat_prop(:,:) to read in values
-      ! uses default name
-      ! filenames are e.g.,: 'tomography_model_01.xyz' ... 'tomography_model_{NFILES_TOMO}.xyz'
+      ! NOTE: since we have no undefined materials, we cannot access 
+      ! undef_mat_prop(:,:) to read in values
+      ! This uses a default naming schema: 'tomography_model_??.xyz'
+      ! filenames are e.g.,: 'tomography_model_01.xyz' ... 
+      !                      'tomography_model_02.xyz' ...
+      !                      'tomography_model_{NFILES_TOMO}.xyz'
+      ! Note the leading '0' before a two digit value. Assuming Users won't 
+      ! have more than 99 separate tomography models
       write(filenumber, '(I2.2)'), iundef
       filename = 'tomography_model_' // trim(filenumber) // '.xyz'
     else
@@ -185,7 +190,7 @@
     ! counter
     ifiles_tomo = ifiles_tomo + 1
 
-    ! sets filename with path (e.g. "DATA/tomo_files/" + "tomo.xyz")
+    ! sets filename with path (e.g. "DATA/tomo_files/" + "tomography_model_01.xyz")
     ! corrects the path and filename of tomography model
     if (TOMOGRAPHY_PATH(len_trim(TOMOGRAPHY_PATH):len_trim(TOMOGRAPHY_PATH)) == "/") then
       tomo_filename = TOMOGRAPHY_PATH(1:len_trim(TOMOGRAPHY_PATH)) // trim(filename)
@@ -282,7 +287,7 @@
   endif
 
   ! checks if we found a tomography model
-  if (NFILES_TOMO == 0) call exit_MPI(myrank_tomo,'Error no tomography model was read in')
+  if (ifiles_tomo == 0) call exit_MPI(myrank_tomo,'Error no tomography model was read in')
 
   ! allocates models dimensions
   allocate(ORIG_X(NFILES_TOMO),ORIG_Y(NFILES_TOMO),ORIG_Z(NFILES_TOMO),stat=ier)
@@ -392,9 +397,14 @@ end subroutine init_tomography_files
 
     ! sets filename
     if (nundefMat_ext_mesh == 0 .and. IMODEL == IMODEL_TOMO) then
-      ! note: since we have no undefined materials, we cannot access undef_mat_prop(:,:) to read in values
-      ! uses default name
-      ! filenames are e.g.,: 'tomography_model_01.xyz' ... 'tomography_model_{NFILES_TOMO}.xyz'
+      ! NOTE: since we have no undefined materials, we cannot access 
+      ! undef_mat_prop(:,:) to read in values
+      ! This uses a default naming schema: 'tomography_model_??.xyz'
+      ! filenames are e.g.,: 'tomography_model_01.xyz' ... 
+      !                      'tomography_model_02.xyz' ...
+      !                      'tomography_model_{NFILES_TOMO}.xyz'
+      ! Note the leading '0' before a two digit value. Assuming Users won't 
+      ! have more than 99 separate tomography models
       write(filenumber, '(I2.2)'), iundef
       filename = 'tomography_model_' // trim(filenumber) // '.xyz'
     else

--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -180,7 +180,7 @@
       !   have more than 99 separate tomography models
       ! - NOTE: The first model corresponds to the bottom of the mesh 
       !   (i.e., element 1). Larger numbers correspond to shallower depths 
-      write(filenumber, '(I2.2)'), iundef
+      write(filenumber, '(I2.2)') iundef
       filename = 'tomography_model_' // trim(filenumber) // '.xyz'
     else
       ! checks if associated material is a tomography model

--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -152,7 +152,6 @@
   ! sets number of materials to loop over
   nmaterials = nundefMat_ext_mesh
 
-  NFILES_TOMO = 0
   nrecord_max = 0
   ifiles_tomo = 0
 

--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -411,7 +411,7 @@ end subroutine init_tomography_files
       !   have more than 99 separate tomography models
       ! - NOTE: The first model corresponds to the bottom of the mesh 
       !   (i.e., element 1). Larger numbers correspond to shallower depths
-      write(filenumber, '(I2.2)'), iundef
+      write(filenumber, '(I2.2)') iundef
       filename = 'tomography_model_' // trim(filenumber) // '.xyz'
     else
       ! checks if associated material is a tomography model

--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -823,8 +823,8 @@ end subroutine init_tomography_files
 
   ! checks if we over-impose a tomography model by Par_file setting: MODEL = tomo
   if (nundefMat_ext_mesh == 0 .and. IMODEL == IMODEL_TOMO) then
-    ! sets material number
-    imat = 1
+    ! sets material number based on material ID
+    imat = imaterial_id
   else
     ! checks if material is a tomographic material (negative id)
     if (imaterial_id >= 0) return

--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -179,7 +179,7 @@
       ! - NOTE: the leading '0' before a two digit value. Assuming Users won't 
       !   have more than 99 separate tomography models
       ! - NOTE: The first model corresponds to the bottom of the mesh 
-      !   (i.e., element 1). Larger numbers correspond to shallower depths
+      !   (i.e., element 1). Larger numbers correspond to shallower depths 
       write(filenumber, '(I2.2)'), iundef
       filename = 'tomography_model_' // trim(filenumber) // '.xyz'
     else

--- a/src/shared/read_parameter_file.F90
+++ b/src/shared/read_parameter_file.F90
@@ -1405,6 +1405,7 @@
   call bcast_all_string(MODEL)
 
   call bcast_all_string(TOMOGRAPHY_PATH)
+  call bcast_all_singlei(NFILES_TOMO)
   call bcast_all_string(SEP_MODEL_DIRECTORY)
 
   call bcast_all_singlel(APPROXIMATE_OCEAN_LOAD)

--- a/src/shared/read_parameter_file.F90
+++ b/src/shared/read_parameter_file.F90
@@ -180,6 +180,13 @@
       write(*,*)
     endif
 
+    call read_value_integer(NFILES_TOMO, 'NFILES_TOMO', ier)
+    if (ier /= 0) then
+      some_parameters_missing_from_Par_file = .true.
+      write(*,'(a)') 'NFILES_TOMO                 = 1'
+      write(*,*)
+    endif
+
     call read_value_string(SEP_MODEL_DIRECTORY, 'SEP_MODEL_DIRECTORY', ier)
     if (ier /= 0) then
       some_parameters_missing_from_Par_file = .true.

--- a/src/shared/shared_par.F90
+++ b/src/shared/shared_par.F90
@@ -101,7 +101,9 @@ end module constants
   logical :: APPROXIMATE_OCEAN_LOAD,TOPOGRAPHY,ATTENUATION,ANISOTROPY
   logical :: GRAVITY
 
+  ! external tomography models
   character(len=MAX_STRING_LEN) :: TOMOGRAPHY_PATH
+  integer :: NFILES_TOMO
 
   ! attenuation
   ! reference frequency of seismic model


### PR DESCRIPTION
### What does this PR do?

- Allows Users to specify an arbitrary number of external tomography models 
- Introduces a new Par_file parameter: `NFILES_TOMO`
- NFILES_TOMO tells SPECFEM to look for an integer number of tomography files in `TOMOGRAPHY_PATH` (valid range [1, inf])
- Files require explicit naming as: tomography_model_01.xyz, tomography_model_02.xyz, ..., tomography_model_<NFILES_TOMO>.xyz 
- *Note the leading 0 (assuming <99 external models)* 
- Adjusts SPECFEM machinery to accommodate the new parameter 

### Why was it initiated?  

Related Issue: #1306 

When importing external tomography models, fine spatial sampling at depth leads to unnecessarily large ASCII files. So we (@carltape et al.) split up our domains by depth regions (e.g., shallow, crust, mantle). 

SPECFEM in it's current state can only accommodate one tomography model, so to get around this @rmodrak wrote up a [small hardcoded edit to the source code ](https://github.com/geodynamics/specfem3d/files/2550080/model_tomography.txt)to allow for 3 tomography models. _Originally posted by @rmodrak in https://github.com/SPECFEM/specfem3d/issues/1306#issuecomment-435985634_

 Following @rmodrak I made this edit more generalized by allowing for a User-defined parameter that allow for an arbitrary number of tomography files to be included. By default this parameter is set to 1, which is the same behavior as before.

----------------------------

Likely this will need some code review. I'm not sure how far-reaching these changes are for other model types or for CUBIT meshes. Although I did test with my own 3-file external tomography model using the internal mesher and was able to reproduce correct results that I was getting when using the edited source file from @rmodrak 

I'm open to other ways of implementing this that might not require a new Par_file parameter.  [Examples will need to be updated to deal with the new Par_file](https://github.com/bch0w/specfem3d/actions/runs/3441797979/jobs/5741757820).

Here's relevant lines from `output_generate_databases.txt`:
```bash
   ...determining velocity model                                                 
                                                                                 
      number of tomographic models       =            3                          
      maximum number of data records     =     23402520                          
      size of required tomography arrays =    1071.282     MB per process        
                                                                                 
      material id:           -1                                                  
      file       : DATA/tomo_files/tomography_model_01.xyz                       
      data format: #x #y #z #vp #vs #density #Q_p #Q_s                           
      number of grid points = NX*NY*NZ:     1656720                              
                                                                                 
      material id:           -2                                                  
      file       : DATA/tomo_files/tomography_model_02.xyz                       
      data format: #x #y #z #vp #vs #density #Q_p #Q_s                           
      number of grid points = NX*NY*NZ:    23402520                              
                                                                                 
      material id:           -3                                                  
      file       : DATA/tomo_files/tomography_model_03.xyz                       
      data format: #x #y #z #vp #vs #density #Q_p #Q_s                           
      number of grid points = NX*NY*NZ:    14157080    
```

And a figure confirming that this model was partitioned correctly to my mesh (New Zealand context).

![nzatom_north_vs](https://user-images.githubusercontent.com/23055374/201238196-af280f2a-fcb4-4887-9a7b-ca934161e499.png)

[output_generate_databases.txt](https://github.com/SPECFEM/specfem3d/files/9985614/output_generate_databases.txt)


