### PR TITLE
adds HDF5 support for movie outputs (shakemap, surface & volumetric movies)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
         # new:
         #echo "diff=$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )" >> $GITHUB_OUTPUT
         # no replacements needed
-        echo "diff=$( echo "$DIFF" )" >> $GITHUB_OUTPUT
+        echo "diff=\"$DIFF\"" >> $GITHUB_OUTPUT
 
     - name: Output changes
       run: echo "${{ steps.diff.outputs.diff }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,14 +29,14 @@ jobs:
           export DIFF=$( git diff --name-only ${{ github.event.before }} $GITHUB_SHA )
           echo "  diff between ${{ github.event.before }} and $GITHUB_SHA"
         fi
-        echo "$DIFF"
+        echo "***"; echo "$DIFF"; echo "***"
         # Escape newlines (replace \n with %0A)
         # deprecated:
         #echo "::set-output name=diff::$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )"
         # new:
         #echo "diff=$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )" >> $GITHUB_OUTPUT
         # no replacements needed
-        echo "diff=\"$DIFF\"" >> $GITHUB_OUTPUT
+        echo "diff=\"$DIFF\"" >> "$GITHUB_OUTPUT"
 
     - name: Output changes
       run: echo "${{ steps.diff.outputs.diff }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,9 +34,15 @@ jobs:
         # deprecated:
         #echo "::set-output name=diff::$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )"
         # new:
+        # replace new line with %0A - will result finding only one file with a very long name...
         #echo "diff=$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )" >> $GITHUB_OUTPUT
-        # no replacements needed
-        echo "diff=\"$DIFF\"" >> "$GITHUB_OUTPUT"
+        # doesn't work...
+        #echo "diff=\"$DIFF\"" >> "$GITHUB_OUTPUT"
+        # new multi-line format:
+        # (https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings)
+        echo "diff<<EOF" >> $GITHUB_OUTPUT
+        echo "$DIFF" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
 
     - name: Output changes
       run: echo "${{ steps.diff.outputs.diff }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,9 @@ jobs:
         # deprecated:
         #echo "::set-output name=diff::$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )"
         # new:
-        echo "diff=$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )" >> $GITHUB_OUTPUT
+        #echo "diff=$( echo "$DIFF" | sed ':a;N;$!ba;s/\n/%0A/g' )" >> $GITHUB_OUTPUT
+        # no replacements needed
+        echo "diff=$( echo "$DIFF" )" >> $GITHUB_OUTPUT
 
     - name: Output changes
       run: echo "${{ steps.diff.outputs.diff }}"

--- a/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ACOUSTIC/DATA/Par_file
+++ b/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ACOUSTIC/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ACOUSTIC_ELASTIC/DATA/Par_file
+++ b/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ACOUSTIC_ELASTIC/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ELASTIC/DATA/Par_file
+++ b/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ELASTIC/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_absorbing_CPML_5sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_absorbing_CPML_5sides/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_absorbing_CPML_6sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_absorbing_CPML_6sides/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_elastic_absorbing_CPML_5sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_elastic_absorbing_CPML_5sides/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_elastic_absorbing_CPML_6sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_elastic_absorbing_CPML_6sides/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_elastic_absorbing_CPML_5sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_elastic_absorbing_CPML_5sides/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_elastic_absorbing_CPML_6sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_elastic_absorbing_CPML_6sides/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/Gmsh_simple_box_hex27/DATA/Par_file
+++ b/EXAMPLES/Gmsh_simple_box_hex27/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/Gmsh_simple_lddrk/DATA/Par_file
+++ b/EXAMPLES/Gmsh_simple_lddrk/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/LTS_homogeneous_halfspace_HEX8/DATA/Par_file
+++ b/EXAMPLES/LTS_homogeneous_halfspace_HEX8/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/Mount_StHelens/DATA/Par_file
+++ b/EXAMPLES/Mount_StHelens/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/analytic_examples/analytic_solution_elastic/DATA/Par_file
+++ b/EXAMPLES/analytic_examples/analytic_solution_elastic/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/attenuation/viscoelastic/DATA/Par_file
+++ b/EXAMPLES/attenuation/viscoelastic/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/check_absolute_amplitude_of_force_source_seismograms/DATA/Par_file
+++ b/EXAMPLES/check_absolute_amplitude_of_force_source_seismograms/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/coffee_mug_with_fluid_inside/DATA/Par_file
+++ b/EXAMPLES/coffee_mug_with_fluid_inside/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/decompose_mesh_MPI/DATA/Par_file
+++ b/EXAMPLES/decompose_mesh_MPI/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/decompose_mesh_MPI_with_faults/DATA/Par_file
+++ b/EXAMPLES/decompose_mesh_MPI_with_faults/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/fault_examples/hete_fault_properties/DATA/Par_file
+++ b/EXAMPLES/fault_examples/hete_fault_properties/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/fault_examples/splay_faults/DATA/Par_file
+++ b/EXAMPLES/fault_examples/splay_faults/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/fault_examples/tpv102/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv102/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/fault_examples/tpv103/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv103/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/fault_examples/tpv15/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv15/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/fault_examples/tpv16/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv16/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/fault_examples/tpv5/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv5/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/homogeneous_acoustic/DATA/Par_file
+++ b/EXAMPLES/homogeneous_acoustic/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/homogeneous_halfspace_HEX27_elastic_no_absorbing/DATA/Par_file
+++ b/EXAMPLES/homogeneous_halfspace_HEX27_elastic_no_absorbing/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
+++ b/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/homogeneous_halfspace_HEX8_elastic_no_absorbing/DATA/Par_file
+++ b/EXAMPLES/homogeneous_halfspace_HEX8_elastic_no_absorbing/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/homogeneous_poroelastic/DATA/Par_file
+++ b/EXAMPLES/homogeneous_poroelastic/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/homogeneous_poroelastic/DATA/Par_file_coarse
+++ b/EXAMPLES/homogeneous_poroelastic/DATA/Par_file_coarse
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/inversion_examples/fwi_test_acoustic/DATA/Par_file
+++ b/EXAMPLES/inversion_examples/fwi_test_acoustic/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/layered_halfspace/DATA/Par_file
+++ b/EXAMPLES/layered_halfspace/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/meshfem3D_examples/cavity/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/cavity/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/meshfem3D_examples/cavity/DATA/Par_file.96procs
+++ b/EXAMPLES/meshfem3D_examples/cavity/DATA/Par_file.96procs
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/meshfem3D_examples/many_interfaces/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/many_interfaces/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/meshfem3D_examples/regular_element_mesh/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/regular_element_mesh/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/meshfem3D_examples/sep_bathymetry/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/sep_bathymetry/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/meshfem3D_examples/simple_model/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/simple_model/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/meshfem3D_examples/socal1D/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/socal1D/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/meshfem3D_examples/socal1D/example_utm/Par_file_utm
+++ b/EXAMPLES/meshfem3D_examples/socal1D/example_utm/Par_file_utm
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/noise_non_uniform/DATA/Par_file
+++ b/EXAMPLES/noise_non_uniform/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/noise_non_uniform/DATA/Par_file_step1
+++ b/EXAMPLES/noise_non_uniform/DATA/Par_file_step1
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/noise_non_uniform/DATA/Par_file_step2
+++ b/EXAMPLES/noise_non_uniform/DATA/Par_file_step2
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/noise_tomography/DATA/Par_file
+++ b/EXAMPLES/noise_tomography/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file
+++ b/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file_one_proc
+++ b/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file_one_proc
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file_several_proc
+++ b/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file_several_proc
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/oldstuff/small_example_please_do_not_remove_CURRENTLY_BROKEN_according_to_Vadim/create_data/DATA/Par_file
+++ b/EXAMPLES/oldstuff/small_example_please_do_not_remove_CURRENTLY_BROKEN_according_to_Vadim/create_data/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/oldstuff/small_example_please_do_not_remove_CURRENTLY_BROKEN_according_to_Vadim/fwi_fk/DATA/Par_file
+++ b/EXAMPLES/oldstuff/small_example_please_do_not_remove_CURRENTLY_BROKEN_according_to_Vadim/fwi_fk/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/seismoacoustic_bishop2022/DATA_FIG4/Par_file
+++ b/EXAMPLES/seismoacoustic_bishop2022/DATA_FIG4/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/seismoacoustic_bishop2022/DATA_FIG8/Par_file
+++ b/EXAMPLES/seismoacoustic_bishop2022/DATA_FIG8/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/sensitivity_kernels_liutromp2006/DATA/Par_file
+++ b/EXAMPLES/sensitivity_kernels_liutromp2006/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/small_adjoint_multiple_sources/DATA/Par_file
+++ b/EXAMPLES/small_adjoint_multiple_sources/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/small_example_coupling_FK_specfem/DATA/Par_file
+++ b/EXAMPLES/small_example_coupling_FK_specfem/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file_one_proc
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file_one_proc
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file_several_proc
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file_several_proc
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file_one_proc
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file_one_proc
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file_several_proc
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file_several_proc
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/tomographic_model/DATA/Par_file
+++ b/EXAMPLES/tomographic_model/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/waterlayered_halfspace/DATA/Par_file
+++ b/EXAMPLES/waterlayered_halfspace/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/EXAMPLES/waterlayered_poroelastic/DATA/Par_file
+++ b/EXAMPLES/waterlayered_poroelastic/DATA/Par_file
@@ -392,4 +392,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # HDF5 Database I/O
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
+HDF5_FOR_MOVIES                 = .false.
 

--- a/src/generate_databases/read_partition_files_hdf5.F90
+++ b/src/generate_databases/read_partition_files_hdf5.F90
@@ -170,8 +170,8 @@
   dsetname = "nnodes_loc"
   call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, nnodes_ext_mesh,(/myrank/),.true.)
 
-  !#TODO: io server
-  !n_control_node = nnodes_ext_mesh
+  ! stores number of mesh points in this slice for output in checkmesh.xmf
+  xdmf_mesh_nnodes = nnodes_ext_mesh
 
   ! open and read dataset nodes_coords
   dsetname = "nodes_coords"

--- a/src/generate_databases/save_arrays_solver_hdf5.F90
+++ b/src/generate_databases/save_arrays_solver_hdf5.F90
@@ -174,9 +174,16 @@
   call get_connectivity_for_movie(nspec_ab, ibool, spec_elm_conn_xdmf, sum(offset_nglob(0:myrank-1)))
 
   call gather_all_all_singlei(nspec_irregular,offset_nspec_irregular,NPROC) ! n spec in each proc
-  if (APPROXIMATE_OCEAN_LOAD) call gather_all_all_singlei(NGLOB_OCEAN,offset_nglob_ocean,NPROC)
-  if (POROELASTIC_SIMULATION) call gather_all_all_singlei(NSPEC_PORO,offset_nspecporo,NPROC)
-  if (PML_CONDITIONS) call gather_all_all_singlei(nspec_cpml,offset_nspeccpml,NPROC)
+
+  if (APPROXIMATE_OCEAN_LOAD) &
+    call gather_all_all_singlei(NGLOB_OCEAN,offset_nglob_ocean,NPROC)
+
+  if (POROELASTIC_SIMULATION) &
+    call gather_all_all_singlei(NSPEC_PORO,offset_nspecporo,NPROC)
+
+  if (PML_CONDITIONS) &
+    call gather_all_all_singlei(nspec_cpml,offset_nspeccpml,NPROC)
+
   if ((SIMULATION_TYPE == 1 .and. SAVE_FORWARD) .or. SIMULATION_TYPE == 3) then
     call gather_all_all_singlei(nglob_interface_PML_acoustic, &
                                 offset_nglob_interface_PML_acoustic,NPROC)
@@ -200,19 +207,17 @@
   call gather_all_all_singlei(num_interfaces_ext_mesh,offset_num_interfaces_ext_mesh,NPROC)
   call gather_all_all_singlei(max_nibool_interfaces_ext_mesh,offset_max_ni_bool_interfaces_ext_mesh,NPROC)
 
-  if (ELASTIC_SIMULATION .and. ANISOTROPY) call gather_all_all_singlei(nspec_aniso,offset_nspec_aniso,NPROC)
-  if (ACOUSTIC_SIMULATION) then
+  if (ELASTIC_SIMULATION .and. ANISOTROPY) &
+    call gather_all_all_singlei(nspec_aniso,offset_nspec_aniso,NPROC)
+
+  if (ACOUSTIC_SIMULATION) &
     call gather_all_all_singlei(num_phase_ispec_acoustic,offset_num_phase_ispec_acoustic,NPROC)
-  endif
 
-  if (ELASTIC_SIMULATION) then
+  if (ELASTIC_SIMULATION) &
     call gather_all_all_singlei(num_phase_ispec_elastic,offset_num_phase_ispec_elastic,NPROC)
-  endif
 
-  if (POROELASTIC_SIMULATION) then
-    call gather_all_all_singlei(num_phase_ispec_poroelastic, &
-                                offset_num_phase_ispec_poroelastic,NPROC)
-  endif
+  if (POROELASTIC_SIMULATION) &
+    call gather_all_all_singlei(num_phase_ispec_poroelastic,offset_num_phase_ispec_poroelastic,NPROC)
 
   if (USE_MESH_COLORING_GPU) then
     if (ACOUSTIC_SIMULATION) &
