### PR TITLE
simplified code for reading anisotropic tomographic models with potential speed up

### DIFF
--- a/src/generate_databases/model_tomography.f90
+++ b/src/generate_databases/model_tomography.f90
@@ -537,27 +537,12 @@ end subroutine init_tomography_files
       endif
 
       ! stores record values
-      c_tomography(imat,1,1) = c11_tomo
-      c_tomography(imat,1,2) = c12_tomo
-      c_tomography(imat,1,3) = c13_tomo
-      c_tomography(imat,1,4) = c14_tomo
-      c_tomography(imat,1,5) = c15_tomo
-      c_tomography(imat,1,6) = c16_tomo
-      c_tomography(imat,1,7) = c22_tomo
-      c_tomography(imat,1,8) = c23_tomo
-      c_tomography(imat,1,9) = c24_tomo
-      c_tomography(imat,1,10) = c25_tomo
-      c_tomography(imat,1,11) = c26_tomo
-      c_tomography(imat,1,12) = c33_tomo
-      c_tomography(imat,1,13) = c34_tomo
-      c_tomography(imat,1,14) = c35_tomo
-      c_tomography(imat,1,15) = c36_tomo
-      c_tomography(imat,1,16) = c44_tomo
-      c_tomography(imat,1,17) = c45_tomo
-      c_tomography(imat,1,18) = c46_tomo
-      c_tomography(imat,1,19) = c55_tomo
-      c_tomography(imat,1,20) = c56_tomo
-      c_tomography(imat,1,21) = c66_tomo
+      c_tomography(imat,1,:) = (/ c11_tomo, c12_tomo, c13_tomo, c14_tomo, c15_tomo, c16_tomo, &
+                                        c22_tomo, c23_tomo, c24_tomo, c25_tomo, c26_tomo, &
+                                        c33_tomo, c34_tomo, c35_tomo, c36_tomo, &
+                                        c44_tomo, c45_tomo, c46_tomo, &
+                                        c55_tomo, c56_tomo, &
+                                        c66_tomo /)
 
       rho_tomography(imat,1) = rho_tomo
       z_tomography(imat,1) = z_tomo
@@ -573,27 +558,12 @@ end subroutine init_tomography_files
           if (ier /= 0) stop 'Error reading tomo file line format with q values'
 
           ! stores record values
-          c_tomography(imat,irecord,1) = c11_tomo
-          c_tomography(imat,irecord,2) = c12_tomo
-          c_tomography(imat,irecord,3) = c13_tomo
-          c_tomography(imat,irecord,4) = c14_tomo
-          c_tomography(imat,irecord,5) = c15_tomo
-          c_tomography(imat,irecord,6) = c16_tomo
-          c_tomography(imat,irecord,7) = c22_tomo
-          c_tomography(imat,irecord,8) = c23_tomo
-          c_tomography(imat,irecord,9) = c24_tomo
-          c_tomography(imat,irecord,10) = c25_tomo
-          c_tomography(imat,irecord,11) = c26_tomo
-          c_tomography(imat,irecord,12) = c33_tomo
-          c_tomography(imat,irecord,13) = c34_tomo
-          c_tomography(imat,irecord,14) = c35_tomo
-          c_tomography(imat,irecord,15) = c36_tomo
-          c_tomography(imat,irecord,16) = c44_tomo
-          c_tomography(imat,irecord,17) = c45_tomo
-          c_tomography(imat,irecord,18) = c46_tomo
-          c_tomography(imat,irecord,19) = c55_tomo
-          c_tomography(imat,irecord,20) = c56_tomo
-          c_tomography(imat,irecord,21) = c66_tomo
+          c_tomography(imat,irecord,:) = (/ c11_tomo, c12_tomo, c13_tomo, c14_tomo, c15_tomo, c16_tomo, &
+                                            c22_tomo, c23_tomo, c24_tomo, c25_tomo, c26_tomo, &
+                                            c33_tomo, c34_tomo, c35_tomo, c36_tomo, &
+                                            c44_tomo, c45_tomo, c46_tomo, &
+                                            c55_tomo, c56_tomo, &
+                                            c66_tomo /)
 
           rho_tomography(imat,irecord) = rho_tomo
           z_tomography(imat,irecord) = z_tomo
