### PR TITLE
Updates to user manual, slurm scripts, model reading, and adjoint kernels' computation

### DIFF
--- a/doc/USER_MANUAL/04_creating_databases.tex
+++ b/doc/USER_MANUAL/04_creating_databases.tex
@@ -299,9 +299,6 @@ source time function.
 When using this option, by default the code can locate the force source
 anywhere between mesh points in order to honor its exact location; this
 is more precise than using the closest GLL mesh point, but it is also a bit slower.
-If needed, you can change that default behavior and force the code to use the closest
-GLL mesh point instead by setting flag \texttt{USE\_BEST\_LOCATION} to \texttt{.false.} instead of \texttt{.true.} in file
-\texttt{setup/constants.h} and recompiling the code.
 \item [{\texttt{USE\_RICKER\_TIME\_FUNCTION}}] Turn this flag on to use
 a Ricker source time function, i.e., the second derivative of a Gaussian, instead of the source time functions
 set by default to represent a (tilted) \texttt{FORCESOLUTION} force

--- a/doc/USER_MANUAL/07_adjoint_simulations.tex
+++ b/doc/USER_MANUAL/07_adjoint_simulations.tex
@@ -202,8 +202,8 @@ system. This is done by setting \texttt{ANISOTROPIC\_KL} \texttt{=}
 The definition of the parameters $C_{IJ}$ in terms of the corresponding
 components $c_{ijkl},ijkl,i,j,k,l=1,2,3$ of the elastic tensor in
 cartesian coordinates follows \citet{ChTr07}. The 21 anisotropic