@@ -233,12 +238,18 @@
   ! offset arrays
   if (myrank == 0) then
     call h5_create_file(filename)
+
     call h5_write_dataset_1d_i_no_group("offset_nglob",offset_nglob)
     call h5_write_dataset_1d_i_no_group("offset_nspec",offset_nspec)
     call h5_write_dataset_1d_i_no_group("offset_nspec_irregular",offset_nspec_irregular)
-    if (APPROXIMATE_OCEAN_LOAD) call h5_write_dataset_1d_i_no_group("offset_nglob_ocean",offset_nglob_ocean)
-    if (POROELASTIC_SIMULATION) call h5_write_dataset_1d_i_no_group("offset_nspecporo",offset_nspecporo)
-    if (PML_CONDITIONS)         call h5_write_dataset_1d_i_no_group("offset_nspeccpml",offset_nspeccpml)
+
+    if (APPROXIMATE_OCEAN_LOAD) &
+      call h5_write_dataset_1d_i_no_group("offset_nglob_ocean",offset_nglob_ocean)
+    if (POROELASTIC_SIMULATION) &
+      call h5_write_dataset_1d_i_no_group("offset_nspecporo",offset_nspecporo)
+    if (PML_CONDITIONS) &
+      call h5_write_dataset_1d_i_no_group("offset_nspeccpml",offset_nspeccpml)
+
     if ((SIMULATION_TYPE == 1 .and. SAVE_FORWARD) .or. SIMULATION_TYPE == 3) then
       call h5_write_dataset_1d_i_no_group("offset_nglob_interface_PML_acoustic",offset_nglob_interface_PML_acoustic)
       call h5_write_dataset_1d_i_no_group("offset_nglob_interface_PML_elastic",offset_nglob_interface_PML_elastic)
@@ -258,23 +269,29 @@
     call h5_write_dataset_1d_i_no_group("offset_num_coupling_el_po_faces",offset_num_coupling_el_po_faces)
     call h5_write_dataset_1d_i_no_group("offset_num_interfaces_ext_mesh",offset_num_interfaces_ext_mesh)
 
-    if (ELASTIC_SIMULATION .and. ANISOTROPY) call h5_write_dataset_1d_i_no_group("offset_nspec_aniso",offset_nspec_aniso)
+    if (ELASTIC_SIMULATION .and. ANISOTROPY) &
+      call h5_write_dataset_1d_i_no_group("offset_nspec_aniso",offset_nspec_aniso)
+
     if (ACOUSTIC_SIMULATION) then
       if (sum(offset_num_phase_ispec_acoustic) > 0) &
         call h5_write_dataset_1d_i_no_group("offset_num_phase_ispec_acoustic",offset_num_phase_ispec_acoustic)
     endif
+
     if (ELASTIC_SIMULATION) then
       if (sum(offset_num_phase_ispec_elastic) > 0) &
         call h5_write_dataset_1d_i_no_group("offset_num_phase_ispec_elastic",offset_num_phase_ispec_elastic)
     endif
+
     if (POROELASTIC_SIMULATION) then
       if (sum(offset_num_phase_ispec_poroelastic) > 0) &
         call h5_write_dataset_1d_i_no_group("offset_num_phase_ispec_poroelastic",offset_num_phase_ispec_poroelastic)
     endif
+
     if (USE_MESH_COLORING_GPU) then
       if (ACOUSTIC_SIMULATION) call h5_write_dataset_1d_i_no_group("offset_num_colors_acoustic",offset_num_colors_acoustic)
       if (ELASTIC_SIMULATION)  call h5_write_dataset_1d_i_no_group("offset_num_colors_elastic",offset_num_colors_elastic)
     endif
+
     call h5_write_dataset_1d_i_no_group("offset_nspec_ab",offset_nspec_ab)
     call h5_write_dataset_1d_i_no_group("offset_nglob_ab",offset_nglob_ab)
 
@@ -326,6 +343,7 @@
       dset_name = "jacobianstore" ! 4 r (/0,0,0,offset_nspec_irregular=offset_nspec/)
       call h5_create_dataset_gen(dset_name,(/NGLLX,NGLLY,NGLLZ,sum(offset_nspec_irregular(:))/), 4, CUSTOM_REAL)
     else
+      ! dummy
       dset_name = "xixstore" ! 4 r  (/0,0,0,offset_nspec_irregular=offset_nspec/)
       call h5_create_dataset_gen(dset_name,(/1,1,1,1/), 4, CUSTOM_REAL)
       dset_name = "xiystore" ! 4 r  (/0,0,0,offset_nspec_irregular=offset_nspec/)
@@ -379,12 +397,13 @@
         dset_name = "rmass_ocean_load" ! 1 r (/offset_nglob_ocean/)
         call h5_create_dataset_gen(dset_name,(/sum(offset_nglob_ocean(:))/), 1, CUSTOM_REAL)
       endif
+
       !pll Stacey
       dset_name = "rho_vp" ! 4 r (/0,0,0,offset_nspec/)
       call h5_create_dataset_gen(dset_name,(/NGLLX,NGLLY,NGLLZ,sum(offset_nspec(:))/), 4, CUSTOM_REAL)
       dset_name = "rho_vs" ! 4 r (/0,0,0,offset_nspec/)
       call h5_create_dataset_gen(dset_name,(/NGLLX,NGLLY,NGLLZ,sum(offset_nspec(:))/), 4, CUSTOM_REAL)
-   endif
+    endif
 
     ! poroelastic
     if (POROELASTIC_SIMULATION) then
@@ -410,7 +429,7 @@
       call h5_create_dataset_gen(dset_name,(/NGLLX,NGLLY,NGLLZ,sum(offset_nspecporo(:))/), 4, CUSTOM_REAL)
       dset_name = "rho_vsI" ! 4 r (/0,0,0,offset_nspecporo/)
       call h5_create_dataset_gen(dset_name,(/NGLLX,NGLLY,NGLLZ,sum(offset_nspecporo(:))/), 4, CUSTOM_REAL)
-   endif
+    endif
 
     ! C-PML absorbing boundary conditions
     if (PML_CONDITIONS) then
@@ -472,7 +491,7 @@
           endif
         endif
       endif
-    endif
+    endif   ! PML
 
     ! absorbing boundary surface
     dset_name = "num_abs_boundary_faces" ! 1 i (/myrank/)
@@ -497,13 +516,14 @@
           call h5_create_dataset_gen(dset_name, (/sum(offset_nglob_xy(:))/),1,CUSTOM_REAL)
           dset_name = "rmassz" ! 1 r (/offset_nglob_xy/)
           call h5_create_dataset_gen(dset_name, (/sum(offset_nglob_xy(:))/),1,CUSTOM_REAL)
-       endif
+        endif
         if (ACOUSTIC_SIMULATION) then
           dset_name = "rmassz_acoustic" ! 1 r (/offset_nglob_xy/)
           call h5_create_dataset_gen(dset_name, (/sum(offset_nglob_xy(:))/),1,CUSTOM_REAL)
         endif
       endif
     else
+      ! dummy
       dset_name = "abs_boundary_ispec" ! 1 i (/myrank/)
       call h5_create_dataset_gen(dset_name,(/NPROC/), 1, 1)
       dset_name = "abs_boundary_ijk" ! 3 i (/0,0,myrank/)
@@ -542,18 +562,31 @@
     call h5_create_dataset_gen(dset_name,(/NPROC/), 1, 1)
     dset_name = "NSPEC2D_TOP" ! 1 i (/myrank/)
     call h5_create_dataset_gen(dset_name,(/NPROC/), 1, 1)
-    dset_name = "ibelm_xmin" ! 1 i (/offset_nspec2D_xmin/)
-    call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_xmin(:))/), 1, 1)
-    dset_name = "ibelm_xmax" ! 1 i (/offset_nspec2D_xmax/)
-    call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_xmax(:))/), 1, 1)
-    dset_name = "ibelm_ymin" ! 1 i (/offset_nspec2D_ymin/)
-    call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_ymin(:))/), 1, 1)
-    dset_name = "ibelm_ymax" ! 1 i (/offset_nspec2D_ymax/)
-    call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_ymax(:))/), 1, 1)
-    dset_name = "ibelm_bottom" ! 1 i (/offset_nspec2D_bottom_ext/)
-    call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_bottom_ext(:))/), 1, 1)
-    dset_name = "ibelm_top" ! 1 i (/offset_nspec2D_top_ext/)
-    call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_top_ext(:))/), 1, 1)
+
+    if (sum(offset_nspec2D_xmin) > 0) then
+      dset_name = "ibelm_xmin" ! 1 i (/offset_nspec2D_xmin/)
+      call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_xmin(:))/), 1, 1)
+    endif
+    if (sum(offset_nspec2D_xmax) > 0) then
+      dset_name = "ibelm_xmax" ! 1 i (/offset_nspec2D_xmax/)
+      call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_xmax(:))/), 1, 1)
+    endif
+    if (sum(offset_nspec2D_ymin) > 0) then
+      dset_name = "ibelm_ymin" ! 1 i (/offset_nspec2D_ymin/)
+      call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_ymin(:))/), 1, 1)
+    endif
+    if (sum(offset_nspec2D_ymax) > 0) then
+      dset_name = "ibelm_ymax" ! 1 i (/offset_nspec2D_ymax/)
+      call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_ymax(:))/), 1, 1)
+    endif
+    if (sum(offset_nspec2D_bottom_ext) > 0) then
+      dset_name = "ibelm_bottom" ! 1 i (/offset_nspec2D_bottom_ext/)
+      call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_bottom_ext(:))/), 1, 1)
+    endif
+    if (sum(offset_nspec2D_top_ext) > 0) then
+      dset_name = "ibelm_top" ! 1 i (/offset_nspec2D_top_ext/)
+      call h5_create_dataset_gen(dset_name,(/sum(offset_nspec2D_top_ext(:))/), 1, 1)
+    endif
 
     ! free surface
     dset_name = "num_free_surface_faces" ! 1 i (/myrank/)
@@ -1070,22 +1103,36 @@
   call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/nspec2D_bottom/), (/myrank/),if_col)
   dset_name = "NSPEC2D_TOP" ! 1 i (/myrank/)
   call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/nspec2D_top/), (/myrank/),if_col)
-  dset_name = "ibelm_xmin" ! 1 i (/offset_nspec2D_xmin/)
-  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),if_col)
-  dset_name = "ibelm_xmax" ! 1 i (/offset_nspec2D_xmax/)
-  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),if_col)
-  dset_name = "ibelm_ymin" ! 1 i (/offset_nspec2D_ymin/)
-  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),if_col)
-  dset_name = "ibelm_ymax" ! 1 i (/offset_nspec2D_ymax/)
-  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),if_col)
-  dset_name = "ibelm_bottom" ! 1 i (/offset_nspec2D_bottom_ext/)
-  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),if_col)
-  dset_name = "ibelm_top" ! 1 i (/offset_nspec2D_top_ext/)
-  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),if_col)
+
+  if (sum(offset_nspec2D_xmin) > 0) then
+    dset_name = "ibelm_xmin" ! 1 i (/offset_nspec2D_xmin/)
+    call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),if_col)
+  endif
+  if (sum(offset_nspec2D_xmax) > 0) then
+    dset_name = "ibelm_xmax" ! 1 i (/offset_nspec2D_xmax/)
+    call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),if_col)
+  endif
+  if (sum(offset_nspec2D_ymin) > 0) then
+    dset_name = "ibelm_ymin" ! 1 i (/offset_nspec2D_ymin/)
+    call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),if_col)
+  endif
+  if (sum(offset_nspec2D_ymax) > 0) then
+    dset_name = "ibelm_ymax" ! 1 i (/offset_nspec2D_ymax/)
+    call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),if_col)
+  endif
+  if (sum(offset_nspec2D_bottom_ext) > 0) then
+    dset_name = "ibelm_bottom" ! 1 i (/offset_nspec2D_bottom_ext/)
+    call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),if_col)
+  endif
+  if (sum(offset_nspec2D_top_ext) > 0) then
+    dset_name = "ibelm_top" ! 1 i (/offset_nspec2D_top_ext/)
+    call h5_write_dataset_1d_i_collect_hyperslab(dset_name, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),if_col)
+  endif
 
   ! free surface
   dset_name = "num_free_surface_faces" ! 1 i (/myrank/)
   call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/num_free_surface_faces/), (/myrank/),if_col)