@@ -610,27 +580,12 @@ end subroutine init_tomography_files
           if (ier /= 0) stop 'Error reading tomo file line format'
 
           ! stores record values
-          c_tomography(imat,irecord,1) = c11_tomo
-          c_tomography(imat,irecord,2) = c12_tomo
-          c_tomography(imat,irecord,3) = c13_tomo
-          c_tomography(imat,irecord,4) = c14_tomo
-          c_tomography(imat,irecord,5) = c15_tomo
-          c_tomography(imat,irecord,6) = c16_tomo
-          c_tomography(imat,irecord,7) = c22_tomo
-          c_tomography(imat,irecord,8) = c23_tomo
-          c_tomography(imat,irecord,9) = c24_tomo
-          c_tomography(imat,irecord,10) = c25_tomo
-          c_tomography(imat,irecord,11) = c26_tomo
-          c_tomography(imat,irecord,12) = c33_tomo
-          c_tomography(imat,irecord,13) = c34_tomo
-          c_tomography(imat,irecord,14) = c35_tomo
-          c_tomography(imat,irecord,15) = c36_tomo
-          c_tomography(imat,irecord,16) = c44_tomo
-          c_tomography(imat,irecord,17) = c45_tomo
-          c_tomography(imat,irecord,18) = c46_tomo
-          c_tomography(imat,irecord,19) = c55_tomo
-          c_tomography(imat,irecord,20) = c56_tomo
-          c_tomography(imat,irecord,21) = c66_tomo
+          c_tomography(imat,irecord,:) = (/ c11_tomo, c12_tomo, c13_tomo, c14_tomo, c15_tomo, c16_tomo, &
+                                            c22_tomo, c23_tomo, c24_tomo, c25_tomo, c26_tomo, &
+                                            c33_tomo, c34_tomo, c35_tomo, c36_tomo, &
+                                            c44_tomo, c45_tomo, c46_tomo, &
+                                            c55_tomo, c56_tomo, &
+                                            c66_tomo /)
 
           rho_tomography(imat,irecord) = rho_tomo
           z_tomography(imat,irecord) = z_tomo
@@ -826,7 +781,7 @@ end subroutine init_tomography_files
   logical,intent(out) :: has_tomo_value
 
   ! local parameters
-  integer :: ier,i
+  integer :: ier
   integer :: ix,iy,iz,imat
   integer :: p0,p1,p2,p3,p4,p5,p6,p7
 
@@ -847,7 +802,7 @@ end subroutine init_tomography_files
   real(kind=CUSTOM_REAL) :: L_val
 
   ! anisotropy
-  real(kind=CUSTOM_REAL) :: c1,c2,c3,c4,c5,c6,c7,c8
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: c1,c2,c3,c4,c5,c6,c7,c8
   real(kind=CUSTOM_REAL), dimension(:), allocatable :: c_final
 
   ! initializes flag
@@ -1014,18 +969,16 @@ end subroutine init_tomography_files
     if (ier /= 0) call exit_MPI_without_rank('error allocating array 905X')
     if (ier /= 0) call exit_MPI(myrank_tomo,'not enough memory to allocate interpolated anisotropy parameters array')
 
