### PR TITLE
updates to slurm submit scripts and sensitivity_kernels_liutromp2006 example

### DIFF
--- a/EXAMPLES/sensitivity_kernels_liutromp2006/DATA/Par_file
+++ b/EXAMPLES/sensitivity_kernels_liutromp2006/DATA/Par_file
@@ -66,9 +66,9 @@ NGNOD                           = 8
 MODEL                           = default
 
 # path for external tomographic models files
-TOMOGRAPHY_PATH                 = ./DATA/tomo_files/
+TOMOGRAPHY_PATH                 = DATA/tomo_files/
 # if you are using a SEP model (oil-industry format)
-SEP_MODEL_DIRECTORY             = ./DATA/my_SEP_model/
+SEP_MODEL_DIRECTORY             = DATA/my_SEP_model/
 
 #-----------------------------------------------------------
 
@@ -162,7 +162,7 @@ HDUR_MOVIE                      = 0.0
 SAVE_MESH_FILES                 = .true.
 
 # path to store the local database file on each node
-LOCAL_PATH                      = ./DATABASES
+LOCAL_PATH                      = DATABASES
 
 # interval at which we output time step info and max of norm of displacement
 NTSTEP_BETWEEN_OUTPUT_INFO      = 1000
@@ -187,7 +187,7 @@ USE_SOURCES_RECEIVERS_Z         = .false.
 # - the components of a (non necessarily unitary) direction vector for the force source in the E/N/Z_UP basis.
 # The direction vector is made unitary internally in the code and thus only its direction matters here;
 # its norm is ignored and the norm of the force used is the factor force source times the source time function.
-USE_FORCE_POINT_SOURCE          = .true.
+USE_FORCE_POINT_SOURCE          = .false.
 
 # set to true to use a Ricker source time function instead of the source time functions set by default
 # to represent a (tilted) FORCESOLUTION force point source or a CMTSOLUTION moment-tensor source.
@@ -200,10 +200,15 @@ USE_RICKER_TIME_FUNCTION        = .false.
 # This file must have a single column containing the amplitude of the source at that time step,
 # and on its first line it must contain the time step used, which must be equal to DT as defined at the beginning of this Par_file (the code will check that).
 # Be sure when this option is .false. to remove the name of stf file in CMTSOLUTION or FORCESOURCE
-USE_EXTERNAL_SOURCE_FILE        = .true.
+USE_EXTERNAL_SOURCE_FILE        = .false.
 
 # print source time function
-PRINT_SOURCE_TIME_FUNCTION      = .true.
+PRINT_SOURCE_TIME_FUNCTION      = .false.
+
+# source encoding
+# (for acoustic simulations only for now) determines source encoding factor +/-1 depending on sign of moment tensor
+# (see e.g. Krebs et al., 2009. Fast full-wavefield seismic inversion using encoded sources, Geophysics, 74 (6), WCC177-WCC188.)
+USE_SOURCE_ENCODING             = .false.
 
 #-----------------------------------------------------------
 #
@@ -213,6 +218,10 @@ PRINT_SOURCE_TIME_FUNCTION      = .true.
 
 # interval in time steps for writing of seismograms
 NTSTEP_BETWEEN_OUTPUT_SEISMOS   = 10000
+
+# set to n to reduce the sampling rate of output seismograms by a factor of n
+# defaults to 1, which means no down-sampling
+NTSTEP_BETWEEN_OUTPUT_SAMPLE    = 1
 
 # decide if we save displacement, velocity, acceleration and/or pressure in forward runs (they can be set to true simultaneously)
 # currently pressure seismograms are implemented in acoustic (i.e. fluid) elements only
@@ -224,9 +233,6 @@ SAVE_SEISMOGRAMS_PRESSURE       = .false.   # currently implemented in acoustic 
 # save seismograms also when running the adjoint runs for an inverse problem
 # (usually they are unused and not very meaningful, leave this off in almost all cases)
 SAVE_SEISMOGRAMS_IN_ADJOINT_RUN = .false.
