### PR TITLE
Minor updates to user manual and slurm scripts

### DIFF
--- a/doc/USER_MANUAL/04_creating_databases.tex
+++ b/doc/USER_MANUAL/04_creating_databases.tex
@@ -299,9 +299,6 @@ source time function.
 When using this option, by default the code can locate the force source
 anywhere between mesh points in order to honor its exact location; this
 is more precise than using the closest GLL mesh point, but it is also a bit slower.
-If needed, you can change that default behavior and force the code to use the closest
-GLL mesh point instead by setting flag \texttt{USE\_BEST\_LOCATION} to \texttt{.false.} instead of \texttt{.true.} in file
-\texttt{setup/constants.h} and recompiling the code.
 \item [{\texttt{USE\_RICKER\_TIME\_FUNCTION}}] Turn this flag on to use
 a Ricker source time function, i.e., the second derivative of a Gaussian, instead of the source time functions
 set by default to represent a (tilted) \texttt{FORCESOLUTION} force

--- a/doc/USER_MANUAL/07_adjoint_simulations.tex
+++ b/doc/USER_MANUAL/07_adjoint_simulations.tex
@@ -202,8 +202,8 @@ system. This is done by setting \texttt{ANISOTROPIC\_KL} \texttt{=}
 The definition of the parameters $C_{IJ}$ in terms of the corresponding
 components $c_{ijkl},ijkl,i,j,k,l=1,2,3$ of the elastic tensor in
 cartesian coordinates follows \citet{ChTr07}. The 21 anisotropic
-kernels are saved in the \texttt{LOCAL\_PATH} in one file with the
-name of \texttt{proc??????\_cijkl\_kernel.bin} (with \texttt{proc??????}
+kernels are saved in the \texttt{LOCAL\_PATH} as 21 files with names 
+\texttt{proc??????\_c??\_kernel.bin} (with \texttt{proc??????}
 the processor number). The output kernels correspond to absolute perturbations
 $\delta C_{IJ}$ of the elastic parameters and their unit is in $s/GPa/km^{3}$.
 For consistency, the output density kernels with this option turned

--- a/doc/USER_MANUAL/14_post_processing.tex
+++ b/doc/USER_MANUAL/14_post_processing.tex
@@ -139,22 +139,7 @@ written out in binary format.
 to have only the main process writing out seismograms. This can
 be useful on a cluster, where only the main process node has access
 to the output directory.
-\item [{\texttt{USE\_OUTPUT\_FILES\_PATH}}] Set to \texttt{.false.} to
-have the seismograms output to \texttt{LOCAL\_PATH} directory specified
-in the main parameter file \texttt{DATA/Par\_file}. In this case,
-you could collect the synthetics onto the frontend using the \texttt{collect\_seismo\_lsf\_multi.pl}
-script located in the \texttt{utils/Cluster/lsf/} directory. The usage
-of the script would be e.g.:
-
-\begin{verbatim}
-collect_seismo.pl machines DATA/Par_file
-\end{verbatim}
-
 \end{description}
-
-where \texttt{machines} is a file containing the node names and \texttt{DATA/Par\_file}
-the parameter file used to extract the \texttt{LOCAL\_PATH} directory
-used for the simulation.
 
 
 \section{Clean Local Database}

--- a/utils/Cluster/slurm/go_generate_databases_slurm.bash
+++ b/utils/Cluster/slurm/go_generate_databases_slurm.bash
@@ -21,7 +21,7 @@ MODEL=`grep ^MODEL DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
 mkdir -p OUTPUT_FILES
 
 # backup tomography files if any for this simulation
-if [[ $MODEL -eq tomo ]]; then
+if [ $MODEL = tomo ]; then
     cp -r DATA/tomo_files OUTPUT_FILES/
 fi
 

--- a/utils/Cluster/slurm/go_solver_slurm.bash
+++ b/utils/Cluster/slurm/go_solver_slurm.bash
@@ -28,13 +28,13 @@ cp DATA/Par_file OUTPUT_FILES/
 cp DATA/STATIONS OUTPUT_FILES/
 cp setup/constants.h OUTPUT_FILES/
 
-if [[ $FORCESOLUTION ]]; then
+if [ $FORCESOLUTION = .true. ]; then
     cp DATA/FORCESOLUTION OUTPUT_FILES/
 else
     cp DATA/CMTSOLUTION OUTPUT_FILES/
 fi
 
-if [[ $EXTERNAL_STF ]]; then
+if [ $EXTERNAL_STF = .true. ]; then
     cp source_time_function.txt OUTPUT_FILES/
 fi
 


### PR DESCRIPTION
User manual -
- Removed some discontinued Par_file parameters/flags.
- Updated note that general anisotropic parameters' kernels are being written into 21 separate files instead of 1 file.

Slurm scripts -
- Corrected syntax for 'if' statements. 