-    do i = 1,21
-      c1 = c_tomography(imat,p0+1,i)
-      c2 = c_tomography(imat,p1+1,i)
-      c3 = c_tomography(imat,p2+1,i)
-      c4 = c_tomography(imat,p3+1,i)
-      c5 = c_tomography(imat,p4+1,i)
-      c6 = c_tomography(imat,p5+1,i)
-      c7 = c_tomography(imat,p6+1,i)
-      c8 = c_tomography(imat,p7+1,i)
-      ! use trilinear interpolation in cell to define Vp
-      c_final(i) = interpolate_trilinear(c1,c2,c3,c4,c5,c6,c7,c8)
-    enddo
+    c1 = c_tomography(imat,p0+1,:)
+    c2 = c_tomography(imat,p1+1,:)
+    c3 = c_tomography(imat,p2+1,:)
+    c4 = c_tomography(imat,p3+1,:)
+    c5 = c_tomography(imat,p4+1,:)
+    c6 = c_tomography(imat,p5+1,:)
+    c7 = c_tomography(imat,p6+1,:)
+    c8 = c_tomography(imat,p7+1,:)
+    ! use trilinear interpolation in cell to define C_ij
+    c_final = interpolate_trilinear_array(c1,c2,c3,c4,c5,c6,c7,c8)
 
     c11 = c_final(1)
     c12 = c_final(2)
@@ -1166,7 +1119,7 @@ end subroutine init_tomography_files
   implicit none
 
   real(kind=CUSTOM_REAL) :: interpolate_trilinear
-  real(kind=CUSTOM_REAL),intent(in) :: val1,val2,val3,val4,val5,val6,val7,val8
+  real(kind=CUSTOM_REAL), intent(in) :: val1,val2,val3,val4,val5,val6,val7,val8
 
   ! note: we use gamma factors from parent routine (with 'contains' we can still use the scope of the parent routine).
   !       gamma parameters are global entities here, and used for briefty of the calling routine command,
@@ -1184,6 +1137,33 @@ end subroutine init_tomography_files
          val8 * (1.d0-gamma_interp_x) * gamma_interp_y        * gamma_interp_z4
 
   end function interpolate_trilinear
+
+  function interpolate_trilinear_array(val1,val2,val3,val4,val5,val6,val7,val8)
+
+  use constants, only: CUSTOM_REAL
+
+  implicit none
+
+  real(kind=CUSTOM_REAL), dimension(21) :: interpolate_trilinear_array
+  real(kind=CUSTOM_REAL), intent(in), dimension(:), allocatable :: val1,val2,val3,val4,val5,val6,val7,val8
+
+  ! note: we use gamma factors from parent routine (with 'contains' we can still
+  ! use the scope of the parent routine).
+  !       gamma parameters are global entities here, and used for briefty of the
+  !       calling routine command,
+  !       just to be aware...
+
+  ! interpolation rule
+  interpolate_trilinear_array = val1(:) * (1.d0-gamma_interp_x) * (1.d0-gamma_interp_y) * (1.d0-gamma_interp_z1) + &
+                                val2(:) * gamma_interp_x        * (1.d0-gamma_interp_y) * (1.d0-gamma_interp_z2) + &
+                                val3(:) * gamma_interp_x        * gamma_interp_y        * (1.d0-gamma_interp_z3) + &
+                                val4(:) * (1.d0-gamma_interp_x) * gamma_interp_y        * (1.d0-gamma_interp_z4) + &
+                                val5(:) * (1.d0-gamma_interp_x) * (1.d0-gamma_interp_y) * gamma_interp_z1 + &
+                                val6(:) * gamma_interp_x        * (1.d0-gamma_interp_y) * gamma_interp_z2 + &
+                                val7(:) * gamma_interp_x        * gamma_interp_y        * gamma_interp_z3 + &
+                                val8(:) * (1.d0-gamma_interp_x) * gamma_interp_y        * gamma_interp_z4
+
+  end function interpolate_trilinear_array
 
   end subroutine model_tomography
 


### PR DESCRIPTION
Used arrays instead of loops and repetitive statements. This has the following advantages -
1. May potentially speed up reading of large anisotropic tomographic models.
2. Simplifies the coding.
3. Makes the code more readable.