-
-# subsampling of the seismograms to create smaller files (but less accurately sampled in time)
-NTSTEP_BETWEEN_OUTPUT_SAMPLE    = 1
 
 # save seismograms in binary or ASCII format (binary is smaller but may not be portable between machines)
 USE_BINARY_FOR_SEISMOGRAMS      = .false.
@@ -255,16 +261,6 @@ USE_TRICK_FOR_BETTER_PRESSURE   = .false.
 
 #-----------------------------------------------------------
 #
-# Source encoding
-#
-#-----------------------------------------------------------
-
-# (for acoustic simulations only for now) determines source encoding factor +/-1 depending on sign of moment tensor
-# (see e.g. Krebs et al., 2009. Fast full-wavefield seismic inversion using encoded sources, Geophysics, 74 (6), WCC177-WCC188.)
-USE_SOURCE_ENCODING             = .false.
-
-#-----------------------------------------------------------
-#
 # Energy calculation
 #
 #-----------------------------------------------------------
@@ -282,7 +278,7 @@ NTSTEP_BETWEEN_OUTPUT_ENERGY    = 10
 #-----------------------------------------------------------
 
 # interval in time steps for reading adjoint traces
-# 0 = read the whole adjoint sources at the same time
+# 0 = read the whole adjoint sources at start time
 NTSTEP_BETWEEN_READ_ADJSRC      = 0
 
 # read adjoint sources using ASDF (requires asdf-library)
@@ -315,7 +311,7 @@ SAVE_MOHO_MESH                  = .false.
 COUPLE_WITH_INJECTION_TECHNIQUE = .false.
 INJECTION_TECHNIQUE_TYPE        = 3   # 1 = DSM, 2 = AxiSEM, 3 = FK
 MESH_A_CHUNK_OF_THE_EARTH       = .false.
-TRACTION_PATH                   = ./DATA/AxiSEM_tractions/3/
+TRACTION_PATH                   = DATA/AxiSEM_tractions/3/
 FKMODEL_FILE                    = FKmodel
 RECIPROCITY_AND_KH_INTEGRAL     = .false.   # does not work yet
 

--- a/EXAMPLES/sensitivity_kernels_liutromp2006/README
+++ b/EXAMPLES/sensitivity_kernels_liutromp2006/README
@@ -22,35 +22,41 @@ Note: This example is designed to generate results close to the aforementioned p
      > cd ./utils/adjoint_sources/traveltime
      > make
      > cd ../../..
+     > cp utils/adjoint_sources/traveltime/xcreate_adjsrc_traveltime bin/.
 
 1.4. Compile the utility xcombine_vol_data_vtk.
      > make xcombine_vol_data_vtk
 
 1.5. Use the provided DATA folder as specfem3d's input DATA folder.
+     Note: Remove (and backup if needed) any existing DATA folder before running the following command. 
      > cp -r EXAMPLES/sensitivity_kernels_liutromp2006/DATA .
 
-1.6. Copy the file 'source_time_function.txt' from this data folder to the specfem working directory.
-
+1.6. Copy the file 'source_time_function.txt' provided with this example to the specfem working directory.
+     > cp -r EXAMPLES/sensitivity_kernels_liutromp2006/source_time_function.txt .
 
 
 
 2. To run the forward simulation -
 
 2.1. The example consists of two different simulations and hence the two different 'FORCESOLUTION_*' files in the data folder.
+
+     a. FORCESOLUTION_SH   - will produce the seismogram shown in the top figure of figure 3(a) in the reference paper.
+     b. FORCESOLUTION_P_SV - will produce the seismogram shown in the top figure of figure 3(b) in the reference paper.
+
      Copy the 'FORCESOLUTION_*' file you wish to run and name it as 'FORCESOLUTION'.
 
-2.2. FORCESOLUTION_SH will produce the seismogram in the top figure of figure 3(a).
-     > xmgrace XX.R00-01.HXY.semd
-     FORCESOLUTION_P_SV will produce the seismogram in the top figure of figure 3(b).
-     > xmgrace XX.R00-01.HXX.semd
-
-2.3. Run the simulation with following parameters in the Par_file -
+2.2. Run the simulation with following parameters in the Par_file -
      SIMULATION_TYPE = 1
      SAVE_FORWARD = .true.
