### PR TITLE
Corrections/modifications to the writing of anisotropic parameters' kernels

### DIFF
--- a/src/shared/adios_method_stubs.c
+++ b/src/shared/adios_method_stubs.c
@@ -89,9 +89,11 @@ void FC_FUNC_(save_forward_arrays_undoatt_adios,SAVE_FORWARD_UNDOATT_ARRAYS_ADIO
 
 void FC_FUNC_(save_kernels_acoustic_adios,SAVE_KERNELS_ACOUSTIC_ADIOS)(void) {}
 
-void FC_FUNC_(save_kernels_elastic_adios,SAVE_KERNELS_ELASTIC_ADIOS)(realw* alphav_kl, realw* alphah_kl,
+void FC_FUNC_(save_kernels_elastic_iso_adios,SAVE_KERNELS_ELASTIC_ISO_ADIOS)(realw* rhop_kl, realw* alpha_kl, realw* beta_kl) {}
+
+void FC_FUNC_(save_kernels_elastic_aniso_adios,SAVE_KERNELS_ELASTIC_ANISO_ADIOS)(realw* alphav_kl, realw* alphah_kl,
                                                                      realw* betav_kl, realw* betah_kl, realw* eta_kl,
-                                                                     realw* rhop_kl, realw* alpha_kl, realw* beta_kl) {}
+                                                                     realw* alpha_kl, realw* beta_kl) {}
 
 void FC_FUNC_(save_kernels_poroelastic_adios,SAVE_KERNELS_POROELASTIC_ADIOS)(void) {}
 

--- a/src/specfem3D/save_adjoint_kernels.f90
+++ b/src/specfem3D/save_adjoint_kernels.f90
@@ -38,42 +38,15 @@
 
   subroutine save_adjoint_kernels()
 
-  use constants, only: CUSTOM_REAL, NGLLX, NGLLY, NGLLZ, SAVE_WEIGHTS
+  use constants, only: SAVE_WEIGHTS
   use shared_parameters, only: ACOUSTIC_SIMULATION,ELASTIC_SIMULATION,POROELASTIC_SIMULATION
 
-  use specfem_par, only: LOCAL_PATH, NSPEC_AB, ADIOS_FOR_KERNELS, NOISE_TOMOGRAPHY, NSPEC_ADJOINT, &
-                         APPROXIMATE_HESS_KL, ANISOTROPIC_KL, SAVE_TRANSVERSE_KL
+  use specfem_par, only: LOCAL_PATH, NSPEC_AB, ADIOS_FOR_KERNELS, NOISE_TOMOGRAPHY, &
+                         APPROXIMATE_HESS_KL, ANISOTROPIC_KL
 
   use specfem_par_noise, only: sigma_kl
 
   implicit none
-
-  interface
-    subroutine save_kernels_elastic(alphav_kl, alphah_kl, &
-                                    betav_kl, betah_kl, eta_kl, &
-                                    rhop_kl, alpha_kl, beta_kl)
-
-      use constants, only: CUSTOM_REAL
-
-      ! FIXME
-      ! Break the CUSTOM_REAL stuff.
-      ! put all this file in a module so interface is implicit
-      ! OR
-      ! redo what was done before SVN revision 22718
-      !
-      ! see other FIXME below (same than see one)
-!! DK DK: sorry, we cannot afford to break the code; too many people use it; I thus put CUSTOM_REAL back
-      real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: alphav_kl,alphah_kl,betav_kl,betah_kl, &
-                                                                 eta_kl, rhop_kl, alpha_kl, beta_kl
-    end subroutine save_kernels_elastic
-  end interface
-
-  real(kind=CUSTOM_REAL), dimension(:,:,:,:),allocatable :: alphav_kl,alphah_kl, &
-                                                            betav_kl,betah_kl, &
-                                                            eta_kl
-  real(kind=CUSTOM_REAL), dimension(:,:,:,:),allocatable :: rhop_kl,alpha_kl,beta_kl
-
-  integer :: ier
 
   if (ADIOS_FOR_KERNELS) then
     call define_kernel_adios_variables()
@@ -86,43 +59,11 @@
 
   ! elastic domains
   if (ELASTIC_SIMULATION) then
-    ! allocates temporary transversely isotropic kernels
     if (ANISOTROPIC_KL) then
-      if (SAVE_TRANSVERSE_KL) then
-        allocate(alphav_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
-                 alphah_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
-                 betav_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
-                 betah_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
-                 eta_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT),stat=ier)
-        if (ier /= 0) call exit_MPI_without_rank('error allocating array 2247')
-        if (ier /= 0) stop 'error allocating arrays alphav_kl,...'
-        alphav_kl(:,:,:,:) = 0.0_CUSTOM_REAL; alphah_kl(:,:,:,:) = 0.0_CUSTOM_REAL
-        betav_kl(:,:,:,:) = 0.0_CUSTOM_REAL; betah_kl(:,:,:,:) = 0.0_CUSTOM_REAL
-        eta_kl(:,:,:,:) = 0.0_CUSTOM_REAL
-
-        ! derived kernels
-        ! vp,vs kernel
-        allocate(alpha_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
-                 beta_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT),stat=ier)
-        if (ier /= 0) call exit_MPI_without_rank('error allocating array 2249')
-        if (ier /= 0) stop 'error allocating array alpha_kl,beta_kl'
-        alpha_kl(:,:,:,:) = 0.0_CUSTOM_REAL; beta_kl(:,:,:,:) = 0.0_CUSTOM_REAL
-      endif
+      call save_kernels_elastic_aniso()
     else
-      ! derived kernels
-      ! vp,vs,density prime kernel
-      allocate(alpha_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
-               beta_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
-               rhop_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT),stat=ier)
-      if (ier /= 0) call exit_MPI_without_rank('error allocating array 2252')
-      if (ier /= 0) stop 'error allocating array rhop_kl'
-      alpha_kl(:,:,:,:) = 0.0_CUSTOM_REAL; beta_kl(:,:,:,:) = 0.0_CUSTOM_REAL
-      rhop_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      call save_kernels_elastic_iso()
     endif
-
-    call save_kernels_elastic(alphav_kl, alphah_kl, &
-                              betav_kl, betah_kl, eta_kl, &
-                              rhop_kl, alpha_kl, beta_kl)
   endif
 
   if (POROELASTIC_SIMULATION) then
@@ -148,19 +89,7 @@
   if (ADIOS_FOR_KERNELS) then
     call perform_write_adios_kernels()
   endif
-
-  if (ELASTIC_SIMULATION) then
-    ! frees temporary arrays
-    if (ANISOTROPIC_KL) then
-      if (SAVE_TRANSVERSE_KL) then
-        deallocate(alphav_kl,alphah_kl,betav_kl,betah_kl,eta_kl)
-        deallocate(alpha_kl,beta_kl)
-      endif
-    else
-      deallocate(rhop_kl,alpha_kl,beta_kl)
-    endif
-  endif
-
+  
   end subroutine save_adjoint_kernels
 
 !
@@ -336,52 +265,40 @@
 !-------------------------------------------------------------------------------------------------
 !
 
-!> Save elastic related kernels
+!> Save elastic isotropic kernels
 
-  subroutine save_kernels_elastic(alphav_kl, alphah_kl, &
-                                  betav_kl, betah_kl, eta_kl, &
-                                  rhop_kl, alpha_kl, beta_kl)
+  subroutine save_kernels_elastic_iso()
 
-  use specfem_par, only: CUSTOM_REAL,NSPEC_AB,ibool,mustore,kappastore, &
-                         ANISOTROPIC_KL,SAVE_TRANSVERSE_KL,FOUR_THIRDS, &
-                         ADIOS_FOR_KERNELS,IOUT,prname,SAVE_MOHO_MESH, &
-                         myrank,IMAIN
+  use specfem_par, only: CUSTOM_REAL,NSPEC_AB,NSPEC_ADJOINT,ibool,mustore,kappastore, &
+                         FOUR_THIRDS,ADIOS_FOR_KERNELS,IOUT,prname, &
+                         SAVE_MOHO_MESH,myrank,IMAIN
   use specfem_par_elastic
 
   implicit none
 