+
   if (sum(offset_num_free_surface_faces) > 0) then
     dset_name = "free_surface_ispec" ! 1 i (/offset_num_free_surface_faces/)
     call h5_write_dataset_1d_i_collect_hyperslab(dset_name, free_surface_ispec, &
@@ -1112,8 +1159,8 @@
 
   ! acoustic-elastic coupling surface
   dset_name = "num_coupling_ac_el_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/num_coupling_ac_el_faces/), &
-              (/myrank/),if_col)
+  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/num_coupling_ac_el_faces/), (/myrank/),if_col)
+
   if (sum(offset_num_coupling_ac_el_faces) > 0) then
     dset_name = "coupling_ac_el_ispec" ! 1 i (/offset_num_coupling_ac_el_faces/)
     call h5_write_dataset_1d_i_collect_hyperslab(dset_name, coupling_ac_el_ispec, &
@@ -1140,8 +1187,8 @@
 
   ! acoustic-poroelastic coupling surface
   dset_name = "num_coupling_ac_po_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/num_coupling_ac_po_faces/), &
-          (/myrank/),if_col)
+  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/num_coupling_ac_po_faces/), (/myrank/),if_col)
+
   if (sum(offset_num_coupling_ac_po_faces) > 0) then
     dset_name = "coupling_ac_po_ispec" ! 1 i (/offset_num_coupling_ac_po_faces/)
     call h5_write_dataset_1d_i_collect_hyperslab(dset_name, coupling_ac_po_ispec, &
@@ -1167,8 +1214,8 @@
 
   ! elastic-poroelastic coupling surface
   dset_name = "num_coupling_el_po_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/num_coupling_el_po_faces/), &
-            (/myrank/),if_col)
+  call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/num_coupling_el_po_faces/), (/myrank/),if_col)
+
   if (sum(offset_num_coupling_el_po_faces) > 0) then
     dset_name = "coupling_el_po_ispec" ! 1 i (/offset_num_coupling_el_po_faces/)
     call h5_write_dataset_1d_i_collect_hyperslab(dset_name, coupling_el_po_ispec, &
@@ -1205,6 +1252,7 @@
 
   dset_name = "num_interfaces_ext_mesh" ! 1 i (/myrank/)
   call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/num_interfaces_ext_mesh/), (/myrank/),if_col)
+
   if (sum(offset_num_interfaces_ext_mesh) > 0) then
     dset_name = "max_nibool_interfaces_ext_mesh" ! 1 i (/myrank/)
     call h5_write_dataset_1d_i_collect_hyperslab(dset_name, (/max_nibool_interfaces_ext_mesh/), (/myrank/),if_col)

--- a/src/inverse_problem_for_model/rules.mk
+++ b/src/inverse_problem_for_model/rules.mk
@@ -192,6 +192,7 @@ inverse_problem_for_model_OBJECTS += \
 	$O/update_displacement_scheme.spec.o \
 	$O/update_displacement_LDDRK.spec.o \
 	$O/write_movie_output.spec.o \
+	$O/write_movie_output_HDF5.spec_hdf5.o \
 	$O/write_output_ASCII_or_binary.spec.o \
 	$O/write_output_HDF5.spec_hdf5.o \
 	$O/write_output_SU.spec.o \

--- a/src/meshfem3D/create_CPML_regions.f90
+++ b/src/meshfem3D/create_CPML_regions.f90
@@ -53,7 +53,7 @@
 
   logical, dimension(:), allocatable :: is_X_CPML,is_Y_CPML,is_Z_CPML
 
-  integer :: nspec_CPML_total
+  integer :: nspec_CPML_total,nspec_total
   integer :: i1,i2,i3,i4,i5,i6,i7,i8
   integer :: ispec,ispec_CPML
   integer :: ier
@@ -229,13 +229,18 @@
   enddo
 
   ! outputs total number of CPML elements
+  nspec_total = 0
+  call sum_all_i(nspec,nspec_total)
+
   nspec_CPML_total = 0
   call sum_all_i(nspec_CPML,nspec_CPML_total)
+
+  call bcast_all_singlei(nspec_total)
   call bcast_all_singlei(nspec_CPML_total)
 
   if (myrank == 0) then
     write(IMAIN,*) '  Created a total of ',nspec_CPML_total,' unique CPML elements'
-    write(IMAIN,*)'   (i.e., ',100.*nspec_CPML/real(nspec),'% of the mesh)'
+    write(IMAIN,*)'   (i.e., ',100. * nspec_CPML_total / real(nspec_total),'% of the mesh)'
     write(IMAIN,*)
   endif
 

--- a/src/shared/parallel.f90
+++ b/src/shared/parallel.f90
@@ -120,12 +120,12 @@ end module my_mpi
 
   integer :: ier
 
-! close sub-communicators if needed, if running more than one earthquake from the same job
+  ! close sub-communicators if needed, if running more than one earthquake from the same job
   call world_unsplit()
 
   call MPI_BARRIER(MPI_COMM_WORLD,ier)
 
-! stop all the MPI processes, and exit
+  ! stop all the MPI processes, and exit
   call MPI_FINALIZE(ier)
   if (ier /= 0) stop 'Error finalizing MPI'
 

--- a/src/shared/shared_par.F90
+++ b/src/shared/shared_par.F90
@@ -172,15 +172,19 @@ end module constants
   logical :: ADIOS_FOR_DATABASES, ADIOS_FOR_MESH, ADIOS_FOR_FORWARD_ARRAYS, ADIOS_FOR_KERNELS, ADIOS_FOR_UNDO_ATTENUATION
 
   ! HDF5 file i/o
-  logical :: HDF5_ENABLED = .false.           ! for all databases i/o in hdf5
+  logical :: HDF5_ENABLED = .false.              ! for all databases i/o in hdf5
+  logical :: HDF5_FOR_MOVIES = .false.           ! for movies (shakemap, surface movies, volume movies)
 
   ! HDF5 seismogram output
   logical :: HDF5_FORMAT  = .false.           ! for seismograms output in hdf5
 
-  !#TODO: IO server
-  !! number of io dedicated nodes
-  !integer :: HDF5_IO_NNODE
-  !integer :: n_control_node
+  ! HDF5 IO server
+  ! number of io dedicated nodes
+  integer :: HDF5_IO_NNODES = 0
+
+  ! flag for io-dedicated/compute node.
+  logical :: IO_storage_task = .false.
+  logical :: IO_compute_task = .true.
 
   ! external code coupling (DSM, AxiSEM)
   logical :: COUPLE_WITH_INJECTION_TECHNIQUE

--- a/src/specfem3D/couple_with_injection.f90
+++ b/src/specfem3D/couple_with_injection.f90
@@ -65,7 +65,10 @@
   integer :: ier
   character(len=MAX_STRING_LEN) :: dsmname
 
-! for coupling with EXTERNAL CODE !! CD CD modify here
+  ! checks if anything to do
+  if (.not. IO_compute_task) return
+
+  ! for coupling with EXTERNAL CODE !! CD CD modify here
   if (COUPLE_WITH_INJECTION_TECHNIQUE .or. SAVE_RUN_BOUN_FOR_KH_INTEGRAL) then
     if (myrank == 0) then
       write(IMAIN,*)

--- a/src/specfem3D/detect_mesh_surfaces.f90
+++ b/src/specfem3D/detect_mesh_surfaces.f90
@@ -37,6 +37,9 @@
 
   integer :: ier
 
+  ! checks if anything to do
+  if (.not. IO_compute_task) return
+
   ! flag for any movie simulation
   if (MOVIE_SURFACE .or. CREATE_SHAKEMAP .or. MOVIE_VOLUME .or. PNM_IMAGE) then
     MOVIE_SIMULATION = .true.
@@ -130,6 +133,23 @@
       curl_x(:,:,:,:) = 0._CUSTOM_REAL
       curl_y(:,:,:,:) = 0._CUSTOM_REAL
       curl_z(:,:,:,:) = 0._CUSTOM_REAL
+
+      ! allocate array for global points
+      allocate(div_glob(NGLOB_AB),stat=ier)
+      if (ier /= 0) call exit_MPI_without_rank('error allocating array 2004')
+      div_glob(:) = 0._CUSTOM_REAL
+
+      allocate(valence_glob(NGLOB_AB), stat=ier)
+      if (ier /= 0) call exit_MPI_without_rank('error allocating array 2005')
+      if (ier /= 0) stop 'error allocating arrays for movie div and curl'
+      valence_glob(:) = 0
+    endif
+
+    ! acoustic only
+    if (.not. ELASTIC_SIMULATION .and. .not. POROELASTIC_SIMULATION) then
+      allocate(wavefield_pressure(NGLLX,NGLLY,NGLLZ,NSPEC_AB),stat=ier)
+      if (ier /= 0) call exit_MPI_without_rank('error allocating array 1731')
+      wavefield_pressure(:,:,:,:) = 0._CUSTOM_REAL
     endif
   endif
 

--- a/src/specfem3D/finalize_simulation.f90
+++ b/src/specfem3D/finalize_simulation.f90
@@ -38,6 +38,17 @@
 
   implicit none
 
+  !#TODO: hdf5 i/o server
+  ! checks if anything to do
+  !if (.not. IO_compute_task) then
+  !  ! finalizes MPI subgroup for intercommunication
+  !  if (HDF5_IO_NNODES > 0) then
+  !    call world_unsplit_inter()
+  !  endif
+  !  ! all done
+  !  return
+  !endif
+
   ! synchronize all processes, waits until all processes have written their seismograms
   call synchronize_all()
 
@@ -103,6 +114,12 @@
 
   ! synchronize all the processes to make sure everybody has finished
   call synchronize_all()
+
+  !#TODO: hdf5 i/o server
+  ! finalizes MPI subgroup for intercommunication
+  !if (HDF5_IO_NNODES > 0) then
+  !  call world_unsplit_inter()
+  !endif
 
   end subroutine finalize_simulation
 

--- a/src/specfem3D/initialize_simulation.F90
+++ b/src/specfem3D/initialize_simulation.F90
@@ -71,6 +71,17 @@
   BROADCAST_AFTER_READ = .true.
   call read_parameter_file(BROADCAST_AFTER_READ)
 
+  !#TODO: hdf5 i/o server
+  ! HDF5 separate nodes for i/o server
+  !if (HDF5_IO_NNODES > 0) call separate_compute_and_io_nodes()
+  ! checks if anything to do
+  !if (.not. IO_compute_task) then
+  !  ! i/o server synchronization
+  !  if (HDF5_IO_NNODES > 0) call synchronize_inter()
+  !  ! all done
+  !  return
+  !endif
+
   ! checks flags
   call initialize_simulation_check()
 
@@ -286,6 +297,10 @@
 
   ! synchronizes processes
   call synchronize_all()
+
+  !#TODO: hdf5 i/o server
+  ! i/o server synchronization
+  !if (HDF5_IO_NNODES > 0) call synchronize_inter()
 
   end subroutine initialize_simulation
 

--- a/src/specfem3D/iterate_time.F90
+++ b/src/specfem3D/iterate_time.F90
@@ -185,6 +185,24 @@
   ! get MPI starting
   time_start = wtime()
 
+  !#TODO: hdf5 i/o server
+  ! start io server
+  !if (HDF5_IO_NNODES > 0) then
+  !  if (IO_storage_task) then
+  !    call do_io_start_idle()
+  !  else
+  !    ! compute node passes necessary info to io node
+  !    call pass_info_to_io()
+  !  endif
+  !  ! checks if anything to do
+  !  if (.not. IO_compute_task) then
+  !    ! i/o server synchronization
+  !    call synchronize_inter()
+  !    ! all done
+  !    return
+  !  endif
+  !endif
+
   do it = it_begin,it_end
 
     ! simulation status output and stability check
@@ -328,6 +346,10 @@
     endif
   endif
 #endif
+
+  !#TODO: hdf5 i/o server
+  ! i/o server synchronization
+  !if (HDF5_IO_NNODES > 0) call synchronize_inter()
 
   end subroutine iterate_time
 

--- a/src/specfem3D/iterate_time_undoatt.F90
+++ b/src/specfem3D/iterate_time_undoatt.F90
@@ -264,6 +264,24 @@
   ! get MPI starting
   time_start = wtime()
 
+  !#TODO: hdf5 i/o server
+  ! start io server
+  !if (HDF5_IO_NNODES > 0) then
+  !  if (IO_storage_task) then
+  !    call do_io_start_idle()
+  !  else
+  !    ! compute node passes necessary info to io node
+  !    call pass_info_to_io()
+  !  endif
+  !  ! checks if anything to do
+  !  if (.not. IO_compute_task) then
+  !    ! i/o server synchronization
+  !    call synchronize_inter()
+  !    ! all done
+  !    return
+  !  endif
+  !endif
+
   ! *********************************************************
   ! ************* MAIN LOOP OVER THE TIME STEPS *************
   ! *********************************************************
@@ -600,5 +618,9 @@
     print *,'Error time increments: it_end = ',it_end,' and last it = ',it,' do not match!'
     call exit_MPI(myrank,'Error invalid time increment ending')
   endif
+
+  !#TODO: hdf5 i/o server
+  ! i/o server synchronization
+  !if (HDF5_IO_NNODES > 0) call synchronize_inter()
 
   end subroutine iterate_time_undoatt

--- a/src/specfem3D/prepare_timerun.F90
+++ b/src/specfem3D/prepare_timerun.F90
@@ -40,6 +40,9 @@
   double precision :: tCPU,tstart
   double precision, external :: wtime
 
+  ! checks if anything to do
+  if (.not. IO_compute_task) return
+
   ! synchonizes
   call synchronize_all()
 