+     USE_FORCE_POINT_SOURCE = .true.
+     USE_EXTERNAL_SOURCE_FILE = .true.
 
-2.4. Compare the generated seismograms with the ones provided in the REF_SEIS folder
+     Note: Remove (and backup if needed) any existing OUTPUT_FILES folder before running the example.
+     Note: Modify job submission scripts to request the number of cores given by Par_file parameter 'NPROC'.
+
+2.3. Compare the generated seismograms with the ones provided in the REF_SEIS folder
      > xmgrace OUTPUT_FILES/*.semd
-     > xmgrace EXAMPLES/kernel_liutromp2006/REF_SEIS/****_simulation/*.semd
+     > xmgrace EXAMPLES/sensitivity_kernels_liutromp2006/REF_SEIS/****_simulation/*.semd
      where **** will depend on the simulation type
 
 
@@ -61,16 +67,16 @@ Note: This example is designed to generate results close to the aforementioned p
 3.1. Create adjoint sources for the kernel of interest -
 
      a. P kernel -      
-        > ./utils/adjoint_sources/traveltime/xcreate_adjsrc_traveltime 10 18 1 OUTPUT_FILES/XX.R00-01.HX*.semd
+        > ./bin/xcreate_adjsrc_traveltime 10 18 1 OUTPUT_FILES/XX.R00-01.HX*.semd
    
      b. S kernel -
-        > ./utils/adjoint_sources/traveltime/xcreate_adjsrc_traveltime 24 34 2 OUTPUT_FILES/XX.R00-01.HX*.semd
+        > ./bin/xcreate_adjsrc_traveltime 24 34 2 OUTPUT_FILES/XX.R00-01.HX*.semd
 
      c. SS kernel -
-        > ./utils/adjoint_sources/traveltime/xcreate_adjsrc_traveltime 34 44 2 OUTPUT_FILES/XX.R00-01.HX*.semd
+        > ./bin/xcreate_adjsrc_traveltime 34 44 2 OUTPUT_FILES/XX.R00-01.HX*.semd
 
      d. PS + SP kernel -
-        > ./utils/adjoint_sources/traveltime/xcreate_adjsrc_traveltime 24 30 1 OUTPUT_FILES/XX.R00-01.HX*.semd
+        > ./bin/xcreate_adjsrc_traveltime 24 30 1 OUTPUT_FILES/XX.R00-01.HX*.semd
 
 3.2. Move adjoint sources to the required folder -
      > mkdir SEM
@@ -78,7 +84,7 @@ Note: This example is designed to generate results close to the aforementioned p
 
 3.3. Compare the created adjoint sources with the ones provided in the REF_ADJ_SRC folder
      > xmgrace SEM/*.adj
-     > xmgrace EXAMPLES/kernel_liutromp2006/REF_ADJ_SRC/****/*.adj
+     > xmgrace EXAMPLES/sensitivity_kernels_liutromp2006/REF_ADJ_SRC/****/*.adj
      where **** will depend on the kernel type
 
 3.4. Run the simulation with following parameters in the Par_file -

--- a/utils/Cluster/slurm/go_combine_vol_data_slurm.bash
+++ b/utils/Cluster/slurm/go_combine_vol_data_slurm.bash
@@ -4,7 +4,7 @@
 #SBATCH --ntasks=1
 #SBATCH -t 10
 
-#SBATCH --output=OUTPUT_FILES/%j.o
+#SBATCH --output=%j.o
 #SBATCH --job-name=go_combine_vol_data
 
 umask 0022
@@ -29,5 +29,11 @@ srun -l /bin/hostname | sort -n | awk '{print $2}' > ./nodes.$SLURM_JOB_ID
 mpirun -np 1 -machinefile ./nodes.$SLURM_JOB_ID ./bin/xcombine_vol_data_vtk 0 $nmax vs $LOCALPATH/ $LOCALPATH 0
 
 cp go_combine_vol_data_slurm.bash OUTPUT_FILES/
+
+# obtain and store job information
+echo "$SLURM_JOBID" > OUTPUT_FILES/jobid
+
+JOBID=$(<OUTPUT_FILES/jobid)
+mv $JOBID.o OUTPUT_FILES/
 
 echo "done "