-kernels are saved in the \texttt{LOCAL\_PATH} in one file with the
-name of \texttt{proc??????\_cijkl\_kernel.bin} (with \texttt{proc??????}
+kernels are saved in the \texttt{LOCAL\_PATH} as 21 files with names 
+\texttt{proc??????\_c??\_kernel.bin} (with \texttt{proc??????}
 the processor number). The output kernels correspond to absolute perturbations
 $\delta C_{IJ}$ of the elastic parameters and their unit is in $s/GPa/km^{3}$.
 For consistency, the output density kernels with this option turned

--- a/doc/USER_MANUAL/14_post_processing.tex
+++ b/doc/USER_MANUAL/14_post_processing.tex
@@ -139,22 +139,7 @@ written out in binary format.
 to have only the main process writing out seismograms. This can
 be useful on a cluster, where only the main process node has access
 to the output directory.
-\item [{\texttt{USE\_OUTPUT\_FILES\_PATH}}] Set to \texttt{.false.} to
-have the seismograms output to \texttt{LOCAL\_PATH} directory specified
-in the main parameter file \texttt{DATA/Par\_file}. In this case,
-you could collect the synthetics onto the frontend using the \texttt{collect\_seismo\_lsf\_multi.pl}
-script located in the \texttt{utils/Cluster/lsf/} directory. The usage
-of the script would be e.g.:
-
-\begin{verbatim}
-collect_seismo.pl machines DATA/Par_file
-\end{verbatim}
-
 \end{description}
-
-where \texttt{machines} is a file containing the node names and \texttt{DATA/Par\_file}
-the parameter file used to extract the \texttt{LOCAL\_PATH} directory
-used for the simulation.
 
 
 \section{Clean Local Database}

--- a/src/generate_databases/model_default.f90
+++ b/src/generate_databases/model_default.f90
@@ -92,6 +92,28 @@
   kappa_fr = 0._CUSTOM_REAL
   mu_fr = 0._CUSTOM_REAL
 
+  c11 = 0._CUSTOM_REAL
+  c12 = 0._CUSTOM_REAL
+  c13 = 0._CUSTOM_REAL
+  c14 = 0._CUSTOM_REAL
+  c15 = 0._CUSTOM_REAL
+  c16 = 0._CUSTOM_REAL
+  c22 = 0._CUSTOM_REAL
+  c23 = 0._CUSTOM_REAL
+  c24 = 0._CUSTOM_REAL
+  c25 = 0._CUSTOM_REAL
+  c26 = 0._CUSTOM_REAL
+  c33 = 0._CUSTOM_REAL
+  c34 = 0._CUSTOM_REAL
+  c35 = 0._CUSTOM_REAL
+  c36 = 0._CUSTOM_REAL
+  c44 = 0._CUSTOM_REAL
+  c45 = 0._CUSTOM_REAL
+  c46 = 0._CUSTOM_REAL
+  c55 = 0._CUSTOM_REAL
+  c56 = 0._CUSTOM_REAL
+  c66 = 0._CUSTOM_REAL
+
   ! check if the material is known or unknown
   if (imaterial_id > 0) then
     ! gets velocity model as specified by (cubit) mesh files for elastic & acoustic

--- a/src/specfem3D/save_adjoint_kernels.f90
+++ b/src/specfem3D/save_adjoint_kernels.f90
@@ -276,7 +276,7 @@
   subroutine save_kernels_elastic_iso()
 
   use specfem_par, only: CUSTOM_REAL,NSPEC_AB,NSPEC_ADJOINT,ibool,mustore,kappastore, &
-                         FOUR_THIRDS,ADIOS_FOR_KERNELS,IOUT,prname, &
+                         ADIOS_FOR_KERNELS,IOUT,prname, &
                          myrank,IMAIN
   use specfem_par_elastic
 
@@ -325,7 +325,7 @@
             rho_kl(i,j,k,ispec) = - rhol * rho_kl(i,j,k,ispec)
 
             ! shear modulus kernel
-            mu_kl(i,j,k,ispec) = - 2.0_CUSTOM_REAL * mul * mu_kl(i,j,k,ispec)
+            mu_kl(i,j,k,ispec) = - 2.0 * mul * mu_kl(i,j,k,ispec)
 
             ! bulk modulus kernel
             kappa_kl(i,j,k,ispec) = - kappal * kappa_kl(i,j,k,ispec)
@@ -336,11 +336,11 @@
 
             ! vs kernel
             beta_kl(i,j,k,ispec) = &
-            2.0_CUSTOM_REAL * ( mu_kl(i,j,k,ispec) - FOUR_THIRDS * mul / kappal * kappa_kl(i,j,k,ispec) )
+            2.0 * ( mu_kl(i,j,k,ispec) - 4.0 / 3.0 * mul / kappal * kappa_kl(i,j,k,ispec) )
 
             ! vp kernel
             alpha_kl(i,j,k,ispec) = &
-            2.0_CUSTOM_REAL * ( 1.0_CUSTOM_REAL + FOUR_THIRDS * mul / kappal ) * kappa_kl(i,j,k,ispec)
+            2.0  * ( 1.0 + 4.0 / 3.0 * mul / kappal ) * kappa_kl(i,j,k,ispec)
 
           enddo
         enddo
@@ -420,7 +420,7 @@
   subroutine save_kernels_elastic_aniso()
 
   use specfem_par, only: CUSTOM_REAL,NSPEC_AB,NSPEC_ADJOINT,ibool,mustore,kappastore, &
-                         SAVE_TRANSVERSE_KL,FOUR_THIRDS, &
+                         SAVE_TRANSVERSE_KL, &
                          ADIOS_FOR_KERNELS,IOUT,prname, &
                          myrank,IMAIN, ANISOTROPY
   use specfem_par_elastic
@@ -526,19 +526,19 @@
                 L = c44store(i,j,k,ispec)
                 N = c66store(i,j,k,ispec)
                 F = c13store(i,j,k,ispec)
-                eta = N / (A - 2.0_CUSTOM_REAL * L)
+                eta = N / (A - 2.0 * L)
               else
                 ! Store local material values
                 mul = mustore(i,j,k,ispec)
                 kappal = kappastore(i,j,k,ispec)
 
                 ! Computes parameters for an isotropic model
-                A = kappal + FOUR_THIRDS * mul
+                A = kappal + 4.0 / 3.0 * mul
                 C = A
                 L = mul
                 N = mul
-                F = kappal - 2._CUSTOM_REAL/3._CUSTOM_REAL * mul
-                eta = 1._CUSTOM_REAL
+                F = kappal - 2.0 / 3.0 * mul
+                eta = 1.0
               endif
 
               ! note: cijkl_kl_local() is fully anisotropic C_ij kernel
@@ -563,11 +563,11 @@
               ! From the relations giving Cij in function of An
               ! Checked with Min Chen's results (routine build_cij)
 
-              an_kl(1) = cijkl_kl_local(1)+cijkl_kl_local(2)+cijkl_kl_local(7)    !A
-              an_kl(2) = cijkl_kl_local(12)                                       !C
-              an_kl(3) = -2*cijkl_kl_local(2)+cijkl_kl_local(21)                  !N
-              an_kl(4) = cijkl_kl_local(16)+cijkl_kl_local(19)                    !L
-              an_kl(5) = cijkl_kl_local(3)+cijkl_kl_local(8)                      !F
+              an_kl(1) = cijkl_kl_local(1) + cijkl_kl_local(2) + cijkl_kl_local(7)    !A
+              an_kl(2) = cijkl_kl_local(12)                                           !C
+              an_kl(3) = - 2.0 * cijkl_kl_local(2) + cijkl_kl_local(21)               !N
+              an_kl(4) = cijkl_kl_local(16) + cijkl_kl_local(19)                      !L
+              an_kl(5) = cijkl_kl_local(3) + cijkl_kl_local(8)                        !F
 
               ! for parameterization: ( alpha_v, alpha_h, beta_v, beta_h, eta, rho )
 

--- a/src/specfem3D/save_adjoint_kernels.f90
+++ b/src/specfem3D/save_adjoint_kernels.f90
@@ -526,7 +526,7 @@
                 L = c44store(i,j,k,ispec)
                 N = c66store(i,j,k,ispec)
                 F = c13store(i,j,k,ispec)
-                eta = N / (A - 2.0 * L)
+                eta = F / (A - 2.0 * L)
               else
                 ! Store local material values
                 mul = mustore(i,j,k,ispec)

--- a/utils/Cluster/slurm/go_combine_vol_data_slurm.bash
+++ b/utils/Cluster/slurm/go_combine_vol_data_slurm.bash
@@ -14,10 +14,10 @@ cd $SLURM_SUBMIT_DIR
 # script to combine vol data
 # read Par_file to get information about the run
 # compute total number of nodes needed
-NPROC=`grep NPROC DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+NPROC=`cat DATA/Par_file | egrep "^NPROC" | awk '{ print $3 }'`
 
 # path to database files for mesh (relative to bin/)
-LOCALPATH=`grep LOCAL_PATH DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+LOCALPATH=`cat DATA/Par_file | egrep "^LOCAL_PATH" | awk '{ print $3 }'`
 
 nmax=$(($NPROC-1))
 

--- a/utils/Cluster/slurm/go_decomposer_slurm.bash
+++ b/utils/Cluster/slurm/go_decomposer_slurm.bash
@@ -14,10 +14,10 @@ cd $SLURM_SUBMIT_DIR
 # script to decompose mesh
 # read Par_file to get information about the run
 # compute total number of partitions needed
-NPROC=`grep ^NPROC DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+NPROC=`cat DATA/Par_file | egrep "^NPROC" | awk '{ print $3 }'`
 
 mkdir -p OUTPUT_FILES
-LOCALPATH=`grep ^LOCAL_PATH DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+LOCALPATH=`cat DATA/Par_file | egrep "^LOCAL_PATH" | awk '{ print $3 }'`
 mkdir -p $LOCALPATH
 
 # USER: CHANGE MESH DIRECTORY

--- a/utils/Cluster/slurm/go_generate_databases_slurm.bash
+++ b/utils/Cluster/slurm/go_generate_databases_slurm.bash
@@ -21,7 +21,7 @@ MODEL=`grep ^MODEL DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
 mkdir -p OUTPUT_FILES
 
 # backup tomography files if any for this simulation
-if [[ $MODEL -eq tomo ]]; then
+if [ $MODEL = tomo ]; then
     cp -r DATA/tomo_files OUTPUT_FILES/
 fi
 

--- a/utils/Cluster/slurm/go_generate_databases_slurm.bash
+++ b/utils/Cluster/slurm/go_generate_databases_slurm.bash
@@ -14,14 +14,14 @@ cd $SLURM_SUBMIT_DIR
 # script to generate databases
 # read Par_file to get information about the run
 # compute total number of nodes needed
-NPROC=`grep ^NPROC DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+NPROC=`cat DATA/Par_file | egrep "^NPROC" | awk '{ print $3 }'`
 # check the type of model
-MODEL=`grep ^MODEL DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+MODEL=`cat DATA/Par_file | egrep "^MODEL" | awk '{ print $3 }'`
 
 mkdir -p OUTPUT_FILES
 
 # backup tomography files if any for this simulation
-if [ $MODEL = tomo ]; then
+if [[ "${MODEL}" == "tomo" ]]; then
     cp -r DATA/tomo_files OUTPUT_FILES/
 fi
 

--- a/utils/Cluster/slurm/go_mesher_slurm.bash
+++ b/utils/Cluster/slurm/go_mesher_slurm.bash
@@ -14,10 +14,10 @@ cd $SLURM_SUBMIT_DIR
 # script to make mesh internally
 # read Par_file to get information about the run
 # compute total number of nodes needed
-NPROC=`grep ^NPROC DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+NPROC=`cat DATA/Par_file | egrep "^NPROC" | awk '{ print $3 }'`
 
 mkdir -p OUTPUT_FILES
-LOCALPATH=`grep ^LOCAL_PATH DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+LOCALPATH=`cat DATA/Par_file | egrep "^LOCAL_PATH" | awk '{ print $3 }'`
 mkdir -p $LOCALPATH
 
 # backup files used for mesh generation

--- a/utils/Cluster/slurm/go_solver_slurm.bash
+++ b/utils/Cluster/slurm/go_solver_slurm.bash
@@ -14,11 +14,11 @@ cd $SLURM_SUBMIT_DIR
 # script to run the solver
 # read Par_file to get information about the run
 # compute total number of nodes needed
-NPROC=`grep ^NPROC DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+NPROC=`cat DATA/Par_file | egrep "^NPROC" | awk '{ print $3 }'`
 
-FORCESOLUTION=`grep ^USE_FORCE_POINT_SOURCE DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+FORCESOLUTION=`cat DATA/Par_file | egrep "^USE_FORCE_POINT_SOURCE" | awk '{ print $3 }'`
 
-EXTERNAL_STF=`grep ^USE_EXTERNAL_SOURCE_FILE DATA/Par_file | grep -v -E '^[[:space:]]*#' | cut -d = -f 2`
+EXTERNAL_STF=`cat DATA/Par_file | egrep "^USE_EXTERNAL_SOURCE_FILE" | awk '{ print $3 }'`
 
 mkdir -p OUTPUT_FILES
 
@@ -28,13 +28,13 @@ cp DATA/Par_file OUTPUT_FILES/
 cp DATA/STATIONS OUTPUT_FILES/
 cp setup/constants.h OUTPUT_FILES/
 
-if [ $FORCESOLUTION = .true. ]; then
+if [[ "${FORCESOLUTION}" == ".true." ]]; then
     cp DATA/FORCESOLUTION OUTPUT_FILES/
 else
     cp DATA/CMTSOLUTION OUTPUT_FILES/
 fi
 
-if [ $EXTERNAL_STF = .true. ]; then
+if [[ "${EXTERNAL_STF}" == ".true." ]]; then
     cp source_time_function.txt OUTPUT_FILES/
 fi
 

--- a/utils/Cluster/slurm/go_solver_slurm.bash
+++ b/utils/Cluster/slurm/go_solver_slurm.bash
@@ -28,13 +28,13 @@ cp DATA/Par_file OUTPUT_FILES/
 cp DATA/STATIONS OUTPUT_FILES/
 cp setup/constants.h OUTPUT_FILES/
 
-if [[ $FORCESOLUTION ]]; then
+if [ $FORCESOLUTION = .true. ]; then
     cp DATA/FORCESOLUTION OUTPUT_FILES/
 else
     cp DATA/CMTSOLUTION OUTPUT_FILES/
 fi
 
-if [[ $EXTERNAL_STF ]]; then
+if [ $EXTERNAL_STF = .true. ]; then
     cp source_time_function.txt OUTPUT_FILES/
 fi
 


### PR DESCRIPTION
This pull request contains the following updates -

1. User manual - removes obsolete parameters' descriptions
2. Slurm scripts - updates parameter reading from Par_file, and the 'if ' statements
3. Model reading -
    - initializes anisotropy variables in model_default.f90
    - updates array usage in reading anisotropic tomographic models
4. Adjoint kernels' computation -
    - consistent use of the 'type' of coefficients in the equations with better readability
    - correction for equation of 'eta' for transverse isotropic models