--- a/src/specfem3D/read_mesh_databases.F90
+++ b/src/specfem3D/read_mesh_databases.F90
@@ -32,8 +32,7 @@
 
   use constants, only: MAX_STRING_LEN,IIN,myrank,I_should_read_the_database
 
-  use specfem_par, only: prname,LOCAL_PATH, &
-    NSPEC_AB,NGLOB_AB,NSPEC_IRREGULAR
+  use specfem_par, only: prname, LOCAL_PATH, NSPEC_AB, NGLOB_AB, NSPEC_IRREGULAR
 
   ! ADIOS
   use shared_parameters, only: ADIOS_FOR_MESH
@@ -108,6 +107,9 @@
   ! debugging
   integer :: i
   logical, parameter :: DEBUG_MPI_ARRAYS = .false.
+
+  ! checks if anything to do
+  if (.not. IO_compute_task) return
 
   ! selects routine for file i/o format
   if (ADIOS_FOR_MESH) then
@@ -1355,6 +1357,9 @@
 
   integer :: ier
 
+  ! checks if anything to do
+  if (.not. IO_compute_task) return
+
   ! selects routine for file i/o format
   if (ADIOS_FOR_MESH) then
     ! ADIOS file format
@@ -1501,6 +1506,9 @@
   integer :: ier
 
   ! note: this routines has no file I/O, it (only) allocates necessary arrays for adjoint/kernel simulations
+
+  ! checks if anything to do
+  if (.not. IO_compute_task) return
 
   ! allocates adjoint arrays for elastic simulations
   if (ELASTIC_SIMULATION .and. SIMULATION_TYPE == 3) then

--- a/src/specfem3D/read_mesh_databases_hdf5.F90
+++ b/src/specfem3D/read_mesh_databases_hdf5.F90
@@ -1034,34 +1034,27 @@
       dsetname = "ibelm_xmin"
       call h5_read_dataset_1d_i_collect_hyperslab(dsetname, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),if_col)
     endif
-
     if (sum(offset_nspec2D_xmax) > 0) then
       dsetname = "ibelm_xmax"
       call h5_read_dataset_1d_i_collect_hyperslab(dsetname, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),if_col)
     endif
-
     if (sum(offset_nspec2D_ymin) > 0) then
       dsetname = "ibelm_ymin"
       call h5_read_dataset_1d_i_collect_hyperslab(dsetname, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),if_col)
     endif
-
     if (sum(offset_nspec2D_ymax) > 0) then
       dsetname = "ibelm_ymax"
       call h5_read_dataset_1d_i_collect_hyperslab(dsetname, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),if_col)
     endif
-
     if (sum(offset_nspec2D_bottom_ext) > 0) then
       dsetname = "ibelm_bottom"
       call h5_read_dataset_1d_i_collect_hyperslab(dsetname, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),if_col)
     endif
-
     if (sum(offset_nspec2D_top_ext) > 0) then
       dsetname = "ibelm_top"
       call h5_read_dataset_1d_i_collect_hyperslab(dsetname, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),if_col)
     endif
-
   endif
-
   if (size(ibelm_xmin) > 0) call bcast_all_i_for_database(ibelm_xmin(1), size(ibelm_xmin))
   if (size(ibelm_xmax) > 0) call bcast_all_i_for_database(ibelm_xmax(1), size(ibelm_xmax))
   if (size(ibelm_ymin) > 0) call bcast_all_i_for_database(ibelm_ymin(1), size(ibelm_ymin))
@@ -1121,8 +1114,7 @@
   ! acoustic-elastic coupling surface
   if (I_should_read_the_database) then
     dsetname = "num_coupling_ac_el_faces"
-    call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, num_coupling_ac_el_faces, &
-                (/myrank/),if_col)
+    call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, num_coupling_ac_el_faces, (/myrank/),if_col)
   endif
   call bcast_all_i_for_database(num_coupling_ac_el_faces, 1)
 
@@ -1171,8 +1163,7 @@
   ! acoustic-poroelastic coupling surface
   if (I_should_read_the_database) then
     dsetname = "num_coupling_ac_po_faces"
-    call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, num_coupling_ac_po_faces, &
-            (/myrank/),if_col)
+    call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, num_coupling_ac_po_faces, (/myrank/),if_col)
   endif
   call bcast_all_i_for_database(num_coupling_ac_po_faces, 1)
 
@@ -1221,8 +1212,7 @@
   ! elastic-poroelastic coupling surface
   if (I_should_read_the_database) then
     dsetname = "num_coupling_el_po_faces"
-    call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, num_coupling_el_po_faces, &
-              (/myrank/),if_col)
+    call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, num_coupling_el_po_faces, (/myrank/),if_col)
   endif
   call bcast_all_i_for_database(num_coupling_el_po_faces, 1)
 
@@ -1494,8 +1484,7 @@
       dsetname = "nspec_outer_poroelastic"
       call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, nspec_outer_poroelastic,(/myrank/),if_col)
       dsetname = "num_phase_ispec_poroelastic"
-      call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, num_phase_ispec_poroelastic, &
-              (/myrank/),if_col)
+      call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, num_phase_ispec_poroelastic, (/myrank/),if_col)
     endif
     call bcast_all_i_for_database(nspec_inner_poroelastic, 1)
     call bcast_all_i_for_database(nspec_outer_poroelastic, 1)
@@ -1529,11 +1518,9 @@
     if (ACOUSTIC_SIMULATION) then
       if (I_should_read_the_database) then
         dsetname = "num_colors_outer_acoustic"
-        call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, &
-                num_colors_outer_acoustic,(/myrank/),if_col)
+        call h5_read_dataset_scalar_i_collect_hyperslab(dsetname,num_colors_outer_acoustic,(/myrank/),if_col)
         dsetname = "num_colors_inner_acoustic"
-        call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, &
-                num_colors_inner_acoustic,(/myrank/),if_col)
+        call h5_read_dataset_scalar_i_collect_hyperslab(dsetname,num_colors_inner_acoustic,(/myrank/),if_col)
       endif
       call bcast_all_i_for_database(num_colors_outer_acoustic, 1)
       call bcast_all_i_for_database(num_colors_inner_acoustic, 1)
@@ -1557,11 +1544,9 @@
     if (ELASTIC_SIMULATION) then
       if (I_should_read_the_database) then
         dsetname = "num_colors_outer_elastic"
-        call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, &
-                num_colors_outer_elastic,(/myrank/),if_col)
+        call h5_read_dataset_scalar_i_collect_hyperslab(dsetname,num_colors_outer_elastic,(/myrank/),if_col)
         dsetname = "num_colors_inner_elastic"
-        call h5_read_dataset_scalar_i_collect_hyperslab(dsetname, &
-                num_colors_inner_elastic,(/myrank/),if_col)
+        call h5_read_dataset_scalar_i_collect_hyperslab(dsetname,num_colors_inner_elastic,(/myrank/),if_col)
       endif
       call bcast_all_i_for_database(num_colors_outer_elastic, 1)
       call bcast_all_i_for_database(num_colors_inner_elastic, 1)

--- a/src/specfem3D/rules.mk
+++ b/src/specfem3D/rules.mk
@@ -128,6 +128,7 @@ specfem3D_OBJECTS = \
 	$O/update_displacement_scheme.spec.o \
 	$O/update_displacement_LDDRK.spec.o \
 	$O/write_movie_output.spec.o \
+	$O/write_movie_output_HDF5.spec_hdf5.o \
 	$O/write_output_ASCII_or_binary.spec.o \
 	$O/write_output_HDF5.spec_hdf5.o \
 	$O/write_output_SU.spec.o \

--- a/src/specfem3D/rules.mk
+++ b/src/specfem3D/rules.mk
@@ -240,6 +240,16 @@ else
 specfem3D_SHARED_OBJECTS += $(adios_specfem3D_STUBS)
 endif
 
+##
+## HDF5
+##
+
+ifeq ($(HDF5),yes)
+specfem3D_MODULES += \
+	$(FC_MODDIR)/specfem_par_movie_hdf5.$(FC_MODEXT) \
+	$(EMPTY_MACRO)
+endif
+
 ###
 ### ASDF
 ###

--- a/src/specfem3D/setup_GLL_points.f90
+++ b/src/specfem3D/setup_GLL_points.f90
@@ -36,6 +36,9 @@
   implicit none
   integer :: i,j,k,inum
 
+  ! checks if anything to do
+  if (.not. IO_compute_task) return
+
   ! outputs total element numbers
   call sum_all_i(count(ispec_is_acoustic(:)),inum)
   if (myrank == 0) then

--- a/src/specfem3D/setup_sources_receivers.f90
+++ b/src/specfem3D/setup_sources_receivers.f90
@@ -32,6 +32,9 @@
 
   implicit none
 
+  ! checks if anything to do
+  if (.not. IO_compute_task) return
+
   ! setup for point search
   call setup_point_search_arrays()
 

--- a/src/specfem3D/specfem3D_par.F90
+++ b/src/specfem3D/specfem3D_par.F90
@@ -647,6 +647,11 @@ module specfem_par_movie
   ! to save full 3D snapshot of velocity (movie volume)
   real(kind=CUSTOM_REAL), dimension(:,:,:,:),allocatable:: div, curl_x, curl_y, curl_z
   real(kind=CUSTOM_REAL), dimension(:,:,:,:),allocatable:: wavefield_x,wavefield_y,wavefield_z
+  real(kind=CUSTOM_REAL), dimension(:,:,:,:),allocatable:: wavefield_pressure
+
+  ! divergence and curl only in the global nodes
+  real(kind=CUSTOM_REAL),dimension(:),allocatable:: div_glob
+  integer,dimension(:),allocatable :: valence_glob
 
   ! surface point locations
   real(kind=CUSTOM_REAL), dimension(:), allocatable :: store_val_x

--- a/src/specfem3D/vtk_window.F90
+++ b/src/specfem3D/vtk_window.F90
@@ -68,6 +68,9 @@ end module vtk_window_par
   ! local parameters
   integer :: ier
 
+  ! checks if anything to do
+  if (.not. IO_compute_task) return
+
   ! user output
   if (myrank == 0) then
     write(IMAIN,*)

--- a/src/specfem3D/write_movie_output_HDF5.F90
+++ b/src/specfem3D/write_movie_output_HDF5.F90
@@ -227,7 +227,7 @@ contains
   fname_h5_data_shake = trim(OUTPUT_FILES) // "/shakemap.h5"
 
   ! get the offset info from main rank
-  call bcast_all_cr(faces_surface_offset,size(faces_surface_offset))
+  call bcast_all_i(faces_surface_offset,size(faces_surface_offset))
 
   if (myrank == 0) then
     size_surf_array = size(store_val_x_all)
@@ -498,7 +498,7 @@ contains
 
   ! get the offset info from main rank
   if (it == NTSTEP_BETWEEN_FRAMES) then
-    call bcast_all_cr(faces_surface_offset,size(faces_surface_offset))
+    call bcast_all_i(faces_surface_offset,size(faces_surface_offset))
   endif
 
   if (myrank == 0) then
@@ -1042,8 +1042,8 @@ contains
   ! group for storing node coordinates and mesh element connectivity
   group_name = "mesh"
 
-  call gather_all_all_singlei((/NSPEC_AB/),nelm_par_proc_nio,NPROC)
-  call gather_all_all_singlei((/NGLOB_AB/),nglob_par_proc_nio,NPROC)
+  call gather_all_all_singlei(NSPEC_AB,nelm_par_proc_nio,NPROC)
+  call gather_all_all_singlei(NGLOB_AB,nglob_par_proc_nio,NPROC)
 
   nglob_all = sum(nglob_par_proc_nio(0:NPROC-1))
   nspec_all = sum(nelm_par_proc_nio(0:NPROC-1))