--- a/utils/Cluster/slurm/go_decomposer_slurm.bash
+++ b/utils/Cluster/slurm/go_decomposer_slurm.bash
@@ -4,7 +4,7 @@
 #SBATCH --ntasks=1
 #SBATCH -t 60
 
-#SBATCH --output=OUTPUT_FILES/%j.o
+#SBATCH --output=%j.o
 #SBATCH --job-name=go_decomposer
 
 umask 0022
@@ -16,22 +16,26 @@ cd $SLURM_SUBMIT_DIR
 # compute total number of partitions needed
 NPROC=`grep ^NPROC DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
 
-# path to database files for mesh
+mkdir -p OUTPUT_FILES
 LOCALPATH=`grep ^LOCAL_PATH DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
-
-echo starting decomposer for $NPROC partitions
-echo " "
-
-mkdir -p OUTPUT_FILES/
-
-# save a copy
-cp go_decomposer_slurm.bash OUTPUT_FILES/
+mkdir -p $LOCALPATH
 
 # USER: CHANGE MESH DIRECTORY
 #MESHDIR=./EXAMPLES/homogeneous_halfspace/MESH
 MESHDIR=./EXAMPLES/homogeneous_halfspace/MESH-default
 
-mkdir -p $LOCALPATH
+# save a copy
+cp go_decomposer_slurm.bash OUTPUT_FILES/
+
+# obtain slurm job information
+echo "$SLURM_JOBID" > OUTPUT_FILES/jobid
+
+echo starting decomposer for $NPROC partitions
+echo " "
+
 ./bin/xdecompose_mesh $NPROC $MESHDIR/ $LOCALPATH/
+
+JOBID=$(<OUTPUT_FILES/jobid)
+mv $JOBID.o OUTPUT_FILES/
 
 echo "done "

--- a/utils/Cluster/slurm/go_generate_databases_slurm.bash
+++ b/utils/Cluster/slurm/go_generate_databases_slurm.bash
@@ -4,7 +4,7 @@
 #SBATCH --ntasks=4
 #SBATCH -t 60
 
-#SBATCH --output=OUTPUT_FILES/%j.o
+#SBATCH --output=%j.o
 #SBATCH --job-name=go_database
 
 umask 0022
@@ -15,18 +15,26 @@ cd $SLURM_SUBMIT_DIR
 # read Par_file to get information about the run
 # compute total number of nodes needed
 NPROC=`grep ^NPROC DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+# check the type of model
+MODEL=`grep ^MODEL DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
 
 mkdir -p OUTPUT_FILES
 
+# backup tomography files if any for this simulation
+if [[ $MODEL -eq tomo ]]; then
+    cp -r DATA/tomo_files OUTPUT_FILES/
+fi
+
 # backup files used for database generation
 cp go_generate_databases_slurm.bash OUTPUT_FILES/
+cp DATA/Par_file OUTPUT_FILES/
 
 # save a complete copy of source files
 #rm -rf OUTPUT_FILES/src
 #cp -rp ./src OUTPUT_FILES/
 
 # obtain job information
-cat $SLURM_JOB_NODELIST > OUTPUT_FILES/compute_nodes
+echo "$SLURM_JOB_NODELIST" > OUTPUT_FILES/compute_nodes
 echo "$SLURM_JOBID" > OUTPUT_FILES/jobid
 
 echo starting MPI database generation on $NPROC processors
@@ -34,5 +42,8 @@ echo " "
 
 sleep 2
 mpiexec -np $NPROC ./bin/xgenerate_databases
+
+JOBID=$(<OUTPUT_FILES/jobid)
+mv $JOBID.o OUTPUT_FILES/
 
 echo "done "

--- a/utils/Cluster/slurm/go_mesher_slurm.bash
+++ b/utils/Cluster/slurm/go_mesher_slurm.bash
@@ -4,7 +4,7 @@
 #SBATCH --ntasks=4
 #SBATCH -t 60
 
-#SBATCH --output=OUTPUT_FILES/%j.o
+#SBATCH --output=%j.o
 #SBATCH --job-name=go_mesher
 
 umask 0022