-  interface
-    subroutine save_kernels_elastic_adios(alphav_kl, alphah_kl, &
-                                          betav_kl, betah_kl, eta_kl, &
-                                          rhop_kl, alpha_kl, beta_kl)
-
-      use constants, only: CUSTOM_REAL
-
-      ! FIXME
-      ! see other FIXME above.
-!! DK DK: sorry, we cannot afford to break the code; too many people use it; I thus put CUSTOM_REAL back
-      real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: &
-          alphav_kl,alphah_kl,betav_kl,betah_kl, &
-          eta_kl, rhop_kl, alpha_kl, beta_kl
-    end subroutine save_kernels_elastic_adios
-  end interface
-
-  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: &
-    alphav_kl,alphah_kl,betav_kl,betah_kl, &
-    eta_kl, rhop_kl, alpha_kl, beta_kl
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: rhop_kl, alpha_kl, beta_kl
 
   ! local parameters
   integer:: ispec,i,j,k,iglob,ier
   real(kind=CUSTOM_REAL) :: rhol,mul,kappal
 
-  ! Transverse isotropic paramters
-  real(kind=CUSTOM_REAL) :: A,N,C,L,F,eta
-  real(kind=CUSTOM_REAL), dimension(21) :: cijkl_kl_local
-  real(kind=CUSTOM_REAL), dimension(5) :: an_kl
-
   ! stats
   real(kind=CUSTOM_REAL) :: rho_max,rhop_max,kappa_max,mu_max,alpha_max,beta_max,moho_max
-  real(kind=CUSTOM_REAL) :: alphav_max,alphah_max,betav_max,betah_max,eta_max,cijkl_max
+
+  ! derived kernels
+  ! vp,vs,density prime kernel
+  allocate(alpha_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+           beta_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+           rhop_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT),stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2252')
+  if (ier /= 0) stop 'error allocating array alpha_kl, beta_kl, rhop_kl'
+  alpha_kl(:,:,:,:) = 0.0_CUSTOM_REAL; beta_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+  rhop_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+
+  ! isotropic adjoint kernels (see e.g. Tromp et al. 2005)
+  ! for a parameterization: (rho,mu,kappa) "primary" kernels
+  ! density kernel
+  ! multiplies with rho
 
   ! finalizes calculation of rhop, beta, alpha kernels
   do ispec = 1, NSPEC_AB
@@ -399,92 +316,26 @@
             mul = mustore(i,j,k,ispec)
             kappal = kappastore(i,j,k,ispec)
 
-            if (ANISOTROPIC_KL) then
-              ! anisotropic kernels
-              if (SAVE_TRANSVERSE_KL) then
-                cijkl_kl_local(:) = - cijkl_kl(:,i,j,k,ispec)
+            rho_kl(i,j,k,ispec) = - rhol * rho_kl(i,j,k,ispec)
 
-                ! Computes parameters for an isotropic model
-                A = kappal + FOUR_THIRDS * mul
-                C = A
-                L = mul
-                N = mul
-                F = kappal - 2._CUSTOM_REAL/3._CUSTOM_REAL * mul
-                eta = 1._CUSTOM_REAL
+            ! shear modulus kernel
+            mu_kl(i,j,k,ispec) = - 2.0_CUSTOM_REAL * mul * mu_kl(i,j,k,ispec)
 
-                ! note: cijkl_kl_local() is fully anisotropic C_ij kernel components (non-dimensionalized)
-                !          for GLL point at (i,j,k,ispec)
+            ! bulk modulus kernel
+            kappa_kl(i,j,k,ispec) = - kappal * kappa_kl(i,j,k,ispec)
 
-                ! Purpose : compute the kernels for the An coeffs (an_kl)
-                ! from the kernels for Cij (cijkl_kl_local)
+            ! for a parameterization: (rho,alpha,beta)
+            ! density prime kernel
+            rhop_kl(i,j,k,ispec) = rho_kl(i,j,k,ispec) + kappa_kl(i,j,k,ispec) + mu_kl(i,j,k,ispec)
 