--- a/src/specfem3D/write_movie_output_HDF5.F90
+++ b/src/specfem3D/write_movie_output_HDF5.F90
@@ -1,0 +1,1321 @@
+!=====================================================================
+!
+!                          S p e c f e m 3 D
+!                          -----------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                              CNRS, France
+!                       and Princeton University, USA
+!                 (there are currently many more authors!)
+!                           (c) October 2017
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+
+! HDF5 format movie output
+
+#ifdef USE_HDF5
+
+  module specfem_par_movie_hdf5
+
+  use constants, only: NGLLX,NGLLY,NGLLZ,CUSTOM_REAL,MAX_STRING_LEN,OUTPUT_FILES,myrank
+
+  use shared_parameters, only: NPROC,NSTEP,NTSTEP_BETWEEN_FRAMES,USE_HIGHRES_FOR_MOVIES, &
+    ACOUSTIC_SIMULATION,ELASTIC_SIMULATION,POROELASTIC_SIMULATION
+
+  !#TODO: hdf5 i/o server
+  !use shared_parameters, only: HDF5_IO_NNODES
+
+  use specfem_par, only: NSPEC_AB,NGLOB_AB,ibool,it,DT,t0,xstore,ystore,zstore
+
+  use specfem_par_movie, only: faces_surface_offset, &
+    store_val_ux,store_val_uy,store_val_uz, &
+    store_val_x_all,store_val_y_all,store_val_z_all, &
+    shakemap_ux,shakemap_uy,shakemap_uz, &
+    wavefield_x,wavefield_y,wavefield_z,wavefield_pressure, &
+    div_glob,div,curl_x,curl_y,curl_z
+
+  use manager_hdf5
+
+  implicit none
+
+  ! xdmf
+  ! file i/o units
+  integer :: xdmf_shake               = 191
+  integer :: xdmf_surf                = 192
+  integer :: xdmf_vol                 = 193
+  ! file position for entering surface snapshot records
+  integer :: surf_xdmf_pos = 0
+
+  ! surface movie arrays
+  integer :: size_surf_array = 0
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: surf_x,   surf_y,   surf_z, &
+                                                       surf_ux,  surf_uy,  surf_uz
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: surf_x_aug,   surf_y_aug,   surf_z_aug, &
+                                                       surf_ux_aug,  surf_uy_aug,  surf_uz_aug
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: shake_ux, shake_uy, shake_uz, &
+                                                       shake_ux_aug, shake_uy_aug, shake_uz_aug
+
+  ! volume movie arrays
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: div_on_node, curl_x_on_node, curl_y_on_node, curl_z_on_node
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: velocity_x_on_node,velocity_y_on_node,velocity_z_on_node
+
+  ! arrays for hdf5 output
+  integer, dimension(:), allocatable :: nelm_par_proc_nio, nglob_par_proc_nio
+  integer, dimension(:), allocatable :: nglob_offset
+  integer, dimension(:), allocatable :: nelm_offset
+
+contains
+
+  !-------------------------------------------
+
+  function r2c(k) result(str)
+
+  ! "Convert an real to string."
+
+  implicit none
+  real(kind=CUSTOM_REAL), intent(in) :: k
+  character(len=20) str
+  write (str, *) k
+  str = adjustl(str)
+  end function r2c
+
+  !-------------------------------------------
+
+  ! reorder and expand the input array (for only corner nodes) to high res array (all GLL)
+  subroutine recompose_for_hires(arr_in, arr_out)
+
+  implicit none
+
+  real(kind=CUSTOM_REAL), dimension(:), intent(in)    :: arr_in
+  real(kind=CUSTOM_REAL), dimension(:), intent(inout) :: arr_out
+
+  integer :: nfaces_actual
+  integer :: i,j,k,c
+  integer :: factor_face_aug = (NGLLX-1)*(NGLLY-1)
+  integer :: npoint_per_face = NGLLX*NGLLY
+  integer :: npoint_corner = 4
+
+  nfaces_actual = size(arr_in)/(NGLLX*NGLLY) ! expecting NGLLX == NGLLY == NGLLZ
+
+  c = 1
+  do i = 0, nfaces_actual-1
+    do j = 0,NGLLY-2 !y
+      do k = 0,NGLLX-2 !x
+        arr_out(c  +j*(NGLLX-1)*4+k*4) = arr_in(i*npoint_per_face+1      +k+j*NGLLX)
+        arr_out(c+1+j*(NGLLX-1)*4+k*4) = arr_in(i*npoint_per_face+2      +k+j*NGLLX)
+        arr_out(c+2+j*(NGLLX-1)*4+k*4) = arr_in(i*npoint_per_face+2+NGLLX+k+j*NGLLX)
+        arr_out(c+3+j*(NGLLX-1)*4+k*4) = arr_in(i*npoint_per_face+1+NGLLX+k+j*NGLLX)
+      enddo
+    enddo
+    c = c+factor_face_aug*npoint_corner
+  enddo
+
+  end subroutine recompose_for_hires
+
+  !-------------------------------------------
+
+  subroutine elm2node_base(elm_base, node_base)
+
+  implicit none
+
+  real(kind=CUSTOM_REAL),dimension(NGLLX,NGLLY,NGLLZ,NSPEC_AB),intent(in) :: elm_base
+  real(kind=CUSTOM_REAL), dimension(NGLOB_AB), intent(inout) :: node_base
+  ! local parameters
+  integer :: i,j,k,iglob,ispec
+
+  ! converts from local to global indexing for input array
+  do ispec = 1,NSPEC_AB
+    do k = 1,NGLLZ
+      do j = 1,NGLLY
+        do i = 1,NGLLX
+          iglob = ibool(i,j,k,ispec)
+          ! global field
+          node_base(iglob) = elm_base(i,j,k,ispec)
+        enddo
+      enddo
+    enddo
+  enddo
+
+  end subroutine elm2node_base
+
+  !-------------------------------------------
+
+  subroutine get_conn_for_movie(elm_conn,offset)
+
+  implicit none
+
+  integer, dimension(9,NSPEC_AB*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)), intent(out) :: elm_conn
+  integer, intent(in) :: offset ! node id offset (starting global element id of each proc)
+
+  ! local parameters
+  integer :: ispec,ii,icub,jcub,kcub
+  integer,parameter :: cell_type = 9
+
+  do ispec = 1,NSPEC_AB
+    ! extract information from full GLL grid
+    ! node order follows vtk format
+    do icub = 0,NGLLX-2
+      do jcub = 0,NGLLY-2
+        do kcub = 0,NGLLZ-2
+          ii = 1+(ispec-1)*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1) + (icub*(NGLLY-1)*(NGLLZ-1)+jcub*(NGLLZ-1)+kcub)
+          elm_conn(1, ii)  = cell_type
+          elm_conn(2, ii)  = ibool(icub+1,jcub+1,kcub+1,ispec)-1 + offset   ! node id starts 0 in xdmf rule
+          elm_conn(3, ii)  = ibool(icub+2,jcub+1,kcub+1,ispec)-1 + offset
+          elm_conn(4, ii)  = ibool(icub+2,jcub+2,kcub+1,ispec)-1 + offset
+          elm_conn(5, ii)  = ibool(icub+1,jcub+2,kcub+1,ispec)-1 + offset
+          elm_conn(6, ii)  = ibool(icub+1,jcub+1,kcub+2,ispec)-1 + offset
+          elm_conn(7, ii)  = ibool(icub+2,jcub+1,kcub+2,ispec)-1 + offset
+          elm_conn(8, ii)  = ibool(icub+2,jcub+2,kcub+2,ispec)-1 + offset
+          elm_conn(9, ii)  = ibool(icub+1,jcub+2,kcub+2,ispec)-1 + offset
+        enddo
+      enddo
+    enddo
+  enddo
+
+  end subroutine get_conn_for_movie
+
+
+  end module specfem_par_movie_hdf5
+#endif
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine wmo_save_shakemap_hdf5()
+
+#ifdef USE_HDF5
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+
+  ! local parameters
+  integer :: ier, nfaces_actual, nfaces_aug=(NGLLX-1)*(NGLLY-1),nnodes_per_face_aug=4
+  integer :: len_array_aug, len_array_aug_proc
+  character(len=64) :: dset_name, group_name
+  real(kind=CUSTOM_REAL) :: aug_factor
+  character(len=MAX_STRING_LEN) :: fname_h5_data_shake
+
+  logical, parameter :: if_corrective = .true.
+
+  !#TODO: hdf5 i/o server
+  !if (HDF5_IO_NNODES > 0) then
+  !  ! send shakemap arrays to io node
+  !  call isend_cr_inter(shakemap_ux,nfaces_surface_points,0,io_tag_shake_ux,req)
+  !  call isend_cr_inter(shakemap_uy,nfaces_surface_points,0,io_tag_shake_uy,req)
+  !  call isend_cr_inter(shakemap_uz,nfaces_surface_points,0,io_tag_shake_uz,req)
+  !  ! all done
+  !  return
+  !endif
+
+  fname_h5_data_shake = trim(OUTPUT_FILES) // "/shakemap.h5"
+
+  ! get the offset info from main rank
+  call bcast_all_cr(faces_surface_offset,size(faces_surface_offset))
+
+  if (myrank == 0) then
+    size_surf_array = size(store_val_x_all)
+    call bcast_all_singlei(size_surf_array)
+  else
+    call bcast_all_singlei(size_surf_array)
+  endif
+
+  nfaces_actual = size_surf_array / (NGLLX*NGLLY)
+  len_array_aug = nfaces_actual * nfaces_aug * nnodes_per_face_aug
+
+  ! initialization of h5 file
+  call h5_init()
+
+  if (myrank == 0) then
+    ! create a hdf5 file
+    call h5_create_file(fname_h5_data_shake)
+
+    ! save xyz coordinate array
+    group_name = "surf_coord"
+    call h5_create_group(group_name)
+    call h5_open_group(group_name)
+
+    ! low resolution output
+    if (.not. USE_HIGHRES_FOR_MOVIES) then
+      dset_name = "x"
+      call h5_write_dataset_1d_d(dset_name, store_val_x_all)
+      call h5_close_dataset()
+      dset_name = "y"
+      call h5_write_dataset_1d_d(dset_name, store_val_y_all)
+      call h5_close_dataset()
+      dset_name = "z"
+      call h5_write_dataset_1d_d(dset_name, store_val_z_all)
+      call h5_close_dataset()
+
+      ! write xdmf header
+      call write_xdmf_shakemap(size_surf_array)
+
+      ! high resolution output
+    else
+      allocate(surf_x_aug(len_array_aug), &
+               surf_y_aug(len_array_aug), &
+               surf_z_aug(len_array_aug),stat=ier)
+      if (ier /= 0) stop 'Error allocating surf_x_aug arrays'
+
+      ! nfaces*25nodes => n*16faces*4
+      dset_name = "x"
+      call recompose_for_hires(store_val_x_all,surf_x_aug)
+      call h5_write_dataset_1d_d(dset_name, surf_x_aug)
+      call h5_close_dataset()
+      dset_name = "y"
+      call recompose_for_hires(store_val_y_all,surf_y_aug)
+      call h5_write_dataset_1d_d(dset_name, surf_y_aug)
+      call h5_close_dataset()
+      dset_name = "z"
+      call recompose_for_hires(store_val_z_all,surf_z_aug)
+      call h5_write_dataset_1d_d(dset_name, surf_z_aug)
+      call h5_close_dataset()
+
+      ! write xdmf header
+      call write_xdmf_shakemap(len_array_aug)
+
+      deallocate(surf_x_aug, surf_y_aug, surf_z_aug)
+    endif
+
+    call h5_close_group()
+    call h5_close_file()
+
+  endif
+
+  call synchronize_all()
+
+  ! write dataset in one single h5 file in collective mode.
+  group_name = "shakemap"
+
+  if (myrank == 0) then
+    call h5_open_file(fname_h5_data_shake)
+    call h5_create_group(group_name)
+    call h5_open_group(group_name)
+    if (.not. USE_HIGHRES_FOR_MOVIES) then
+      call h5_create_dataset_gen_in_group("shakemap_ux",(/size_surf_array/),1,CUSTOM_REAL)
+      call h5_create_dataset_gen_in_group("shakemap_uy",(/size_surf_array/),1,CUSTOM_REAL)
+      call h5_create_dataset_gen_in_group("shakemap_uz",(/size_surf_array/),1,CUSTOM_REAL)
+    else
+      call h5_create_dataset_gen_in_group("shakemap_ux",(/len_array_aug/),1,CUSTOM_REAL)
+      call h5_create_dataset_gen_in_group("shakemap_uy",(/len_array_aug/),1,CUSTOM_REAL)
+      call h5_create_dataset_gen_in_group("shakemap_uz",(/len_array_aug/),1,CUSTOM_REAL)
+   endif
+    call h5_close_group()
+    call h5_close_file()
+  endif
+
+  call synchronize_all()
+
+  call h5_open_file_p(fname_h5_data_shake)
+  call h5_open_group(group_name)
+
+  if (.not. USE_HIGHRES_FOR_MOVIES) then
+    dset_name = "shakemap_ux"
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, shakemap_ux, &
+                      (/faces_surface_offset(myrank+1)/), if_corrective)
+    dset_name = "shakemap_uy"
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, shakemap_uy, &
+                      (/faces_surface_offset(myrank+1)/), if_corrective)
+    dset_name = "shakemap_uz"
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, shakemap_uz, &
+                      (/faces_surface_offset(myrank+1)/), if_corrective)
+
+  else
+    nfaces_actual      = size(shakemap_ux)/(NGLLX*NGLLY)
+    len_array_aug_proc = nfaces_actual*nfaces_aug*nnodes_per_face_aug ! augmented array length for each proc
+    aug_factor         = real(len_array_aug)/real(size_surf_array)
+
+    allocate(surf_ux_aug(len_array_aug_proc),stat=ier)
+    allocate(surf_uy_aug(len_array_aug_proc),stat=ier)
+    allocate(surf_uz_aug(len_array_aug_proc),stat=ier)
+
+    dset_name = "shakemap_ux"
+    call recompose_for_hires(shakemap_ux, surf_ux_aug)
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, surf_ux_aug, &
+                      (/int(faces_surface_offset(myrank+1)*aug_factor)/), if_corrective)
+    dset_name = "shakemap_uy"
+    call recompose_for_hires(shakemap_uy, surf_uy_aug)
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, surf_uy_aug, &
+                      (/int(faces_surface_offset(myrank+1)*aug_factor)/), if_corrective)
+    dset_name = "shakemap_uz"
+    call recompose_for_hires(shakemap_uz, surf_uz_aug)
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, surf_uz_aug, &
+                      (/int(faces_surface_offset(myrank+1)*aug_factor)/), if_corrective)
+
+    deallocate(surf_ux_aug, surf_uy_aug, surf_uz_aug)
+  endif
+
+  call h5_close_group()
+  call h5_close_file()
+  call h5_destructor()
+
+#else
+  ! no HDF5 compilation support
+
+  ! compilation without HDF5 support
+  print *
+  print *, "Error: HDF5 routine wmo_save_shakemap_hdf5() called without HDF5 Support."
+  print *, "To enable HDF5 support, reconfigure with --with-hdf5 flag."
+  print *
+
+  ! safety stop
+  stop 'wmo_save_shakemap_hdf5() called without compilation support'
+
+#endif
+
+  end subroutine wmo_save_shakemap_hdf5
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+#ifdef USE_HDF5
+
+  subroutine write_xdmf_shakemap(num_nodes)
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+  integer :: num_elm, num_nodes
+  character(len=MAX_STRING_LEN) :: fname_xdmf_shake
+  character(len=MAX_STRING_LEN) :: fname_h5_data_shake_xdmf
+
+  ! checks if anything do, only main process writes out xdmf file
+  if (myrank /= 0) return
+
+  num_elm = num_nodes / 4
+
+  ! writeout xdmf file for surface movie
+  fname_xdmf_shake = trim(OUTPUT_FILES) // "/shakemap.xmf"
+  fname_h5_data_shake_xdmf = "./shakemap.h5"       ! relative to shakemap.xmf file
+  ! note: this seems to point to / < rootdir>/OUTPUT_FILES/./OUTPUT_FILES//shakemap.h5
+  !       and paraview won't find it...
+  !         fname_h5_data_shake_xdmf = trim(OUTPUT_FILES) // "/shakemap.h5"
+
+  open(unit=xdmf_shake, file=trim(fname_xdmf_shake), recl=256)
+
+  write(xdmf_shake,'(a)') '<?xml version="1.0" ?>'
+  write(xdmf_shake,*) '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>'
+  write(xdmf_shake,*) '<Xdmf Version="3.0">'
+  write(xdmf_shake,*) '<Domain Name="shakemap">'
+  write(xdmf_shake,*) '<Grid>'
+  write(xdmf_shake,*) '<Topology Name="topo" TopologyType="Quadrilateral" NumberOfElements="'//trim(i2c(num_elm))//'"/>'
+  write(xdmf_shake,*) '<Geometry GeometryType="X_Y_Z">'
+  write(xdmf_shake,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="' &
+                                                    //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_shake,*) '        '//trim(fname_h5_data_shake_xdmf)//':/surf_coord/x'
+
+  write(xdmf_shake,*) '</DataItem>'
+  write(xdmf_shake,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                    //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_shake,*) '        '//trim(fname_h5_data_shake_xdmf)//':/surf_coord/y'
+  write(xdmf_shake,*) '</DataItem>'
+  write(xdmf_shake,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                   //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_shake,*) '        '//trim(fname_h5_data_shake_xdmf)//':/surf_coord/z'
+  write(xdmf_shake,*) '</DataItem>'
+  write(xdmf_shake,*) '</Geometry>'
+  write(xdmf_shake,*) '<Attribute Name="shake_ux" AttributeType="Scalar" Center="Node">'
+  write(xdmf_shake,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                  //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_shake,*) '        '//trim(fname_h5_data_shake_xdmf)//':/shakemap/shakemap_ux'
+  write(xdmf_shake,*) '</DataItem>'
+  write(xdmf_shake,*) '</Attribute>'
+  write(xdmf_shake,*) '<Attribute Name="shake_uy" AttributeType="Scalar" Center="Node">'
+  write(xdmf_shake,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                 //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_shake,*) '        '//trim(fname_h5_data_shake_xdmf)//':/shakemap/shakemap_uy'
+  write(xdmf_shake,*) '</DataItem>'
+  write(xdmf_shake,*) '</Attribute>'
+  write(xdmf_shake,*) '<Attribute Name="shake_uz" AttributeType="Scalar" Center="Node">'
+  write(xdmf_shake,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_shake,*) '        '//trim(fname_h5_data_shake_xdmf)//':/shakemap/shakemap_uz'
+  write(xdmf_shake,*) '</DataItem>'
+  write(xdmf_shake,*) '</Attribute>'
+  write(xdmf_shake,*) '</Grid>'
+  write(xdmf_shake,*) '</Domain>'
+  write(xdmf_shake,*) '</Xdmf>'
+
+  close(xdmf_shake)
+
+  end subroutine write_xdmf_shakemap
+
+#endif
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine wmo_movie_save_surface_snapshot_hdf5()
+
+#ifdef USE_HDF5
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+
+  integer :: ier, nfaces_actual
+  integer :: len_array_aug, len_array_aug_proc
+  character(len=64) :: dset_name, group_name
+  character(len=12) :: tempstr
+  real(kind=CUSTOM_REAL) :: aug_factor
+  character(len=MAX_STRING_LEN) :: fname_h5_data_surf
+
+  integer, parameter :: nfaces_aug = (NGLLX-1)*(NGLLY-1)
+  integer, parameter :: nnodes_per_face_aug = 4
+  logical, parameter :: if_corrective = .true.
+
+  !#TODO: hdf5 i/o server
+  !if (HDF5_IO_NNODES > 0) then
+  !  ! send surface body to io node
+  !  call isend_cr_inter(store_val_ux,nfaces_surface_points,0,io_tag_surface_ux,req_dump_surf(1))
+  !  call isend_cr_inter(store_val_uy,nfaces_surface_points,0,io_tag_surface_uy,req_dump_surf(2))
+  !  call isend_cr_inter(store_val_uz,nfaces_surface_points,0,io_tag_surface_uz,req_dump_surf(3))
+  !  n_req_surf = 3
+  !  ! all done
+  !  return
+  !endif
+
+  ! initialize h5 and xdmf  if it == 0
+  fname_h5_data_surf = trim(OUTPUT_FILES) // "/movie_surface.h5"
+
+  ! get the offset info from main rank
+  if (it == NTSTEP_BETWEEN_FRAMES) then
+    call bcast_all_cr(faces_surface_offset,size(faces_surface_offset))
+  endif
+
+  if (myrank == 0) then
+    size_surf_array = size(store_val_x_all)
+    call bcast_all_singlei(size_surf_array)
+  else
+    call bcast_all_singlei(size_surf_array)
+  endif
+
+  nfaces_actual = size_surf_array / (NGLLX*NGLLY)
+  len_array_aug = nfaces_actual * nfaces_aug * nnodes_per_face_aug
+
+  ! initialization of h5 file
+  call h5_init()
+
+  ! main process creates file on first occurrence
+  if (it == NTSTEP_BETWEEN_FRAMES .and. myrank == 0) then
+    ! create a hdf5 file
+    call h5_create_file(fname_h5_data_surf)
+
+    ! save xyz coordinate array
+    group_name = "surf_coord"
+    call h5_create_group(group_name)
+    call h5_open_group(group_name)
+
+    ! grid coordinates
+    if (.not. USE_HIGHRES_FOR_MOVIES) then
+      ! low resolution output
+      dset_name = "x"
+      call h5_write_dataset_1d_d(dset_name, store_val_x_all)
+      call h5_close_dataset()
+      dset_name = "y"
+      call h5_write_dataset_1d_d(dset_name, store_val_y_all)
+      call h5_close_dataset()
+      dset_name = "z"
+      call h5_write_dataset_1d_d(dset_name, store_val_z_all)
+      call h5_close_dataset()
+
+      ! write xdmf header
+      call write_xdmf_surface_header(size_surf_array)
+    else
+      ! high resolution output
+      allocate(surf_x_aug(len_array_aug),stat=ier)
+      allocate(surf_y_aug(len_array_aug),stat=ier)
+      allocate(surf_z_aug(len_array_aug),stat=ier)
+
+      ! nfaces*25nodes => n*16faces*4
+      dset_name = "x"
+      call recompose_for_hires(store_val_x_all,surf_x_aug)
+      call h5_write_dataset_1d_d(dset_name, surf_x_aug)
+      call h5_close_dataset()
+      dset_name = "y"
+      call recompose_for_hires(store_val_y_all,surf_y_aug)
+      call h5_write_dataset_1d_d(dset_name, surf_y_aug)
+      call h5_close_dataset()
+      dset_name = "z"
+      call recompose_for_hires(store_val_z_all,surf_z_aug)
+      call h5_write_dataset_1d_d(dset_name, surf_z_aug)
+      call h5_close_dataset()
+
+      ! write xdmf header
+      call write_xdmf_surface_header(len_array_aug)
+
+      deallocate(surf_x_aug, surf_y_aug, surf_z_aug)
+    endif
+
+    call h5_close_group()
+    call h5_close_file()
+
+  endif
+
+  call synchronize_all()
+
+  ! write dataset in one single h5 file in collective mode.
+  ! create a group for each io step
+  write(tempstr, "(i6.6)") it
+  group_name = "it_" // trim(tempstr)
+
+  if (myrank == 0) then
+    call h5_open_file(fname_h5_data_surf)
+    call h5_create_group(group_name)
+    call h5_open_group(group_name)
+    if (.not. USE_HIGHRES_FOR_MOVIES) then
+      call h5_create_dataset_gen_in_group("ux",(/size_surf_array/),1,CUSTOM_REAL)
+      call h5_create_dataset_gen_in_group("uy",(/size_surf_array/),1,CUSTOM_REAL)
+      call h5_create_dataset_gen_in_group("uz",(/size_surf_array/),1,CUSTOM_REAL)
+    else
+      call h5_create_dataset_gen_in_group("ux",(/len_array_aug/),1,CUSTOM_REAL)
+      call h5_create_dataset_gen_in_group("uy",(/len_array_aug/),1,CUSTOM_REAL)
+      call h5_create_dataset_gen_in_group("uz",(/len_array_aug/),1,CUSTOM_REAL)
+   endif
+    call h5_close_group()
+    call h5_close_file()
+  endif
+
+  call synchronize_all()
+
+  call h5_open_file_p(fname_h5_data_surf)
+  call h5_open_group(group_name)
+
+  if (.not. USE_HIGHRES_FOR_MOVIES) then
+    dset_name = "ux"
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, store_val_ux, &
+                      (/faces_surface_offset(myrank+1)/), if_corrective)
+    dset_name = "uy"
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, store_val_uy, &
+                      (/faces_surface_offset(myrank+1)/), if_corrective)
+    dset_name = "uz"
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, store_val_uz, &
+                      (/faces_surface_offset(myrank+1)/), if_corrective)
+
+    ! write xdmf body
+    if (myrank == 0) call write_xdmf_surface_body(it, size_surf_array)
+
+  else
+    nfaces_actual      = size(store_val_ux)/(NGLLX*NGLLY)
+    len_array_aug_proc = nfaces_actual*nfaces_aug*nnodes_per_face_aug ! augmented array length for each proc
+    aug_factor         = real(len_array_aug)/real(size_surf_array)
+
+    allocate(surf_ux_aug(len_array_aug_proc),stat=ier)
+    allocate(surf_uy_aug(len_array_aug_proc),stat=ier)
+    allocate(surf_uz_aug(len_array_aug_proc),stat=ier)
+
+    dset_name = "ux"
+    call recompose_for_hires(store_val_ux, surf_ux_aug)
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, surf_ux_aug, &
+                      (/int(faces_surface_offset(myrank+1)*aug_factor)/), if_corrective)
+    dset_name = "uy"
+    call recompose_for_hires(store_val_uy, surf_uy_aug)
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, surf_uy_aug, &
+                      (/int(faces_surface_offset(myrank+1)*aug_factor)/), if_corrective)
+    dset_name = "uz"
+    call recompose_for_hires(store_val_uz, surf_uz_aug)
+    call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, surf_uz_aug, &
+                      (/int(faces_surface_offset(myrank+1)*aug_factor)/), if_corrective)
+
+    ! write xdmf body
+    if (myrank == 0) call write_xdmf_surface_body(it, len_array_aug)
+
+    deallocate(surf_ux_aug, surf_uy_aug, surf_uz_aug)
+  endif
+
+  call h5_close_group()
+  call h5_close_file()
+  call h5_destructor()
+#else
+  ! no HDF5 compilation support
+
+  ! compilation without HDF5 support
+  print *
+  print *, "Error: HDF5 routine wmo_movie_save_surface_snapshot_hdf5() called without HDF5 Support."
+  print *, "To enable HDF5 support, reconfigure with --with-hdf5 flag."
+  print *
+
+  ! safety stop
+  stop 'wmo_movie_save_surface_snapshot_hdf5() called without compilation support'
+
+#endif
+
+  end subroutine wmo_movie_save_surface_snapshot_hdf5
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+!
+! xdmf output routines
+!
+#ifdef USE_HDF5
+
+  subroutine write_xdmf_surface_header(num_nodes)
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+  integer, intent(in) :: num_nodes
+  ! local parameters
+  integer :: num_elm
+  character(len=MAX_STRING_LEN) :: fname_xdmf_surf
+  character(len=MAX_STRING_LEN) :: fname_h5_data_surf_xdmf
+
+  ! checks if anything do, only main process writes out xdmf file
+  if (myrank /= 0) return
+
+  ! writeout xdmf file for surface movie
+  fname_xdmf_surf = trim(OUTPUT_FILES) // "/movie_surface.xmf"
+  fname_h5_data_surf_xdmf = "./movie_surface.h5"   ! relative to movie_surface.xmf file
+  ! note: this seems not to work and point to a wrong directory:
+  !         fname_h5_data_surf_xdmf = trim(OUTPUT_FILES) // "/movie_surface.h5"
+
+  num_elm = num_nodes / 4
+
+  open(unit=xdmf_surf, file=trim(fname_xdmf_surf), recl=256)
+
+  write(xdmf_surf,'(a)') '<?xml version="1.0" ?>'
+  write(xdmf_surf,*) '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>'
+  write(xdmf_surf,*) '<Xdmf Version="3.0">'
+  write(xdmf_surf,*) '<Domain Name="mesh">'
+  write(xdmf_surf,*) '<Topology Name="topo" TopologyType="Quadrilateral" NumberOfElements="'//trim(i2c(num_elm))//'"/>'
+  write(xdmf_surf,*) '<Geometry GeometryType="X_Y_Z">'
+  write(xdmf_surf,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="' &
+                                                        //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_surf,*) '        '//trim(fname_h5_data_surf_xdmf)//':/surf_coord/x'
+  write(xdmf_surf,*) '</DataItem>'
+  write(xdmf_surf,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                        //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_surf,*) '        '//trim(fname_h5_data_surf_xdmf)//':/surf_coord/y'
+  write(xdmf_surf,*) '</DataItem>'
+  write(xdmf_surf,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                       //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_surf,*) '        '//trim(fname_h5_data_surf_xdmf)//':/surf_coord/z'
+  write(xdmf_surf,*) '</DataItem>'
+  write(xdmf_surf,*) '</Geometry>'
+
+  write(xdmf_surf,*) '<Grid Name="fensap" GridType="Collection" CollectionType="Temporal">'
+  ! 17 lines
+
+  ! file finish
+  write(xdmf_surf,*) '</Grid>'
+  write(xdmf_surf,*) '</Domain>'
+  write(xdmf_surf,*) '</Xdmf>'
+  ! 20 lines
+
+  ! position where the additional data will be inserted
+  surf_xdmf_pos = 17
+
+  close(xdmf_surf)
+
+  end subroutine write_xdmf_surface_header
+
+#endif
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+#ifdef USE_HDF5
+
+  subroutine write_xdmf_surface_body(it_io, num_nodes)
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+
+  integer, intent(in)    :: it_io
+  integer, intent(in)    :: num_nodes
+  ! local parameters
+  integer :: i
+  character(len=20) :: it_str
+  character(len=MAX_STRING_LEN) :: fname_xdmf_surf
+  character(len=MAX_STRING_LEN) :: fname_h5_data_surf_xdmf
+
+  ! checks if anything do, only main process writes out xdmf file
+  if (myrank /= 0) return
+
+  !#TODO: hdf5 i/o server
+  ! redefinition for no ioserver case
+  !if (fname_xdmf_surf == '' ) fname_xdmf_surf = trim(OUTPUT_FILES)//"/movie_surface.xmf"
+
+  fname_xdmf_surf = trim(OUTPUT_FILES)//"/movie_surface.xmf"
+  fname_h5_data_surf_xdmf = "./movie_surface.h5"    ! relative to movie_surface.xmf file
+  ! this seems to point to a wrong directory:
+  !   fname_h5_data_surf_xdmf = trim(OUTPUT_FILES) // "/movie_surface.h5"
+
+  ! open xdmf file
+  open(unit=xdmf_surf, file=trim(fname_xdmf_surf), status='old', recl=256)
+
+  ! skip lines till the position where we want to write new information
+  do i = 1, surf_xdmf_pos
+    read(xdmf_surf, *)
+  enddo
+
+  write(it_str, "(i6.6)") it_io
+
+  write(xdmf_surf,*) '<Grid Name="surf_mov" GridType="Uniform">'
+  write(xdmf_surf,*) '<Time Value="'//trim(r2c(sngl((it_io-1)*DT-t0)))//'" />'
+  write(xdmf_surf,*) '<Topology Reference="/Xdmf/Domain/Topology" />'
+  write(xdmf_surf,*) '<Geometry Reference="/Xdmf/Domain/Geometry" />'
+  write(xdmf_surf,*) '<Attribute Name="ux" AttributeType="Scalar" Center="Node">'
+  write(xdmf_surf,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                     //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_surf,*) '      '//trim(fname_h5_data_surf_xdmf)//':/it_'//trim(it_str)//'/ux'
+  write(xdmf_surf,*) '</DataItem>'
+  write(xdmf_surf,*) '</Attribute>'
+  write(xdmf_surf,*) '<Attribute Name="uy" AttributeType="Scalar" Center="Node">'
+  write(xdmf_surf,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                     //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_surf,*) '      '//trim(fname_h5_data_surf_xdmf)//':/it_'//trim(it_str)//'/uy'
+  write(xdmf_surf,*) '</DataItem>'
+  write(xdmf_surf,*) '</Attribute>'
+  write(xdmf_surf,*) '<Attribute Name="uz" AttributeType="Scalar" Center="Node">'
+  write(xdmf_surf,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                     //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(i2c(num_nodes))//'">'
+  write(xdmf_surf,*) '      '//trim(fname_h5_data_surf_xdmf)//':/it_'//trim(it_str)//'/uz'
+  write(xdmf_surf,*) '</DataItem>'
+  write(xdmf_surf,*) '</Attribute>'
+  write(xdmf_surf,*) '</Grid>'
+  ! 20 lines
+
+  ! file finish
+  write(xdmf_surf,*) '</Grid>'
+  write(xdmf_surf,*) '</Domain>'
+  write(xdmf_surf,*) '</Xdmf>'
+
+  close(xdmf_surf)
+
+  ! updates file record position
+  surf_xdmf_pos = surf_xdmf_pos + 20
+
+  end subroutine write_xdmf_surface_body
+
+#endif
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine wmo_movie_save_volume_snapshot_hdf5()
+
+#ifdef USE_HDF5
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+
+  ! local parameters
+  real(kind=CUSTOM_REAL),dimension(:), allocatable :: d_p
+  integer :: ier
+  logical :: pressure_io, divglob_io, div_io, veloc_io, curl_io
+  !#TODO: hdf5 i/o server
+  !integer :: req_count
+
+  ! initializes
+  pressure_io = .false.
+  divglob_io = .false.
+  div_io = .false.
+  veloc_io = .false.
+  curl_io = .false.
+
+  !#TODO: hdf5 i/o server
+  !req_count = 1
+
+  ! prepares hdf5 file
+  if (it == NTSTEP_BETWEEN_FRAMES) then
+    !#TODO: hdf5 i/o server
+    !if (HDF5_IO_NNODES == 0) then
+      call prepare_vol_movie_hdf5()
+    !endif
+  endif
+
+  ! saves fields
+  if (ACOUSTIC_SIMULATION) then
+    ! outputs pressure field for purely acoustic simulations
+    if (.not. ELASTIC_SIMULATION .and. .not. POROELASTIC_SIMULATION) then
+      ! converts wavefield_pressure from local to global level
+      allocate(d_p(NGLOB_AB),stat=ier)
+      if (ier /= 0) stop 'Error allocating d_p array'
+      call elm2node_base(wavefield_pressure, d_p)
+      ! saves pressure field
+      !#TODO: hdf5 i/o server
+      !if (HDF5_IO_NNODES > 0) then
+      !  ! send pressure_loc
+      !  call isend_cr_inter(d_p,NGLOB_AB,dest_ionod,io_tag_vol_pres,req_dump_vol(req_count))
+      !  req_count = req_count+1
+      !else
+        ! direct io
+        pressure_io = .true.
+        call write_vol_data_hdf5(d_p,"pressure")
+      !endif
+      deallocate(d_p)
+    endif
+  endif ! acoustic
+
+  if (ELASTIC_SIMULATION .or. POROELASTIC_SIMULATION) then
+    ! allocates div/curl arrays on global nodes
+    if (.not. allocated(div_on_node)) then
+      allocate(div_on_node(NGLOB_AB), &
+               curl_x_on_node(NGLOB_AB), &
+               curl_y_on_node(NGLOB_AB), &
+               curl_z_on_node(NGLOB_AB),stat=ier)
+      if (ier /= 0) call exit_MPI_without_rank('error allocating array 1737')
+      if (ier /= 0) stop 'error allocating array movie div and curl'
+      div_on_node(:) = 0._CUSTOM_REAL
+      curl_x_on_node(:) = 0._CUSTOM_REAL
+      curl_y_on_node(:) = 0._CUSTOM_REAL
+      curl_z_on_node(:) = 0._CUSTOM_REAL
+    endif
+
+    ! saves div field
+    !#TODO: hdf5 i/o server
+    !if (HDF5_IO_NNODES > 0) then
+    !  ! send div_glob
+    !  call isend_cr_inter(div_glob,NGLOB_AB,dest_ionod,io_tag_vol_divglob,req_dump_vol(req_count))
+    !  req_count = req_count+1
+    !else
+      ! direct io
+      divglob_io = .true.
+      call write_vol_data_hdf5(div_glob,"div_glob")
+    !endif
+
+    ! div and curl on elemental level
+    call elm2node_base(div,div_on_node)
+    call elm2node_base(curl_x,curl_x_on_node)
+    call elm2node_base(curl_x,curl_x_on_node)
+    call elm2node_base(curl_x,curl_x_on_node)
+
+    ! writes our divergence/curl
+    !#TODO: hdf5 i/o server
+    !if (HDF5_IO_NNODES > 0) then
+    !  ! div
+    !  call isend_cr_inter(div_on_node,NGLOB_AB,dest_ionod,io_tag_vol_div,req_dump_vol(req_count))
+    !  req_count = req_count+1
+    !  ! writes out curl
+    !  call isend_cr_inter(curl_x_on_node,NGLOB_AB,dest_ionod,io_tag_vol_curlx,req_dump_vol(req_count))
+    !  req_count = req_count+1
+    !  call isend_cr_inter(curl_y_on_node,NGLOB_AB,dest_ionod,io_tag_vol_curly,req_dump_vol(req_count))
+    !  req_count = req_count+1
+    !  call isend_cr_inter(curl_z_on_node,NGLOB_AB,dest_ionod,io_tag_vol_curlz,req_dump_vol(req_count))
+    !  req_count = req_count+1
+    !else
+      ! direct io
+      div_io = .true.
+      curl_io = .true.
+      call write_vol_data_hdf5(div_on_node,"div")
+      call write_vol_data_hdf5(curl_x_on_node,"curl_x")
+      call write_vol_data_hdf5(curl_y_on_node,"curl_y")
+      call write_vol_data_hdf5(curl_z_on_node,"curl_z")
+    !endif
+  endif ! elastic or poroelastic
+
+  ! velocity
+  if (.not. allocated(velocity_x_on_node)) then
+    allocate(velocity_x_on_node(NGLOB_AB), &
+             velocity_y_on_node(NGLOB_AB), &
+             velocity_z_on_node(NGLOB_AB),stat=ier)
+    if (ier /= 0) call exit_MPI_without_rank('error allocating array 1733')
+    if (ier /= 0) stop 'error allocating array movie velocity_x etc.'
+    velocity_x_on_node(:) = 0._CUSTOM_REAL
+    velocity_y_on_node(:) = 0._CUSTOM_REAL
+    velocity_z_on_node(:) = 0._CUSTOM_REAL
+  endif
+
+  ! save wavefield from local (NGLLX,NGLLY,NGLLZ,NSPEC) to global (NGLOB) indexing
+  ! given the wavefield is smooth and has no discontinuities at element boundaries, this shouldn't affect the wavefield shapes
+
+  ! uses velocity_x,.. as temporary arrays to store velocity on all GLL points
+  ! copy values on 1d array
+  call elm2node_base(wavefield_x, velocity_x_on_node)
+  call elm2node_base(wavefield_y, velocity_y_on_node)
+  call elm2node_base(wavefield_z, velocity_z_on_node)
+
+  ! saves wavefield components
+  !#TODO: hdf5 i/o server
+  !if (HDF5_IO_NNODES > 0) then
+  !  call isend_cr_inter(velocity_x_on_node,NGLOB_AB,dest_ionod,io_tag_vol_velox,req_dump_vol(req_count))
+  !  req_count = req_count+1
+  !  call isend_cr_inter(velocity_y_on_node,NGLOB_AB,dest_ionod,io_tag_vol_veloy,req_dump_vol(req_count))
+  !  req_count = req_count+1
+  !  call isend_cr_inter(velocity_z_on_node,NGLOB_AB,dest_ionod,io_tag_vol_veloz,req_dump_vol(req_count))
+  !  req_count = req_count+1
+  !else
+    ! direct io
+    veloc_io = .true.
+    call write_vol_data_hdf5(velocity_x_on_node,"veloc_x")
+    call write_vol_data_hdf5(velocity_y_on_node,"veloc_y")
+    call write_vol_data_hdf5(velocity_z_on_node,"veloc_z")
+  !endif
+
+  !#TODO: hdf5 i/o server
+  ! store the number of mpi_isend reqs
+  !n_req_vol = req_count-1
+
+  if (it == NTSTEP_BETWEEN_FRAMES) then
+    !#TODO: hdf5 i/o server
+    !if (HDF5_IO_NNODES == 0) then
+      ! create xdmf header
+      call write_xdmf_vol_hdf5(pressure_io, divglob_io, div_io, veloc_io, curl_io)
+    !endif
+  endif
+
+#else
+  ! no HDF5 compilation support
+
+  ! compilation without HDF5 support
+  print *
+  print *, "Error: HDF5 routine wmo_movie_save_volume_snapshot_hdf5() called without HDF5 Support."
+  print *, "To enable HDF5 support, reconfigure with --with-hdf5 flag."
+  print *
+
+  ! safety stop
+  stop 'wmo_movie_save_volume_snapshot_hdf5() called without compilation support'
+
+#endif
+
+  end subroutine wmo_movie_save_volume_snapshot_hdf5
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+#ifdef USE_HDF5
+
+  subroutine prepare_vol_movie_hdf5()
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+
+  integer, dimension(:,:), allocatable :: elm_conn_loc
+  character(len=64) :: group_name
+  character(len=64) :: dset_name
+  integer           :: iproc, ier, nglob_all, nspec_all
+  character(len=MAX_STRING_LEN) :: fname_h5_data_vol
+  logical,parameter :: if_collective = .true. ! in io_server.f90
+
+  allocate(nglob_par_proc_nio(0:NPROC-1), stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array nglob_par_proc')
+  if (ier /= 0) stop 'error allocating arrays for nglob_par_proc'
+  nglob_par_proc_nio(:) = 0
+   allocate(nelm_par_proc_nio(0:NPROC-1), stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array nelm_par_proc')
+  if (ier /= 0) stop 'error allocating arrays for nelm_par_proc'
+  nelm_par_proc_nio(:) = 0
+  allocate(nglob_offset(0:NPROC-1), stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array nglob_offset')
+  if (ier /= 0) stop 'error allocating arrays for nglob_offset'
+  nglob_offset(:) = 0
+  allocate(nelm_offset(0:NPROC-1), stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array nelm_offset')
+  if (ier /= 0) stop 'error allocating arrays for nelm_offset'
+  nelm_offset(:) = 0
+  allocate(elm_conn_loc(9,NSPEC_AB*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)),stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array elm_conn_loc')
+  if (ier /= 0) stop 'error allocating arrays for elm_conn_loc'
+  elm_conn_loc(:,:) = 0
+
+  fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume.h5"
+
+  ! initializes
+  call h5_init()
+
+  ! group for storing node coordinates and mesh element connectivity
+  group_name = "mesh"
+
+  call gather_all_all_singlei((/NSPEC_AB/),nelm_par_proc_nio,NPROC)
+  call gather_all_all_singlei((/NGLOB_AB/),nglob_par_proc_nio,NPROC)
+
+  nglob_all = sum(nglob_par_proc_nio(0:NPROC-1))
+  nspec_all = sum(nelm_par_proc_nio(0:NPROC-1))
+
+  nglob_offset(0) = 0
+  nelm_offset(0)  = 0
+  do iproc = 1, NPROC-1
+    nglob_offset(iproc) = sum(nglob_par_proc_nio(0:iproc-1))
+    nelm_offset(iproc)  = sum(nelm_par_proc_nio(0:iproc-1))
+  enddo
+  do iproc = 1,NPROC-1
+    nelm_offset(iproc) = nelm_offset(iproc)*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)
+  enddo
+
+  ! create connectivity dataset
+  call get_conn_for_movie(elm_conn_loc, nglob_offset(myrank))
+
+  if (myrank == 0) then
+   ! create a hdf5 file
+    call h5_create_file(fname_h5_data_vol)
+
+    ! create coordinate dataset
+    call h5_open_or_create_group(group_name)
+
+    dset_name = "elm_conn"
+    call h5_create_dataset_gen_in_group(dset_name, (/9,nspec_all*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)/), 2, 1)
+    dset_name = "x"
+    call h5_create_dataset_gen_in_group(dset_name, (/nglob_all/), 1, CUSTOM_REAL)
+    dset_name = "y"
+    call h5_create_dataset_gen_in_group(dset_name, (/nglob_all/), 1, CUSTOM_REAL)
+    dset_name = "z"
+    call h5_create_dataset_gen_in_group(dset_name, (/nglob_all/), 1, CUSTOM_REAL)
+
+    call h5_close_group()
+    call h5_close_file()
+  endif
+  call synchronize_all()
+
+  call h5_open_file_p(fname_h5_data_vol)
+  call h5_open_group(group_name)
+
+  dset_name = "elm_conn"
+  call h5_write_dataset_2d_i_collect_hyperslab_in_group(dset_name,elm_conn_loc,(/0,nelm_offset(myrank)/),if_collective)
+  dset_name = "x"
+  call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name,xstore,(/nglob_offset(myrank)/),if_collective)
+  dset_name = "y"
+  call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name,ystore,(/nglob_offset(myrank)/),if_collective)
+  dset_name = "z"
+  call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name,zstore,(/nglob_offset(myrank)/),if_collective)
+
+  call h5_close_group()
+  call h5_close_file()
+  call h5_destructor()
+
+  end subroutine prepare_vol_movie_hdf5
+
+#endif
+!
+!-------------------------------------------------------------------------------------------------
+!
+#ifdef USE_HDF5
+
+  subroutine write_vol_data_hdf5(darr, dset_name)
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+
+  real(kind=CUSTOM_REAL), dimension(NGLOB_AB), intent(in) :: darr
+  character(len=*), intent(in)                     :: dset_name
+  ! local parameters
+  integer :: dim
+  character(len=64) :: group_name
+  character(len=12) :: tempstr
+  character(len=MAX_STRING_LEN) :: fname_h5_data_vol
+
+  integer, parameter :: rank = 1
+  logical, parameter :: if_collective = .true.
+
+  fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume.h5"
+
+  ! initializes
+  call h5_init()
+
+  ! create a group for each io step
+  write(tempstr, "(i6.6)") it
+  group_name = "it_" // trim(tempstr)
+
+  dim = sum(nglob_par_proc_nio(:))
+
+  if (myrank == 0) then
+    ! create it group
+    call h5_open_file(fname_h5_data_vol)
+
+    ! check if group_name exists
+    call h5_open_or_create_group(group_name)
+
+    ! create dataset
+    call h5_create_dataset_gen_in_group(dset_name, (/dim/), rank, CUSTOM_REAL)
+    call h5_close_group()
+    call h5_close_file()
+  endif
+
+  call synchronize_all()
+
+  ! collective write
+  call h5_open_file_p(fname_h5_data_vol)
+  call h5_open_group(group_name)
+  call h5_write_dataset_1d_r_collect_hyperslab_in_group(dset_name, &
+                                darr, (/nglob_offset(myrank)/), if_collective)
+
+  call h5_close_group()
+  call h5_close_file()
+  call h5_destructor()
+
+  end subroutine write_vol_data_hdf5
+
+#endif
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+#ifdef USE_HDF5
+
+  subroutine write_xdmf_vol_hdf5(pressure_io, divglob_io, div_io, veloc_io, curl_io)
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+
+  logical, intent(in) :: pressure_io, divglob_io, div_io, veloc_io, curl_io
+
+  ! local parameters
+  integer :: i, ii
+  character(len=20) :: it_str,nelm_str,nglo_str
+  character(len=MAX_STRING_LEN) :: fname_xdmf_vol
+  character(len=MAX_STRING_LEN) :: fname_h5_data_vol_xdmf
+
+  ! checks if anything do, only main process writes out xdmf file
+  if (myrank /= 0) return
+
+  ! writeout xdmf file for volume movie
+  fname_xdmf_vol = trim(OUTPUT_FILES) // "/movie_volume.xmf"
+  fname_h5_data_vol_xdmf = "./movie_volume.h5"  ! relative to movie_volume.xmf file
+  ! this seems to point to a wrong director:
+  !   fname_h5_data_vol_xdmf = trim(OUTPUT_FILES) // "/movie_volume.h5"
+
+  open(unit=xdmf_vol, file=trim(fname_xdmf_vol), recl=256)
+
+  ! definition of topology and geometry
+  ! refer only control nodes (8 or 27) as a coarse output
+  ! data array need to be extracted from full data array on GLL points
+  write(xdmf_vol,'(a)') '<?xml version="1.0" ?>'
+  write(xdmf_vol,*) '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>'
+  write(xdmf_vol,*) '<Xdmf xmlns:xi="http://www.w3.org/2003/XInclude" Version="3.0">'
+  write(xdmf_vol,*) '<Domain name="mesh">'
+
+  ! loop for writing information of mesh partitions
+  nelm_str = i2c(sum(nelm_par_proc_nio(:))*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1))
+  nglo_str = i2c(sum(nglob_par_proc_nio(:)))
+
+  write(xdmf_vol,*) '<Topology TopologyType="Mixed" NumberOfElements="'//trim(nelm_str)//'">'
+  write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Int" Precision="4" Dimensions="'&
+                         //trim(nelm_str)//' 9">'
+  write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/elm_conn'
+  write(xdmf_vol,*) '</DataItem>'
+  write(xdmf_vol,*) '</Topology>'
+  write(xdmf_vol,*) '<Geometry GeometryType="X_Y_Z">'
+  write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                      //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+  write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/x'
+  write(xdmf_vol,*) '</DataItem>'
+  write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                      //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+  write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/y'
+  write(xdmf_vol,*) '</DataItem>'
+  write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                      //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+  write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/z'
+  write(xdmf_vol,*) '</DataItem>'
+  write(xdmf_vol,*) '</Geometry>'
+  write(xdmf_vol,*) '<Grid Name="time_col" GridType="Collection" CollectionType="Temporal">'
+
+  do i = 1, int(NSTEP/NTSTEP_BETWEEN_FRAMES)
+
+    ii = i*NTSTEP_BETWEEN_FRAMES
+    write(it_str, "(i6.6)") ii
+
+    write(xdmf_vol,*) '<Grid Name="vol_mov" GridType="Uniform">'
+    write(xdmf_vol,*) '<Time Value="'//trim(r2c(sngl((ii-1)*DT-t0)))//'" />'
+    write(xdmf_vol,*) '<Topology Reference="/Xdmf/Domain/Topology" />'
+    write(xdmf_vol,*) '<Geometry Reference="/Xdmf/Domain/Geometry" />'
+
+    if (pressure_io) then
+      write(xdmf_vol,*) '<Attribute Name="pressure" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/pressure'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    if (divglob_io) then
+      write(xdmf_vol,*) '<Attribute Name="div_glob" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/div_glob'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    if (div_io) then
+      write(xdmf_vol,*) '<Attribute Name="div" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/div'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    if (veloc_io) then
+      write(xdmf_vol,*) '<Attribute Name="veloc_x" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/veloc_x'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+      write(xdmf_vol,*) '<Attribute Name="veloc_y" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/veloc_y'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+      write(xdmf_vol,*) '<Attribute Name="veloc_z" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/veloc_z'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    if (curl_io) then
+      write(xdmf_vol,*) '<Attribute Name="curl_x" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                     //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/curl_x'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+      write(xdmf_vol,*) '<Attribute Name="curl_y" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                     //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/curl_y'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+      write(xdmf_vol,*) '<Attribute Name="curl_z" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                     //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/curl_z'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    write(xdmf_vol,*) '</Grid>'
+  enddo
+
+  ! file finish
+  write(xdmf_vol,*) '</Grid>'
+  write(xdmf_vol,*) '</Domain>'
+  write(xdmf_vol,*) '</Xdmf>'
+
+  close(xdmf_vol)
+
+  end subroutine write_xdmf_vol_hdf5
+
+#endif

--- a/src/specfem3D/write_output_HDF5.F90
+++ b/src/specfem3D/write_output_HDF5.F90
@@ -53,14 +53,16 @@
 
 ! HDF5 writes into a single file (by main process only)
 
-  !#TODO: io server
-  !if (HDF5_IO_NNODES > 0) then
-  !  ! only io nodes do the file output
-  !  ! collect seismograms on io nodes
-  !else
-  !  ! no io server
-  !  ! main process writes out all
-  !endif
+  ! io server
+  if (HDF5_IO_NNODES > 0) then
+    ! only io nodes do the file output
+    ! collect seismograms on io nodes
+    stop 'HDF5 IO server not implemented yet for HDF5 file output'
+  else
+    ! no io server
+    ! main process writes out all
+    continue
+  endif
 
   ! safety check
   if (.not. WRITE_SEISMOGRAMS_BY_MAIN) &


### PR DESCRIPTION
adds a corresponding entry to the Par_files, like 
```
HDF5_FOR_MOVIES                 = .false.
```
that can be turned on for HDF5 file output related to movie & shakemap simulations.