@@ -17,7 +17,8 @@ cd $SLURM_SUBMIT_DIR
 NPROC=`grep ^NPROC DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
 
 mkdir -p OUTPUT_FILES
-mkdir -p OUTPUT_FILES/DATABASES_MPI
+LOCALPATH=`grep ^LOCAL_PATH DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+mkdir -p $LOCALPATH
 
 # backup files used for mesh generation
 cp go_mesher_slurm.bash OUTPUT_FILES/
@@ -28,7 +29,7 @@ cp -r DATA/meshfem3D_files OUTPUT_FILES/
 #cp -rp ./src OUTPUT_FILES/
 
 # obtain slurm job information
-cat $SLURM_JOB_NODELIST > OUTPUT_FILES/compute_nodes
+echo "$SLURM_JOB_NODELIST" > OUTPUT_FILES/compute_nodes
 echo "$SLURM_JOBID" > OUTPUT_FILES/jobid
 
 echo starting MPI internal mesher on $NPROC processors
@@ -36,5 +37,8 @@ echo " "
 
 sleep 2
 mpiexec -np $NPROC ./bin/xmeshfem3D
+
+JOBID=$(<OUTPUT_FILES/jobid)
+mv $JOBID.o OUTPUT_FILES/
 
 echo "done "

--- a/utils/Cluster/slurm/go_solver_slurm.bash
+++ b/utils/Cluster/slurm/go_solver_slurm.bash
@@ -4,7 +4,7 @@
 #SBATCH -n 4
 #SBATCH -t 60
 
-#SBATCH --output=OUTPUT_FILES/%j.o
+#SBATCH --output=%j.o
 #SBATCH --job-name=go_solver
 
 umask 0022
@@ -16,21 +16,34 @@ cd $SLURM_SUBMIT_DIR
 # compute total number of nodes needed
 NPROC=`grep ^NPROC DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
 
+FORCESOLUTION=`grep ^USE_FORCE_POINT_SOURCE DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+
+EXTERNAL_STF=`grep ^USE_EXTERNAL_SOURCE_FILE DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+
 mkdir -p OUTPUT_FILES
 
 # backup files used for this simulation
 cp go_solver_slurm.bash OUTPUT_FILES/
 cp DATA/Par_file OUTPUT_FILES/
 cp DATA/STATIONS OUTPUT_FILES/
-cp DATA/CMTSOLUTION OUTPUT_FILES/
-cp src/shared/constants.h OUTPUT_FILES/
+cp setup/constants.h OUTPUT_FILES/
+
+if [[ $FORCESOLUTION ]]; then
+    cp DATA/FORCESOLUTION OUTPUT_FILES/
+else
+    cp DATA/CMTSOLUTION OUTPUT_FILES/
+fi
+
+if [[ $EXTERNAL_STF ]]; then
+    cp source_time_function.txt OUTPUT_FILES/
+fi
 
 # save a complete copy of source files
 #rm -rf OUTPUT_FILES/src
 #cp -rp ./src OUTPUT_FILES/
 
 # obtain job information
-cat $SLURM_JOB_NODELIST > OUTPUT_FILES/compute_nodes
+echo "$SLURM_JOB_NODELIST" > OUTPUT_FILES/compute_nodes
 echo "$SLURM_JOBID" > OUTPUT_FILES/jobid
 
 echo starting solver on $NPROC processors
@@ -40,5 +53,8 @@ sleep 2
 mpiexec -np $NPROC ./bin/xspecfem3D
 
 cp DATA/STATIONS_FILTERED OUTPUT_FILES/
+
+JOBID=$(<OUTPUT_FILES/jobid)
+mv $JOBID.o OUTPUT_FILES/
 
 echo "done"


### PR DESCRIPTION
Slurm script updates -
1. Slurm scripts look for FORCESOLUTION, tomography model files, external source time function, etc., and saves them to the OUTPUT_FILES folder for reproducibility, for relevant simulations.
2. Other minor updates/corrections.

Sensitivity_kernel_liutromp2006 updates -
1. Par_file made consistent with the present Par_file format.
2. More clarity brought into the instructions.
3. Other minor updates/corrections.