-                ! Definition of the input array cij_kl :
-                ! cij_kl(1) = C11 ; cij_kl(2) = C12 ; cij_kl(3) = C13
-                ! cij_kl(4) = C14 ; cij_kl(5) = C15 ; cij_kl(6) = C16
-                ! cij_kl(7) = C22 ; cij_kl(8) = C23 ; cij_kl(9) = C24
-                ! cij_kl(10) = C25 ; cij_kl(11) = C26 ; cij_kl(12) = C33
-                ! cij_kl(13) = C34 ; cij_kl(14) = C35 ; cij_kl(15) = C36
-                ! cij_kl(16) = C44 ; cij_kl(17) = C45 ; cij_kl(18) = C46
-                ! cij_kl(19) = C55 ; cij_kl(20) = C56 ; cij_kl(21) = C66
-                ! where the Cij (Voigt's notation) are defined as function of
-                ! the components of the elastic tensor in spherical coordinates
-                ! by eq. (A.1) of Chen & Tromp, GJI 168 (2007)
+            ! vs kernel
+            beta_kl(i,j,k,ispec) = &
+            2.0_CUSTOM_REAL * ( mu_kl(i,j,k,ispec) - FOUR_THIRDS * mul / kappal * kappa_kl(i,j,k,ispec) )
 
-                ! From the relations giving Cij in function of An
-                ! Checked with Min Chen's results (routine build_cij)
-
-                an_kl(1) = cijkl_kl_local(1)+cijkl_kl_local(2)+cijkl_kl_local(7)  !A
-                an_kl(2) = cijkl_kl_local(12)                                     !C
-                an_kl(3) = -2*cijkl_kl_local(2)+cijkl_kl_local(21)                !N
-                an_kl(4) = cijkl_kl_local(16)+cijkl_kl_local(19)                  !L
-                an_kl(5) = cijkl_kl_local(3)+cijkl_kl_local(8)                    !F
-
-                ! for parameterization: ( alpha_v, alpha_h, beta_v, beta_h, eta, rho )
-                ! K_alpha_v
-                alphav_kl(i,j,k,ispec) = 2.0 * C * an_kl(2)
-                ! K_alpha_h
-                alphah_kl(i,j,k,ispec) = 2.0 * A * an_kl(1) + 2.0 * A * eta * an_kl(5)
-                ! K_beta_v
-                betav_kl(i,j,k,ispec) = 2.0 * L * an_kl(4) - 4.0 * L * eta * an_kl(5)
-                ! K_beta_h
-                betah_kl(i,j,k,ispec) = 2.0 * N * an_kl(3)
-                ! K_eta
-                eta_kl(i,j,k,ispec) = F * an_kl(5)
-
-                ! to check: isotropic kernels from transverse isotropic ones
-                alpha_kl(i,j,k,ispec) = alphav_kl(i,j,k,ispec) + alphah_kl(i,j,k,ispec)
-                beta_kl(i,j,k,ispec) = betav_kl(i,j,k,ispec) + betah_kl(i,j,k,ispec)
-
-              endif ! SAVE_TRANSVERSE_KL
-
-            else
-              ! isotropic kernels
-
-              ! isotropic adjoint kernels (see e.g. Tromp et al. 2005)
-              ! for a parameterization: (rho,mu,kappa) "primary" kernels
-              ! density kernel
-              ! multiplies with rho
-              rho_kl(i,j,k,ispec) = - rhol * rho_kl(i,j,k,ispec)
-
-              ! shear modulus kernel
-              mu_kl(i,j,k,ispec) = - 2.0_CUSTOM_REAL * mul * mu_kl(i,j,k,ispec)
-
-              ! bulk modulus kernel
-              kappa_kl(i,j,k,ispec) = - kappal * kappa_kl(i,j,k,ispec)
-
-              ! for a parameterization: (rho,alpha,beta)
-              ! density prime kernel
-              rhop_kl(i,j,k,ispec) = rho_kl(i,j,k,ispec) + kappa_kl(i,j,k,ispec) + mu_kl(i,j,k,ispec)
-
-              ! vs kernel
-              beta_kl(i,j,k,ispec) = &
-                2.0_CUSTOM_REAL * ( mu_kl(i,j,k,ispec) - FOUR_THIRDS * mul / kappal * kappa_kl(i,j,k,ispec) )
-
-              ! vp kernel
-              alpha_kl(i,j,k,ispec) = &
-                2.0_CUSTOM_REAL * ( 1.0_CUSTOM_REAL + FOUR_THIRDS * mul / kappal ) * kappa_kl(i,j,k,ispec)
-            endif
-
+            ! vp kernel
+            alpha_kl(i,j,k,ispec) = &
+            2.0_CUSTOM_REAL * ( 1.0_CUSTOM_REAL + FOUR_THIRDS * mul / kappal ) * kappa_kl(i,j,k,ispec)
+                 
           enddo
         enddo
       enddo
@@ -495,23 +346,12 @@
 
   ! overall min/max value
   call max_all_cr(maxval(rho_kl),rho_max)
-  if (ANISOTROPIC_KL) then
-    if (SAVE_TRANSVERSE_KL) then
-      call max_all_cr(maxval(alphav_kl),alphav_max)
-      call max_all_cr(maxval(alphah_kl),alphah_max)
-      call max_all_cr(maxval(betav_kl),betav_max)
-      call max_all_cr(maxval(betah_kl),betah_max)
-      call max_all_cr(maxval(eta_kl),eta_max)
-    else
-      call max_all_cr(maxval(-cijkl_kl),cijkl_max)
-    endif
-  else
-    call max_all_cr(maxval(rhop_kl),rhop_max)
-    call max_all_cr(maxval(kappa_kl),kappa_max)
-    call max_all_cr(maxval(mu_kl),mu_max)
-    call max_all_cr(maxval(alpha_kl),alpha_max)
-    call max_all_cr(maxval(beta_kl),beta_max)
-  endif
+  call max_all_cr(maxval(rhop_kl),rhop_max)
+  call max_all_cr(maxval(kappa_kl),kappa_max)
+  call max_all_cr(maxval(mu_kl),mu_max)
+  call max_all_cr(maxval(alpha_kl),alpha_max)
+  call max_all_cr(maxval(beta_kl),beta_max)
+  
   if (SAVE_MOHO_MESH) then
     call max_all_cr(maxval(moho_kl),moho_max)
   endif
@@ -520,127 +360,310 @@
   if (myrank == 0) then
     write(IMAIN,*) 'Elastic kernels:'
     write(IMAIN,*) '  maximum value of rho  kernel      = ',rho_max
-    if (ANISOTROPIC_KL) then
-      if (SAVE_TRANSVERSE_KL) then
-        ! tranverse isotropic
-        write(IMAIN,*) '  maximum value of alphav kernel     = ',alphav_max
-        write(IMAIN,*) '  maximum value of alphah kernel     = ',alphah_max
-        write(IMAIN,*) '  maximum value of betav kernel      = ',betav_max
-        write(IMAIN,*) '  maximum value of betah kernel      = ',betah_max
-        write(IMAIN,*) '  maximum value of eta kernel        = ',eta_max
-      else
-        ! fully anisotropic
-        write(IMAIN,*) '  maximum value of cijkl kernel     = ',cijkl_max
-      endif
-    else
-      ! isotropic
-      write(IMAIN,*) '  maximum value of kappa kernel     = ',kappa_max
-      write(IMAIN,*) '  maximum value of mu kernel        = ',mu_max
-      write(IMAIN,*)
-      write(IMAIN,*) '  maximum value of rho prime kernel = ',rhop_max
-      write(IMAIN,*) '  maximum value of alpha kernel     = ',alpha_max
-      write(IMAIN,*) '  maximum value of beta kernel      = ',beta_max
-    endif
+    write(IMAIN,*) '  maximum value of kappa kernel     = ',kappa_max
+    write(IMAIN,*) '  maximum value of mu kernel        = ',mu_max
+    write(IMAIN,*)
+    write(IMAIN,*) '  maximum value of rho prime kernel = ',rhop_max
+    write(IMAIN,*) '  maximum value of alpha kernel     = ',alpha_max
+    write(IMAIN,*) '  maximum value of beta kernel      = ',beta_max
+    
     if (SAVE_MOHO_MESH) then
       write(IMAIN,*) '  maximum value of moho kernel      = ',moho_max
     endif
+    
     write(IMAIN,*)
     call flush_IMAIN()
   endif
 
-
   if (ADIOS_FOR_KERNELS) then
-    call save_kernels_elastic_adios(alphav_kl, alphah_kl, &
-                                    betav_kl, betah_kl, eta_kl, &
-                                    rhop_kl, alpha_kl, beta_kl)
+    !call save_kernels_elastic_adios(alphav_kl, alphah_kl, &
+    !                                betav_kl, betah_kl, eta_kl, &
+    !                                rhop_kl, alpha_kl, beta_kl)
   else
-    if (ANISOTROPIC_KL) then
+    ! save kernels to binary files
+    open(unit=IOUT,file=prname(1:len_trim(prname))//'rho_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'error opening file rho_kernel.bin'
+    write(IOUT) rho_kl
+    close(IOUT)
 
-      ! outputs transverse isotropic kernels only
-      if (SAVE_TRANSVERSE_KL) then
-        ! transverse isotropic kernels
-        ! (alpha_v, alpha_h, beta_v, beta_h, eta, rho ) parameterization
-        open(unit=IOUT,file=trim(prname)//'alphav_kernel.bin',status='unknown',form='unformatted',action='write')
-        write(IOUT) alphav_kl
-        close(IOUT)
-        open(unit=IOUT,file=trim(prname)//'alphah_kernel.bin',status='unknown',form='unformatted',action='write')
-        write(IOUT) alphah_kl
-        close(IOUT)
-        open(unit=IOUT,file=trim(prname)//'betav_kernel.bin',status='unknown',form='unformatted',action='write')
-        write(IOUT) betav_kl
-        close(IOUT)
-        open(unit=IOUT,file=trim(prname)//'betah_kernel.bin',status='unknown',form='unformatted',action='write')
-        write(IOUT) betah_kl
-        close(IOUT)
-        open(unit=IOUT,file=trim(prname)//'eta_kernel.bin',status='unknown',form='unformatted',action='write')
-        write(IOUT) eta_kl
-        close(IOUT)
+    open(unit=IOUT,file=prname(1:len_trim(prname))//'mu_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'error opening file mu_kernel.bin'
+    write(IOUT) mu_kl
+    close(IOUT)
 
-        ! transverse isotropic test kernels
-        open(unit=IOUT,file=trim(prname)//'alpha_kernel.bin',status='unknown',form='unformatted',action='write')
-        write(IOUT)  alpha_kl
-        close(IOUT)
-        open(unit=IOUT,file=trim(prname)//'beta_kernel.bin',status='unknown',form='unformatted',action='write')
-        write(IOUT)  beta_kl
-        close(IOUT)
+    open(unit=IOUT,file=prname(1:len_trim(prname))//'kappa_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'error opening file kappa_kernel.bin'
+    write(IOUT) kappa_kl
+    close(IOUT)
 
-      else
-        ! fully anisotropic kernels
-        ! note: the C_ij and density kernels are not for relative perturbations (delta ln( m_i) = delta m_i / m_i),
-        !          but absolute perturbations (delta m_i = m_i - m_0).
-        ! Kappa and mu are for absolute perturbations, can be used to check with purely isotropic versions.
-        open(unit=IOUT,file=trim(prname)//'rho_kernel.bin',status='unknown',form='unformatted',action='write')
-        write(IOUT) - rho_kl
-        close(IOUT)
-        open(unit=IOUT,file=trim(prname)//'cijkl_kernel.bin',status='unknown',form='unformatted',action='write')
-        write(IOUT) - cijkl_kl
-        close(IOUT)
+    open(unit=IOUT,file=prname(1:len_trim(prname))//'rhop_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'error opening file rhop_kernel.bin'
+    write(IOUT) rhop_kl
+    close(IOUT)
 
-      endif
+    open(unit=IOUT,file=prname(1:len_trim(prname))//'beta_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'error opening file beta_kernel.bin'
+    write(IOUT) beta_kl
+    close(IOUT)
 
-    else
-
-      ! save kernels to binary files
-      open(unit=IOUT,file=prname(1:len_trim(prname))//'rho_kernel.bin',status='unknown',form='unformatted',iostat=ier)
-      if (ier /= 0) stop 'error opening file rho_kernel.bin'
-      write(IOUT) rho_kl
-      close(IOUT)
-
-      open(unit=IOUT,file=prname(1:len_trim(prname))//'mu_kernel.bin',status='unknown',form='unformatted',iostat=ier)
-      if (ier /= 0) stop 'error opening file mu_kernel.bin'
-      write(IOUT) mu_kl
-      close(IOUT)
-
-      open(unit=IOUT,file=prname(1:len_trim(prname))//'kappa_kernel.bin',status='unknown',form='unformatted',iostat=ier)
-      if (ier /= 0) stop 'error opening file kappa_kernel.bin'
-      write(IOUT) kappa_kl
-      close(IOUT)
-
-      open(unit=IOUT,file=prname(1:len_trim(prname))//'rhop_kernel.bin',status='unknown',form='unformatted',iostat=ier)
-      if (ier /= 0) stop 'error opening file rhop_kernel.bin'
-      write(IOUT) rhop_kl
-      close(IOUT)
-
-      open(unit=IOUT,file=prname(1:len_trim(prname))//'beta_kernel.bin',status='unknown',form='unformatted',iostat=ier)
-      if (ier /= 0) stop 'error opening file beta_kernel.bin'
-      write(IOUT) beta_kl
-      close(IOUT)
-
-      open(unit=IOUT,file=prname(1:len_trim(prname))//'alpha_kernel.bin',status='unknown',form='unformatted',iostat=ier)
-      if (ier /= 0) stop 'error opening file alpha_kernel.bin'
-      write(IOUT) alpha_kl
-      close(IOUT)
-    endif
-
-    if (SAVE_MOHO_MESH) then
-      open(unit=IOUT,file=prname(1:len_trim(prname))//'moho_kernel.bin',status='unknown',form='unformatted',iostat=ier)
-      if (ier /= 0) stop 'error opening file moho_kernel.bin'
-      write(IOUT) moho_kl
-      close(IOUT)
-    endif
+    open(unit=IOUT,file=prname(1:len_trim(prname))//'alpha_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'error opening file alpha_kernel.bin'
+    write(IOUT) alpha_kl
+    close(IOUT)
   endif
 
-  end subroutine save_kernels_elastic
+  if (SAVE_MOHO_MESH) then
+    open(unit=IOUT,file=prname(1:len_trim(prname))//'moho_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'error opening file moho_kernel.bin'
+    write(IOUT) moho_kl
+    close(IOUT)
+  endif
+
+  deallocate(rhop_kl,alpha_kl,beta_kl)
+
+  end subroutine save_kernels_elastic_iso
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  !> Save elastic anisotropic kernels
+
+  subroutine save_kernels_elastic_aniso()
+
+  use specfem_par, only: CUSTOM_REAL,NSPEC_AB,NSPEC_ADJOINT,ibool,mustore,kappastore, &
+                         SAVE_TRANSVERSE_KL,FOUR_THIRDS, &
+                         ADIOS_FOR_KERNELS,IOUT,prname,SAVE_MOHO_MESH, &
+                         myrank,IMAIN
+  use specfem_par_elastic
+
+  implicit none
+
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: &
+              alphav_kl,alphah_kl,betav_kl,betah_kl, eta_kl, &
+              alpha_kl, beta_kl
+
+  ! local parameters
+  integer:: ispec,i,j,k,iglob,ier
+  real(kind=CUSTOM_REAL) :: mul,kappal
+
+  ! Transverse isotropic paramters
+  real(kind=CUSTOM_REAL) :: A,N,C,L,F,eta
+  real(kind=CUSTOM_REAL), dimension(21) :: cijkl_kl_local
+  real(kind=CUSTOM_REAL), dimension(5) :: an_kl
+
+  ! stats
+  real(kind=CUSTOM_REAL) :: rho_max,moho_max
+  real(kind=CUSTOM_REAL) :: alphav_max,alphah_max,betav_max,betah_max,eta_max,cijkl_max
+
+  ! allocates temporary transversely isotropic kernels
+  if (SAVE_TRANSVERSE_KL) then
+    allocate(alphav_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             alphah_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             betav_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             betah_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             eta_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT),stat=ier)
+    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2247')
+    if (ier /= 0) stop 'error allocating arrays alphav_kl,...'
+    alphav_kl(:,:,:,:) = 0.0_CUSTOM_REAL; alphah_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+    betav_kl(:,:,:,:) = 0.0_CUSTOM_REAL; betah_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+    eta_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+
+    ! derived kernels
+    ! vp,vs kernel
+    allocate(alpha_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             beta_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT),stat=ier)
+    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2249')
+    if (ier /= 0) stop 'error allocating array alpha_kl,beta_kl'
+    alpha_kl(:,:,:,:) = 0.0_CUSTOM_REAL; beta_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+  endif
+
+  ! finalizes calculation of rhop, beta, alpha kernels
+  do ispec = 1, NSPEC_AB
+
+    ! elastic simulations
+    if (ispec_is_elastic(ispec)) then
+
+      do k = 1, NGLLZ
+        do j = 1, NGLLY
+          do i = 1, NGLLX
+            iglob = ibool(i,j,k,ispec)
+
+            ! Store local material values
+            mul = mustore(i,j,k,ispec)
+            kappal = kappastore(i,j,k,ispec)
+
+            if (SAVE_TRANSVERSE_KL) then
+              cijkl_kl_local(:) = - cijkl_kl(:,i,j,k,ispec)
+
+              ! Computes parameters for an isotropic model
+              A = kappal + FOUR_THIRDS * mul
+              C = A
+              L = mul
+              N = mul
+              F = kappal - 2._CUSTOM_REAL/3._CUSTOM_REAL * mul
+              eta = 1._CUSTOM_REAL
+
+              ! note: cijkl_kl_local() is fully anisotropic C_ij kernel
+              ! components (non-dimensionalized)
+              !          for GLL point at (i,j,k,ispec)
+
+              ! Purpose : compute the kernels for the An coeffs (an_kl)
+              ! from the kernels for Cij (cijkl_kl_local)
+
+              ! Definition of the input array cij_kl :
+              ! cij_kl(1) = C11 ; cij_kl(2) = C12 ; cij_kl(3) = C13
+              ! cij_kl(4) = C14 ; cij_kl(5) = C15 ; cij_kl(6) = C16
+              ! cij_kl(7) = C22 ; cij_kl(8) = C23 ; cij_kl(9) = C24
+              ! cij_kl(10) = C25 ; cij_kl(11) = C26 ; cij_kl(12) = C33
+              ! cij_kl(13) = C34 ; cij_kl(14) = C35 ; cij_kl(15) = C36
+              ! cij_kl(16) = C44 ; cij_kl(17) = C45 ; cij_kl(18) = C46
+              ! cij_kl(19) = C55 ; cij_kl(20) = C56 ; cij_kl(21) = C66
+              ! where the Cij (Voigt's notation) are defined as function of
+              ! the components of the elastic tensor in spherical coordinates
+              ! by eq. (A.1) of Chen & Tromp, GJI 168 (2007)
+
+              ! From the relations giving Cij in function of An
+              ! Checked with Min Chen's results (routine build_cij)
+
+              an_kl(1) = cijkl_kl_local(1)+cijkl_kl_local(2)+cijkl_kl_local(7)    !A
+              an_kl(2) = cijkl_kl_local(12)                                       !C
+              an_kl(3) = -2*cijkl_kl_local(2)+cijkl_kl_local(21)                  !N
+              an_kl(4) = cijkl_kl_local(16)+cijkl_kl_local(19)                    !L
+              an_kl(5) = cijkl_kl_local(3)+cijkl_kl_local(8)                      !F
+
+              ! for parameterization: ( alpha_v, alpha_h, beta_v, beta_h, eta, rho )
+                
+              ! K_alpha_v
+              alphav_kl(i,j,k,ispec) = 2.0 * C * an_kl(2)
+              ! K_alpha_h
+              alphah_kl(i,j,k,ispec) = 2.0 * A * an_kl(1) + 2.0 * A * eta * an_kl(5)
+              ! K_beta_v
+              betav_kl(i,j,k,ispec) = 2.0 * L * an_kl(4) - 4.0 * L * eta * an_kl(5)
+              ! K_beta_h
+              betah_kl(i,j,k,ispec) = 2.0 * N * an_kl(3)
+              ! K_eta
+              eta_kl(i,j,k,ispec) = F * an_kl(5)
+
+              ! to check: isotropic kernels from transverse isotropic ones
+              alpha_kl(i,j,k,ispec) = alphav_kl(i,j,k,ispec) + alphah_kl(i,j,k,ispec)
+              beta_kl(i,j,k,ispec) = betav_kl(i,j,k,ispec) + betah_kl(i,j,k,ispec)
+
+            endif ! SAVE_TRANSVERSE_KL
+          enddo
+        enddo
+      enddo
+
+    endif ! elastic
+
+  enddo
+
+  ! overall min/max value
+  call max_all_cr(maxval(rho_kl),rho_max)
+
+  if (SAVE_TRANSVERSE_KL) then
+    call max_all_cr(maxval(alphav_kl),alphav_max)
+    call max_all_cr(maxval(alphah_kl),alphah_max)
+    call max_all_cr(maxval(betav_kl),betav_max)
+    call max_all_cr(maxval(betah_kl),betah_max)
+    call max_all_cr(maxval(eta_kl),eta_max)
+  else
+    call max_all_cr(maxval(-cijkl_kl),cijkl_max)
+  endif
+
+  if (SAVE_MOHO_MESH) then
+    call max_all_cr(maxval(moho_kl),moho_max)
+  endif
+
+  ! user output
+  if (myrank == 0) then
+    write(IMAIN,*) 'Elastic kernels:'
+    write(IMAIN,*) '  maximum value of rho  kernel      = ',rho_max
+
+    if (SAVE_TRANSVERSE_KL) then
+      ! tranverse isotropic
+      write(IMAIN,*) '  maximum value of alphav kernel     = ',alphav_max
+      write(IMAIN,*) '  maximum value of alphah kernel     = ',alphah_max
+      write(IMAIN,*) '  maximum value of betav kernel      = ',betav_max
+      write(IMAIN,*) '  maximum value of betah kernel      = ',betah_max
+      write(IMAIN,*) '  maximum value of eta kernel        = ',eta_max
+    else
+      ! fully anisotropic
+      write(IMAIN,*) '  maximum value of cijkl kernel     = ',cijkl_max
+    endif
+    
+    if (SAVE_MOHO_MESH) then
+      write(IMAIN,*) '  maximum value of moho kernel      = ',moho_max
+    endif
+    
+    write(IMAIN,*)
+    call flush_IMAIN()
+  endif
+
+  if (ADIOS_FOR_KERNELS) then
+    !call save_kernels_elastic_adios(alphav_kl, alphah_kl, &
+    !                                betav_kl, betah_kl, eta_kl, &
+    !                                rhop_kl, alpha_kl, beta_kl)
+  else
+    ! outputs transverse isotropic kernels only
+    if (SAVE_TRANSVERSE_KL) then
+      ! transverse isotropic kernels
+      ! (alpha_v, alpha_h, beta_v, beta_h, eta, rho ) parameterization
+      open(unit=IOUT,file=trim(prname)//'alphav_kernel.bin',status='unknown',form='unformatted',action='write')
+      write(IOUT) alphav_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'alphah_kernel.bin',status='unknown',form='unformatted',action='write')
+      write(IOUT) alphah_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'betav_kernel.bin',status='unknown',form='unformatted',action='write')
+      write(IOUT) betav_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'betah_kernel.bin',status='unknown',form='unformatted',action='write')
+      write(IOUT) betah_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'eta_kernel.bin',status='unknown',form='unformatted',action='write')
+      write(IOUT) eta_kl
+      close(IOUT)
+
+      ! transverse isotropic test kernels
+      open(unit=IOUT,file=trim(prname)//'alpha_kernel.bin',status='unknown',form='unformatted',action='write')
+      write(IOUT)  alpha_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'beta_kernel.bin',status='unknown',form='unformatted',action='write')
+      write(IOUT)  beta_kl
+      close(IOUT)
+
+    else
+      ! fully anisotropic kernels
+      ! note: the C_ij and density kernels are not for relative perturbations
+      ! (delta ln( m_i) = delta m_i / m_i),
+      !          but absolute perturbations (delta m_i = m_i - m_0).
+      ! Kappa and mu are for absolute perturbations, can be used to check with
+      ! purely isotropic versions.
+      open(unit=IOUT,file=trim(prname)//'rho_kernel.bin',status='unknown',form='unformatted',action='write')
+      write(IOUT) - rho_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'cijkl_kernel.bin',status='unknown',form='unformatted',action='write')
+      write(IOUT) - cijkl_kl
+      close(IOUT)
+
+    endif
+
+  endif
+
+  if (SAVE_MOHO_MESH) then
+    open(unit=IOUT,file=prname(1:len_trim(prname))//'moho_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+    if (ier /= 0) stop 'error opening file moho_kernel.bin'
+    write(IOUT) moho_kl
+    close(IOUT)
+  endif
+
+  if (SAVE_TRANSVERSE_KL) then
+    deallocate(alphav_kl,alphah_kl,betav_kl,betah_kl,eta_kl)
+    deallocate(alpha_kl,beta_kl)
+  endif
+  
+  end subroutine save_kernels_elastic_aniso
 
 !
 !-------------------------------------------------------------------------------------------------

--- a/src/specfem3D/save_adjoint_kernels.f90
+++ b/src/specfem3D/save_adjoint_kernels.f90
@@ -376,9 +376,7 @@
   endif
 
   if (ADIOS_FOR_KERNELS) then
-    !call save_kernels_elastic_adios(alphav_kl, alphah_kl, &
-    !                                betav_kl, betah_kl, eta_kl, &
-    !                                rhop_kl, alpha_kl, beta_kl)
+    call save_kernels_elastic_iso_adios(rhop_kl, alpha_kl, beta_kl)
   else
     ! save kernels to binary files
     open(unit=IOUT,file=prname(1:len_trim(prname))//'rho_kernel.bin',status='unknown',form='unformatted',iostat=ier)
@@ -601,9 +599,9 @@
   endif
 
   if (ADIOS_FOR_KERNELS) then
-    !call save_kernels_elastic_adios(alphav_kl, alphah_kl, &
-    !                                betav_kl, betah_kl, eta_kl, &
-    !                                rhop_kl, alpha_kl, beta_kl)
+    call save_kernels_elastic_aniso_adios(alphav_kl, alphah_kl, &
+                                          betav_kl, betah_kl, eta_kl, &
+                                          alpha_kl, beta_kl)
   else
     ! outputs transverse isotropic kernels only
     if (SAVE_TRANSVERSE_KL) then

--- a/src/specfem3D/save_adjoint_kernels.f90
+++ b/src/specfem3D/save_adjoint_kernels.f90
@@ -437,8 +437,13 @@
 
   implicit none
 
-  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: &
-              alphav_kl,alphah_kl,betav_kl,betah_kl, eta_kl
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: alphav_kl,alphah_kl,betav_kl,betah_kl, eta_kl
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: c11_kl,c12_kl,c13_kl,c14_kl,c15_kl,c16_kl, &
+                                                             c22_kl,c23_kl,c24_kl,c25_kl,c26_kl, &
+                                                             c33_kl,c34_kl,c35_kl,c36_kl, &
+                                                             c44_kl,c45_kl,c46_kl, &
+                                                             c55_kl,c56_kl, &
+                                                             c66_kl
 
   ! local parameters
   integer:: ispec,i,j,k,iglob,ier
@@ -452,6 +457,12 @@
   ! stats
   real(kind=CUSTOM_REAL) :: rho_max,moho_max
   real(kind=CUSTOM_REAL) :: alphav_max,alphah_max,betav_max,betah_max,eta_max,cijkl_max
+  real(kind=CUSTOM_REAL) :: c11_kl_max,c12_kl_max,c13_kl_max,c14_kl_max,c15_kl_max,c16_kl_max, &
+                            c22_kl_max,c23_kl_max,c24_kl_max,c25_kl_max,c26_kl_max, &
+                            c33_kl_max,c34_kl_max,c35_kl_max,c36_kl_max, &
+                            c44_kl_max,c45_kl_max,c46_kl_max, &
+                            c55_kl_max,c56_kl_max, &
+                            c66_kl_max
 
   ! allocates temporary transversely isotropic kernels
   if (SAVE_TRANSVERSE_KL) then
@@ -465,6 +476,41 @@
     alphav_kl(:,:,:,:) = 0.0_CUSTOM_REAL; alphah_kl(:,:,:,:) = 0.0_CUSTOM_REAL
     betav_kl(:,:,:,:) = 0.0_CUSTOM_REAL; betah_kl(:,:,:,:) = 0.0_CUSTOM_REAL
     eta_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+  else
+    allocate(c11_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c12_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c13_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c14_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c15_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c16_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c22_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c23_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c24_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c25_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c26_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c33_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c34_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c35_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c36_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c44_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c45_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c46_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c55_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c56_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
+             c66_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT),stat=ier)
+      if (ier /= 0) call exit_MPI_without_rank('error allocating array XXXX')
+      if (ier /= 0) stop 'error allocating arrays c11_kl,c22_kl,...'
+      c11_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c12_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c13_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c14_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c15_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c16_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c22_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c23_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c24_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c25_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c26_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c33_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c34_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c35_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c36_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c44_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c45_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c46_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c55_kl(:,:,:,:) = 0.0_CUSTOM_REAL; c56_kl(:,:,:,:) = 0.0_CUSTOM_REAL
+      c66_kl(:,:,:,:) = 0.0_CUSTOM_REAL
   endif
 
   ! finalizes calculation of rhop, beta, alpha kernels
@@ -478,8 +524,10 @@
           do i = 1, NGLLX
             iglob = ibool(i,j,k,ispec)
 
+            cijkl_kl_local(:) = - cijkl_kl(:,i,j,k,ispec)
+
             if (SAVE_TRANSVERSE_KL) then
-              cijkl_kl_local(:) = - cijkl_kl(:,i,j,k,ispec)
+              ! SAVE_TRANSVERSE_KL
 
               if (ANISOTROPY) then
                 ! Computes parameters for an anisotropic model
@@ -543,8 +591,30 @@
               betah_kl(i,j,k,ispec) = 2.0 * N * an_kl(3)
               ! K_eta
               eta_kl(i,j,k,ispec) = F * an_kl(5)
-            
-            endif ! SAVE_TRANSVERSE_KL
+            else
+              !Cij_kernels
+              c11_kl(i,j,k,ispec) = cijkl_kl_local(1)
+              c12_kl(i,j,k,ispec) = cijkl_kl_local(2)
+              c13_kl(i,j,k,ispec) = cijkl_kl_local(3)
+              c14_kl(i,j,k,ispec) = cijkl_kl_local(4)
+              c15_kl(i,j,k,ispec) = cijkl_kl_local(5)
+              c16_kl(i,j,k,ispec) = cijkl_kl_local(6)
+              c22_kl(i,j,k,ispec) = cijkl_kl_local(7)
+              c23_kl(i,j,k,ispec) = cijkl_kl_local(8)
+              c24_kl(i,j,k,ispec) = cijkl_kl_local(9)
+              c25_kl(i,j,k,ispec) = cijkl_kl_local(10)
+              c26_kl(i,j,k,ispec) = cijkl_kl_local(11)
+              c33_kl(i,j,k,ispec) = cijkl_kl_local(12)
+              c34_kl(i,j,k,ispec) = cijkl_kl_local(13)
+              c35_kl(i,j,k,ispec) = cijkl_kl_local(14)
+              c36_kl(i,j,k,ispec) = cijkl_kl_local(15)
+              c44_kl(i,j,k,ispec) = cijkl_kl_local(16)
+              c45_kl(i,j,k,ispec) = cijkl_kl_local(17)
+              c46_kl(i,j,k,ispec) = cijkl_kl_local(18)
+              c55_kl(i,j,k,ispec) = cijkl_kl_local(19)
+              c56_kl(i,j,k,ispec) = cijkl_kl_local(20)
+              c66_kl(i,j,k,ispec) = cijkl_kl_local(21)
+            endif
           enddo
         enddo
       enddo
@@ -554,7 +624,6 @@
   enddo
 
   ! overall min/max value
-  call max_all_cr(maxval(-rho_kl),rho_max)
 
   if (SAVE_TRANSVERSE_KL) then
     call max_all_cr(maxval(alphav_kl),alphav_max)
@@ -563,7 +632,29 @@
     call max_all_cr(maxval(betah_kl),betah_max)
     call max_all_cr(maxval(eta_kl),eta_max)
   else
+    call max_all_cr(maxval(-rho_kl),rho_max)
     call max_all_cr(maxval(-cijkl_kl),cijkl_max)
+    call max_all_cr(maxval(c11_kl),c11_kl_max)
+    call max_all_cr(maxval(c12_kl),c12_kl_max)
+    call max_all_cr(maxval(c13_kl),c13_kl_max)
+    call max_all_cr(maxval(c14_kl),c14_kl_max)
+    call max_all_cr(maxval(c15_kl),c15_kl_max)
+    call max_all_cr(maxval(c16_kl),c16_kl_max)
+    call max_all_cr(maxval(c22_kl),c22_kl_max)
+    call max_all_cr(maxval(c23_kl),c23_kl_max)
+    call max_all_cr(maxval(c24_kl),c24_kl_max)
+    call max_all_cr(maxval(c25_kl),c25_kl_max)
+    call max_all_cr(maxval(c26_kl),c26_kl_max)
+    call max_all_cr(maxval(c33_kl),c33_kl_max)
+    call max_all_cr(maxval(c34_kl),c34_kl_max)
+    call max_all_cr(maxval(c35_kl),c35_kl_max)
+    call max_all_cr(maxval(c36_kl),c36_kl_max)
+    call max_all_cr(maxval(c44_kl),c44_kl_max)
+    call max_all_cr(maxval(c45_kl),c45_kl_max)
+    call max_all_cr(maxval(c46_kl),c46_kl_max)
+    call max_all_cr(maxval(c55_kl),c55_kl_max)
+    call max_all_cr(maxval(c56_kl),c56_kl_max)
+    call max_all_cr(maxval(c66_kl),c66_kl_max)
   endif
 
   if (SAVE_MOHO_MESH) then
@@ -573,7 +664,6 @@
   ! user output
   if (myrank == 0) then
     write(IMAIN,*) 'Elastic kernels:'
-    write(IMAIN,*) '  maximum value of rho  kernel      = ',rho_max
 
     if (SAVE_TRANSVERSE_KL) then
       ! tranverse isotropic
@@ -584,7 +674,29 @@
       write(IMAIN,*) '  maximum value of eta kernel        = ',eta_max
     else
       ! fully anisotropic
+      write(IMAIN,*) '  maximum value of rho  kernel      = ',rho_max
       write(IMAIN,*) '  maximum value of cijkl kernel     = ',cijkl_max
+      write(IMAIN,*) '  maximum value of c11 kernel     = ',c11_kl_max
+      write(IMAIN,*) '  maximum value of c12 kernel     = ',c12_kl_max
+      write(IMAIN,*) '  maximum value of c13 kernel     = ',c13_kl_max
+      write(IMAIN,*) '  maximum value of c14 kernel     = ',c14_kl_max
+      write(IMAIN,*) '  maximum value of c15 kernel     = ',c15_kl_max
+      write(IMAIN,*) '  maximum value of c16 kernel     = ',c16_kl_max
+      write(IMAIN,*) '  maximum value of c22 kernel     = ',c22_kl_max
+      write(IMAIN,*) '  maximum value of c23 kernel     = ',c23_kl_max
+      write(IMAIN,*) '  maximum value of c24 kernel     = ',c24_kl_max
+      write(IMAIN,*) '  maximum value of c25 kernel     = ',c25_kl_max
+      write(IMAIN,*) '  maximum value of c26 kernel     = ',c26_kl_max
+      write(IMAIN,*) '  maximum value of c33 kernel     = ',c33_kl_max
+      write(IMAIN,*) '  maximum value of c34 kernel     = ',c34_kl_max
+      write(IMAIN,*) '  maximum value of c35 kernel     = ',c35_kl_max
+      write(IMAIN,*) '  maximum value of c36 kernel     = ',c36_kl_max
+      write(IMAIN,*) '  maximum value of c44 kernel     = ',c44_kl_max
+      write(IMAIN,*) '  maximum value of c45 kernel     = ',c45_kl_max
+      write(IMAIN,*) '  maximum value of c46 kernel     = ',c46_kl_max
+      write(IMAIN,*) '  maximum value of c55 kernel     = ',c55_kl_max
+      write(IMAIN,*) '  maximum value of c56 kernel     = ',c56_kl_max
+      write(IMAIN,*) '  maximum value of c66 kernel     = ',c66_kl_max
     endif
     
     if (SAVE_MOHO_MESH) then
@@ -596,8 +708,13 @@
   endif
 
   if (ADIOS_FOR_KERNELS) then
-    call save_kernels_elastic_aniso_adios(alphav_kl, alphah_kl, &
-                                          betav_kl, betah_kl, eta_kl)
+    call save_kernels_elastic_aniso_adios(alphav_kl, alphah_kl, betav_kl, betah_kl, eta_kl, &
+                                          c11_kl,c12_kl,c13_kl,c14_kl,c15_kl,c16_kl, &
+                                          c22_kl,c23_kl,c24_kl,c25_kl,c26_kl, &
+                                          c33_kl,c34_kl,c35_kl,c36_kl, &
+                                          c44_kl,c45_kl,c46_kl, &
+                                          c55_kl,c56_kl, &
+                                          c66_kl)
   else
     ! outputs transverse isotropic kernels only
     if (SAVE_TRANSVERSE_KL) then
@@ -623,15 +740,93 @@
       ! note: the C_ij and density kernels are not for relative perturbations
       ! (delta ln( m_i) = delta m_i / m_i),
       !          but absolute perturbations (delta m_i = m_i - m_0).
-      ! Kappa and mu are for absolute perturbations, can be used to check with
-      ! purely isotropic versions.
       open(unit=IOUT,file=trim(prname)//'rho_kernel.bin',status='unknown',form='unformatted',action='write')
       write(IOUT) - rho_kl
       close(IOUT)
-      open(unit=IOUT,file=trim(prname)//'cijkl_kernel.bin',status='unknown',form='unformatted',action='write')
-      write(IOUT) - cijkl_kl
+      open(unit=IOUT,file=trim(prname)//'c11_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c11_kernel.bin'
+      write(IOUT) c11_kl
       close(IOUT)
-
+      open(unit=IOUT,file=trim(prname)//'c12_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c12_kernel.bin'
+      write(IOUT) c12_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c13_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c13_kernel.bin'
+      write(IOUT) c13_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c14_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c14_kernel.bin'
+      write(IOUT) c14_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c15_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c15_kernel.bin'
+      write(IOUT) c15_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c16_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c16_kernel.bin'
+      write(IOUT) c16_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c22_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c22_kernel.bin'
+      write(IOUT) c22_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c23_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c23_kernel.bin'
+      write(IOUT) c23_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c24_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c24_kernel.bin'
+      write(IOUT) c24_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c25_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c25_kernel.bin'
+      write(IOUT) c25_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c26_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c26_kernel.bin'
+      write(IOUT) c26_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c33_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c33_kernel.bin'
+      write(IOUT) c33_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c34_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c34_kernel.bin'
+      write(IOUT) c34_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c35_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c35_kernel.bin'
+      write(IOUT) c35_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c36_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c36_kernel.bin'
+      write(IOUT) c36_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c44_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c44_kernel.bin'
+      write(IOUT) c44_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c45_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c45_kernel.bin'
+      write(IOUT) c45_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c46_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c46_kernel.bin'
+      write(IOUT) c46_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c55_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c55_kernel.bin'
+      write(IOUT) c55_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c56_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c56_kernel.bin'
+      write(IOUT) c56_kl
+      close(IOUT)
+      open(unit=IOUT,file=trim(prname)//'c66_kernel.bin',status='unknown',form='unformatted',iostat=ier)
+      if (ier /= 0) stop 'error opening file c66_kernel.bin'
+      write(IOUT) c66_kl
+      close(IOUT)
     endif
 
   endif
@@ -645,6 +840,13 @@
 
   if (SAVE_TRANSVERSE_KL) then
     deallocate(alphav_kl,alphah_kl,betav_kl,betah_kl,eta_kl)
+  else
+    deallocate(c11_kl,c12_kl,c13_kl,c14_kl,c15_kl,c16_kl, &
+               c22_kl,c23_kl,c24_kl,c25_kl,c26_kl, &
+               c33_kl,c34_kl,c35_kl,c36_kl, &
+               c44_kl,c45_kl,c46_kl, &
+               c55_kl,c56_kl, &
+               c66_kl)
   endif
   
   end subroutine save_kernels_elastic_aniso

--- a/src/specfem3D/save_adjoint_kernels.f90
+++ b/src/specfem3D/save_adjoint_kernels.f90
@@ -557,7 +557,7 @@
   enddo
 
   ! overall min/max value
-  call max_all_cr(maxval(rho_kl),rho_max)
+  call max_all_cr(maxval(-rho_kl),rho_max)
 
   if (SAVE_TRANSVERSE_KL) then
     call max_all_cr(maxval(alphav_kl),alphav_max)

--- a/src/specfem3D/save_adjoint_kernels.f90
+++ b/src/specfem3D/save_adjoint_kernels.f90
@@ -438,8 +438,7 @@
   implicit none
 
   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: &
-              alphav_kl,alphah_kl,betav_kl,betah_kl, eta_kl, &
-              alpha_kl, beta_kl
+              alphav_kl,alphah_kl,betav_kl,betah_kl, eta_kl
 
   ! local parameters
   integer:: ispec,i,j,k,iglob,ier
@@ -466,14 +465,6 @@
     alphav_kl(:,:,:,:) = 0.0_CUSTOM_REAL; alphah_kl(:,:,:,:) = 0.0_CUSTOM_REAL
     betav_kl(:,:,:,:) = 0.0_CUSTOM_REAL; betah_kl(:,:,:,:) = 0.0_CUSTOM_REAL
     eta_kl(:,:,:,:) = 0.0_CUSTOM_REAL
-
-    ! derived kernels
-    ! vp,vs kernel
-    allocate(alpha_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT), &
-             beta_kl(NGLLX,NGLLY,NGLLZ,NSPEC_ADJOINT),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2249')
-    if (ier /= 0) stop 'error allocating array alpha_kl,beta_kl'
-    alpha_kl(:,:,:,:) = 0.0_CUSTOM_REAL; beta_kl(:,:,:,:) = 0.0_CUSTOM_REAL
   endif
 
   ! finalizes calculation of rhop, beta, alpha kernels
@@ -542,11 +533,7 @@
               betah_kl(i,j,k,ispec) = 2.0 * N * an_kl(3)
               ! K_eta
               eta_kl(i,j,k,ispec) = F * an_kl(5)
-
-              ! to check: isotropic kernels from transverse isotropic ones
-              alpha_kl(i,j,k,ispec) = alphav_kl(i,j,k,ispec) + alphah_kl(i,j,k,ispec)
-              beta_kl(i,j,k,ispec) = betav_kl(i,j,k,ispec) + betah_kl(i,j,k,ispec)
-
+            
             endif ! SAVE_TRANSVERSE_KL
           enddo
         enddo
@@ -600,8 +587,7 @@
 
   if (ADIOS_FOR_KERNELS) then
     call save_kernels_elastic_aniso_adios(alphav_kl, alphah_kl, &
-                                          betav_kl, betah_kl, eta_kl, &
-                                          alpha_kl, beta_kl)
+                                          betav_kl, betah_kl, eta_kl)
   else
     ! outputs transverse isotropic kernels only
     if (SAVE_TRANSVERSE_KL) then
@@ -622,15 +608,6 @@
       open(unit=IOUT,file=trim(prname)//'eta_kernel.bin',status='unknown',form='unformatted',action='write')
       write(IOUT) eta_kl
       close(IOUT)
-
-      ! transverse isotropic test kernels
-      open(unit=IOUT,file=trim(prname)//'alpha_kernel.bin',status='unknown',form='unformatted',action='write')
-      write(IOUT)  alpha_kl
-      close(IOUT)
-      open(unit=IOUT,file=trim(prname)//'beta_kernel.bin',status='unknown',form='unformatted',action='write')
-      write(IOUT)  beta_kl
-      close(IOUT)
-
     else
       ! fully anisotropic kernels
       ! note: the C_ij and density kernels are not for relative perturbations
@@ -658,7 +635,6 @@
 
   if (SAVE_TRANSVERSE_KL) then
     deallocate(alphav_kl,alphah_kl,betav_kl,betah_kl,eta_kl)
-    deallocate(alpha_kl,beta_kl)
   endif
   
   end subroutine save_kernels_elastic_aniso

--- a/src/specfem3D/save_kernels_adios.F90
+++ b/src/specfem3D/save_kernels_adios.F90
@@ -99,7 +99,27 @@
         call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "eta_kl", dummy_kernel)
       else
         call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "rho_kl", dummy_kernel)
-        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "cijkl_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c11_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c12_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c13_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c14_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c15_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c16_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c22_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c23_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c24_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c25_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c26_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c33_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c34_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c35_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c36_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c44_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c45_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c46_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c55_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c56_kl", dummy_kernel)
+        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "c66_kl", dummy_kernel)
       endif
     else
       call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "rho_kl", dummy_kernel)
@@ -272,8 +292,13 @@
 
 !==============================================================================
 !> Save elastic related kernels
-  subroutine save_kernels_elastic_ansio_adios(alphav_kl, alphah_kl, &
-                                              betav_kl, betah_kl, eta_kl)
+  subroutine save_kernels_elastic_ansio_adios(alphav_kl, alphah_kl, betav_kl, betah_kl, eta_kl, &
+                                              c11_kl,c12_kl,c13_kl,c14_kl,c15_kl,c16_kl, &
+                                              c22_kl,c23_kl,c24_kl,c25_kl,c26_kl, &
+                                              c33_kl,c34_kl,c35_kl,c36_kl, &
+                                              c44_kl,c45_kl,c46_kl, &
+                                              c55_kl,c56_kl, &
+                                              c66_kl)
 
   use specfem_par
   use specfem_par_elastic
@@ -309,7 +334,27 @@
   else
     ! fully anisotropic kernels
     call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, "rho_kl", -rho_kl)
-    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, "cijkl_kl", -cijkl_kl)
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c11_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c12_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c13_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c14_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c15_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c16_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c22_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c23_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c24_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c25_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c26_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c33_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c34_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c35_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c36_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c44_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c45_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c46_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c55_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c56_kl))
+    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(c66_kl))  
   endif
   
   if (SAVE_MOHO_MESH) then

--- a/src/specfem3D/save_kernels_adios.F90
+++ b/src/specfem3D/save_kernels_adios.F90
@@ -97,8 +97,6 @@
         call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "betav_kl", dummy_kernel)
         call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "betah_kl", dummy_kernel)
         call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "eta_kl", dummy_kernel)
-        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "alpha_kl", dummy_kernel)
-        call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "beta_kl", dummy_kernel)
       else
         call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "rho_kl", dummy_kernel)
         call define_adios_global_array1D(myadios_group, group_size_inc, local_dim, '', "cijkl_kl", dummy_kernel)
@@ -275,8 +273,7 @@
 !==============================================================================
 !> Save elastic related kernels
   subroutine save_kernels_elastic_ansio_adios(alphav_kl, alphah_kl, &
-                                              betav_kl, betah_kl, eta_kl, &
-                                              alpha_kl, beta_kl)
+                                              betav_kl, betah_kl, eta_kl)
 
   use specfem_par
   use specfem_par_elastic
@@ -294,8 +291,7 @@
 
   ! Transverse isotropic paramters
   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: &
-    alphav_kl,alphah_kl,betav_kl,betah_kl, &
-    eta_kl, alpha_kl, beta_kl
+    alphav_kl,alphah_kl,betav_kl,betah_kl, eta_kl
 
   ! determines maximum values for nspec over all partition slices
   call max_allreduce_singlei(NSPEC_AB,nspec_wmax)
@@ -310,10 +306,6 @@
     call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(betav_kl))
     call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(betah_kl))
     call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(eta_kl))
-
-    ! transverse isotropic test kernels
-    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(alpha_kl))
-    call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, STRINGIFY_VAR(beta_kl))
   else
     ! fully anisotropic kernels
     call write_adios_global_1d_array(myadios_file, myadios_group, myrank, sizeprocs, local_dim, "rho_kl", -rho_kl)


### PR DESCRIPTION
This pull request contains -
1. Removing fortran interfaces from save_adjoint_kernels.f90 .
2. Breaking elastic kernels' write out into two separate subroutines -
    - isotropic parameters' kernels. 
    - anisotropic parmeters' kernels.
3. Corrections to kernel computations when background model is anisotropic.
4. Splitting 5 dimensional c_ijkl kernel array write out into 21 x 4 dimensional C_ij kernel array write out.
5. Other minor updates.