### PR TITLE
adds HDF5 I/O server functionality

### DIFF
--- a/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ACOUSTIC/DATA/Par_file
+++ b/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ACOUSTIC/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ACOUSTIC_ELASTIC/DATA/Par_file
+++ b/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ACOUSTIC_ELASTIC/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ELASTIC/DATA/Par_file
+++ b/EXAMPLES/BENCHMARK_CLAERBOUT_ADJOINT/ELASTIC/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_absorbing_CPML_5sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_absorbing_CPML_5sides/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_absorbing_CPML_6sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_absorbing_CPML_6sides/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_elastic_absorbing_CPML_5sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_elastic_absorbing_CPML_5sides/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_elastic_absorbing_CPML_6sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_acoustic_elastic_absorbing_CPML_6sides/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_elastic_absorbing_CPML_5sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_elastic_absorbing_CPML_5sides/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_elastic_absorbing_CPML_6sides/DATA/Par_file
+++ b/EXAMPLES/CPML_examples/homogeneous_halfspace_HEX8_elastic_absorbing_CPML_6sides/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/Gmsh_simple_box_hex27/DATA/Par_file
+++ b/EXAMPLES/Gmsh_simple_box_hex27/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/Gmsh_simple_lddrk/DATA/Par_file
+++ b/EXAMPLES/Gmsh_simple_lddrk/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/LTS_homogeneous_halfspace_HEX8/DATA/Par_file
+++ b/EXAMPLES/LTS_homogeneous_halfspace_HEX8/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/Mount_StHelens/DATA/Par_file
+++ b/EXAMPLES/Mount_StHelens/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/analytic_examples/analytic_solution_elastic/DATA/Par_file
+++ b/EXAMPLES/analytic_examples/analytic_solution_elastic/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/attenuation/viscoelastic/DATA/Par_file
+++ b/EXAMPLES/attenuation/viscoelastic/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/check_absolute_amplitude_of_force_source_seismograms/DATA/Par_file
+++ b/EXAMPLES/check_absolute_amplitude_of_force_source_seismograms/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/coffee_mug_with_fluid_inside/DATA/Par_file
+++ b/EXAMPLES/coffee_mug_with_fluid_inside/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/decompose_mesh_MPI/DATA/Par_file
+++ b/EXAMPLES/decompose_mesh_MPI/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/decompose_mesh_MPI_with_faults/DATA/Par_file
+++ b/EXAMPLES/decompose_mesh_MPI_with_faults/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/fault_examples/hete_fault_properties/DATA/Par_file
+++ b/EXAMPLES/fault_examples/hete_fault_properties/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/fault_examples/splay_faults/DATA/Par_file
+++ b/EXAMPLES/fault_examples/splay_faults/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/fault_examples/tpv102/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv102/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/fault_examples/tpv103/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv103/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/fault_examples/tpv15/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv15/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/fault_examples/tpv16/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv16/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/fault_examples/tpv5/DATA/Par_file
+++ b/EXAMPLES/fault_examples/tpv5/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/homogeneous_acoustic/DATA/Par_file
+++ b/EXAMPLES/homogeneous_acoustic/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/homogeneous_halfspace_HEX27_elastic_no_absorbing/DATA/Par_file
+++ b/EXAMPLES/homogeneous_halfspace_HEX27_elastic_no_absorbing/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
+++ b/EXAMPLES/homogeneous_halfspace_HEX8_elastic_absorbing_Stacey_5sides/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/homogeneous_halfspace_HEX8_elastic_no_absorbing/DATA/Par_file
+++ b/EXAMPLES/homogeneous_halfspace_HEX8_elastic_no_absorbing/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/homogeneous_poroelastic/DATA/Par_file
+++ b/EXAMPLES/homogeneous_poroelastic/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/homogeneous_poroelastic/DATA/Par_file_coarse
+++ b/EXAMPLES/homogeneous_poroelastic/DATA/Par_file_coarse
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/inversion_examples/fwi_test_acoustic/DATA/Par_file
+++ b/EXAMPLES/inversion_examples/fwi_test_acoustic/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/layered_halfspace/DATA/Par_file
+++ b/EXAMPLES/layered_halfspace/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/meshfem3D_examples/cavity/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/cavity/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/meshfem3D_examples/cavity/DATA/Par_file.96procs
+++ b/EXAMPLES/meshfem3D_examples/cavity/DATA/Par_file.96procs
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/meshfem3D_examples/many_interfaces/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/many_interfaces/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/meshfem3D_examples/regular_element_mesh/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/regular_element_mesh/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/meshfem3D_examples/sep_bathymetry/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/sep_bathymetry/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/meshfem3D_examples/simple_model/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/simple_model/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/meshfem3D_examples/socal1D/DATA/Par_file
+++ b/EXAMPLES/meshfem3D_examples/socal1D/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/meshfem3D_examples/socal1D/example_utm/Par_file_utm
+++ b/EXAMPLES/meshfem3D_examples/socal1D/example_utm/Par_file_utm
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/meshfem3D_examples/socal1D/run_this_example_HDF5_IO_server.sh
+++ b/EXAMPLES/meshfem3D_examples/socal1D/run_this_example_HDF5_IO_server.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+echo "running example: `date`"
+currentdir=`pwd`
+
+# sets up directory structure in current example directory
+echo
+echo "setting up example..."
+echo
+
+# checks if executables were compiled and available
+if [ ! -e ../../../bin/xspecfem3D ]; then
+  echo "Please compile first all binaries in the root directory, before running this example..."; echo
+  exit 1
+fi
+
+# cleans output files
+mkdir -p OUTPUT_FILES
+rm -rf OUTPUT_FILES/*
+
+# links executables
+mkdir -p bin
+cd bin/
+rm -f *
+ln -s ../../../../bin/xmeshfem3D
+ln -s ../../../../bin/xgenerate_databases
+ln -s ../../../../bin/xspecfem3D
+cd ../
+
+# stores setup
+cp DATA/meshfem3D_files/Mesh_Par_file OUTPUT_FILES/
+cp DATA/Par_file OUTPUT_FILES/
+cp DATA/CMTSOLUTION OUTPUT_FILES/
+cp DATA/STATIONS OUTPUT_FILES/
+
+# get the number of processors, ignoring comments in the Par_file
+NPROC=`grep ^NPROC DATA/Par_file | sed 's/#.*//' | cut -d = -f 2`
+
+# HDF5 i/o server
+# get the number of io server propcessors, ignoring comments in the Par_file
+IO_NODES=`grep ^HDF5_IO_NODES DATA/Par_file | sed 's/#.*//' | cut -d = -f 2`
+
+echo
+echo "Par_file setup:"
+echo "  NPROC         = $NPROC"
+echo "  HDF5_IO_NODES = $IO_NODES"
+echo
+
+BASEMPIDIR=`grep ^LOCAL_PATH DATA/Par_file | cut -d = -f 2 `
+mkdir -p $BASEMPIDIR
+
+# runs in-house mesher
+if [ "$NPROC" -eq 1 ]; then
+  # This is a serial simulation
+  echo
+  echo "running mesher..."
+  echo
+  ./bin/xmeshfem3D
+else
+  # This is a MPI simulation
+  echo
+  echo "running mesher on $NPROC processors..."
+  echo
+  mpirun -np $NPROC ./bin/xmeshfem3D
+fi
+# checks exit code
+if [[ $? -ne 0 ]]; then exit 1; fi
+
+# runs database generation
+if [ "$NPROC" -eq 1 ]; then
+  # This is a serial simulation
+  echo
+  echo "running database generation..."
+  echo
+  ./bin/xgenerate_databases
+else
+  # This is a MPI simulation
+  echo
+  echo "running database generation on $NPROC processors..."
+  echo
+  mpirun -np $NPROC ./bin/xgenerate_databases
+fi
+# checks exit code
+if [[ $? -ne 0 ]]; then exit 1; fi
+
+
+# HDF5 i/o server
+# setting new total number of MPI processes
+# solver runs with (NPROC + IO_NODES) mpi processes
+
+NPROC=$(($NPROC+$IO_NODES))
+
+
+# runs simulation
+if [ "$NPROC" -eq 1 ]; then
+  # This is a serial simulation
+  echo
+  echo "running solver..."
+  echo
+  ./bin/xspecfem3D
+else
+  # This is a MPI simulation
+  echo
+  echo "running solver on $NPROC processors..."
+  echo
+  mpirun -np $NPROC ./bin/xspecfem3D
+fi
+# checks exit code
+if [[ $? -ne 0 ]]; then exit 1; fi
+
+echo
+echo "see results in directory: OUTPUT_FILES/"
+echo
+echo "done"
+echo `date`
+
+
+# To create a full mesh using combine_vol_data:
+# cd bin
+# xcombine_vol_data 0 0 vs ../OUTPUT_FILES/DATABASES_MPI/ ../OUTPUT_FILES/DATABASES_MPI/ 1
+# cd ../OUTPUT_FILES/DATABASES_MPI/
+# (check that mesh2vtu.pl is working)
+# ../../../../../utils/Visualization/Paraview/mesh2vtu.pl -i vs.mesh -o vs.vtu
+#
+
+

--- a/EXAMPLES/noise_non_uniform/DATA/Par_file
+++ b/EXAMPLES/noise_non_uniform/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/noise_non_uniform/DATA/Par_file_step1
+++ b/EXAMPLES/noise_non_uniform/DATA/Par_file_step1
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/noise_non_uniform/DATA/Par_file_step2
+++ b/EXAMPLES/noise_non_uniform/DATA/Par_file_step2
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/noise_tomography/DATA/Par_file
+++ b/EXAMPLES/noise_tomography/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file
+++ b/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file_one_proc
+++ b/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file_one_proc
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file_several_proc
+++ b/EXAMPLES/oldstuff/small_example_coupling_axisem_specfem_matlab_gui_CURRENTLY_BROKEN_according_to_Vadim/Param_files/DATA/Par_file_several_proc
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/oldstuff/small_example_please_do_not_remove_CURRENTLY_BROKEN_according_to_Vadim/create_data/DATA/Par_file
+++ b/EXAMPLES/oldstuff/small_example_please_do_not_remove_CURRENTLY_BROKEN_according_to_Vadim/create_data/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/oldstuff/small_example_please_do_not_remove_CURRENTLY_BROKEN_according_to_Vadim/fwi_fk/DATA/Par_file
+++ b/EXAMPLES/oldstuff/small_example_please_do_not_remove_CURRENTLY_BROKEN_according_to_Vadim/fwi_fk/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/seismoacoustic_bishop2022/DATA_FIG4/Par_file
+++ b/EXAMPLES/seismoacoustic_bishop2022/DATA_FIG4/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/seismoacoustic_bishop2022/DATA_FIG8/Par_file
+++ b/EXAMPLES/seismoacoustic_bishop2022/DATA_FIG8/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/sensitivity_kernels_liutromp2006/DATA/Par_file
+++ b/EXAMPLES/sensitivity_kernels_liutromp2006/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/small_adjoint_multiple_sources/DATA/Par_file
+++ b/EXAMPLES/small_adjoint_multiple_sources/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/small_example_coupling_FK_specfem/DATA/Par_file
+++ b/EXAMPLES/small_example_coupling_FK_specfem/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file_one_proc
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file_one_proc
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file_several_proc
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files/DATA/Par_file_several_proc
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file_one_proc
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file_one_proc
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file_several_proc
+++ b/EXAMPLES/small_example_coupling_axisem_specfem/Param_files_for_buried_box/DATA/Par_file_several_proc
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/tomographic_model/DATA/Par_file
+++ b/EXAMPLES/tomographic_model/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/waterlayered_halfspace/DATA/Par_file
+++ b/EXAMPLES/waterlayered_halfspace/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/EXAMPLES/waterlayered_poroelastic/DATA/Par_file
+++ b/EXAMPLES/waterlayered_poroelastic/DATA/Par_file
@@ -393,4 +393,5 @@ ADIOS_FOR_UNDO_ATTENUATION      = .false.
 # (note the flags for HDF5 and ADIOS are mutually exclusive, only one can be used)
 HDF5_ENABLED                    = .false.
 HDF5_FOR_MOVIES                 = .false.
+HDF5_IO_NODES                   = 0   # HDF5 IO server with number of IO dedicated procs
 

--- a/src/decompose_mesh/write_mesh_databases_hdf5.F90
+++ b/src/decompose_mesh/write_mesh_databases_hdf5.F90
@@ -94,7 +94,7 @@
   name_database_hdf5 = outputpath_name(1:len_trim(outputpath_name))//'/'//prname
 
   ! initialize hdf5 io
-  call h5_init()
+  call h5_initialize()
 
   ! create a hdf5 file
   call h5_create_file(name_database_hdf5)
@@ -235,7 +235,7 @@
                                         mat_prop, undef_mat_prop)
 
   call h5_close_file()
-  call h5_destructor()
+  call h5_finalize()
 
   if (COUPLE_WITH_INJECTION_TECHNIQUE .or. MESH_A_CHUNK_OF_THE_EARTH) close(124)
 

--- a/src/generate_databases/read_partition_files_hdf5.F90
+++ b/src/generate_databases/read_partition_files_hdf5.F90
@@ -87,7 +87,7 @@
   call world_get_info_null(info)
 
   ! initializes HDF5
-  call h5_init()
+  call h5_initialize()
   call h5_set_mpi_info(comm, info, myrank, NPROC)
 
   ! opens file
@@ -601,7 +601,7 @@
 
   ! close hdf5
   call h5_close_file_p()
-  call h5_destructor()
+  call h5_finalize()
 
 #else
   ! no HDF5 compilation support

--- a/src/generate_databases/save_arrays_solver_hdf5.F90
+++ b/src/generate_databases/save_arrays_solver_hdf5.F90
@@ -162,7 +162,7 @@
   call world_get_info_null(info)
 
   ! initialize h5 object
-  call h5_init()
+  call h5_initialize()
   call h5_set_mpi_info(comm, info, myrank, NPROC)
 
   !
@@ -1443,7 +1443,7 @@
   endif
 
   call h5_close_file_p()
-  call h5_destructor()
+  call h5_finalize()
 
   ! user output
   call synchronize_all()

--- a/src/inverse_problem_for_model/rules.mk
+++ b/src/inverse_problem_for_model/rules.mk
@@ -156,6 +156,7 @@ inverse_problem_for_model_OBJECTS += \
 	$O/get_elevation.spec.o \
 	$O/get_force.spec.o \
 	$O/gravity_perturbation.spec.o \
+	$O/hdf5_io_server.spec_hdf5.o \
 	$O/initialize_simulation.spec.o \
 	$O/iterate_time.spec.o \
 	$O/locate_MPI_slice.spec.o \

--- a/src/meshfem3D/save_databases_hdf5.F90
+++ b/src/meshfem3D/save_databases_hdf5.F90
@@ -171,7 +171,7 @@
   call world_get_info_null(info)
 
   ! initialize hdf5 io
-  call h5_init()
+  call h5_initialize()
   ! set MPI info
   call h5_set_mpi_info(comm, info, myrank, NPROC)
 
@@ -692,7 +692,6 @@
     dset_name = "offset_nb_interfaces"
     call h5_write_dataset_no_group(dset_name, offset_nb_interfaces)
 
-
     ! create dataset by main process
     call h5_close_file_p()
 
@@ -889,7 +888,7 @@
   call h5_write_dataset_collect_hyperslab(dset_name, num_interface_and_max, (/myrank*2/), .true.)
 
   call h5_close_file_p()
-  call h5_destructor()
+  call h5_finalize()
 
   call synchronize_all()
 

--- a/src/shared/exit_mpi.f90
+++ b/src/shared/exit_mpi.f90
@@ -123,6 +123,8 @@
 
 ! flushes possible left-overs from print-statements
 
+  use iso_Fortran_env, only: stdout => output_unit
+
   implicit none
 
   logical :: is_connected
@@ -135,12 +137,21 @@
 
   ! checks default stdout unit 6
   inquire(unit=6,opened=is_connected)
-  if (is_connected) &
+  if (is_connected) then
     flush(6)
+    return
+  endif
 
   ! checks Cray stdout unit 101
   inquire(unit=101,opened=is_connected)
-  if (is_connected) &
+  if (is_connected) then
     flush(101)
+    return
+  endif
+
+  ! fallback, try stdout
+  if (.not. is_connected) then
+    flush(stdout)
+  endif
 
   end subroutine flush_stdout

--- a/src/shared/hdf5_manager.F90
+++ b/src/shared/hdf5_manager.F90
@@ -4818,6 +4818,8 @@ end module manager_hdf5
 
 !-----------------------------------------------------
 
+#if defined(USE_HDF5)
+
 ! test function for object-oriented interface
 
   subroutine test_io_hdf5()
@@ -4850,3 +4852,4 @@ end module manager_hdf5
     ! h5 goes out of scope, will call the object destructor, i.e., h5io_destructor()
   end subroutine test_io_hdf5
 
+#endif

--- a/src/shared/read_parameter_file.F90
+++ b/src/shared/read_parameter_file.F90
@@ -802,7 +802,7 @@
       ! (optional) movie outputs
       call read_value_logical(HDF5_FOR_MOVIES, 'HDF5_FOR_MOVIES', ier); ier = 0
       ! (optional) number of io dedicated nodes
-      call read_value_integer(HDF5_IO_NNODES, 'HDF5_IO_NNODES', ier); ier = 0
+      call read_value_integer(HDF5_IO_NODES, 'HDF5_IO_NODES', ier); ier = 0
     endif
 
     ! closes parameter file
@@ -992,10 +992,9 @@
     stop 'HDF5_FORMAT and SU_FORMAT together are not supported, please use only one of them'
   if (HDF5_FORMAT .and. .not. WRITE_SEISMOGRAMS_BY_MAIN) &
     stop 'HDF5_FORMAT must have WRITE_SEISMOGRAMS_BY_MAIN set to .true.'
-
-  !#TODO: hdf5 i/o server
-  if (HDF5_IO_NNODES > 0) &
-    stop 'HDF5_IO_NNODES must be zero, i/o server not implemented yet'
+  ! hdf5 i/o server
+  if (HDF5_IO_NODES < 0) &
+    stop 'HDF5_IO_NODES must be zero or positive'
 
   ! PML
   if (PML_CONDITIONS) then
@@ -1428,7 +1427,7 @@
   call bcast_all_singlel(HDF5_FORMAT)
   call bcast_all_singlel(HDF5_ENABLED)
   call bcast_all_singlel(HDF5_FOR_MOVIES)
-  call bcast_all_singlei(HDF5_IO_NNODES)
+  call bcast_all_singlei(HDF5_IO_NODES)
 
   ! broadcast all parameters computed from others
   call bcast_all_singlei(IMODEL)

--- a/src/shared/serial.f90
+++ b/src/shared/serial.f90
@@ -1377,9 +1377,11 @@
   implicit none
 
   integer, intent(in) :: comm
+  integer :: unused_i
 
   ! tests if communicator is valid
   is_valid_comm = .false.
+  unused_i = comm
 
   end function is_valid_comm
 
@@ -1396,6 +1398,23 @@
   comm = 0
 
   end subroutine world_get_comm
+
+!
+!-----
+!
+
+  subroutine world_set_comm(comm)
+
+  implicit none
+
+  integer,intent(in) :: comm
+
+  integer :: unused_i
+
+  stop 'world_set_comm not implemented for serial code'
+  unused_i = comm
+
+  end subroutine world_set_comm
 
 !
 !----
@@ -1439,6 +1458,22 @@
   info = 0
 
   end subroutine world_get_info_null
+
+!
+!-----
+!
+
+  subroutine world_get_size_msg(status,size)
+
+  integer, intent(in) :: status(1)
+  integer, intent(out) :: size
+  integer(kind=4) :: unused_i4
+
+  stop 'world_get_size_msg not implemented for serial code'
+  unused_i4 = status(1)
+  size = 0
+
+  end subroutine world_get_size_msg
 
 !
 !----
@@ -1491,3 +1526,385 @@
 
   end subroutine bcast_all_l_array
 
+!
+!-----
+!
+
+  subroutine world_get_processor_name(name,size)
+
+  use constants, only: MAX_STRING_LEN
+
+  implicit none
+
+  character(len=MAX_STRING_LEN),intent(out) :: name
+  integer,intent(out) :: size
+
+  stop 'world_get_processor_name not implemented for serial code'
+  name = ""
+  size = 0
+
+  end subroutine world_get_processor_name
+
+
+!-----
+!
+! inter-communication group
+!
+!-----
+
+!-------------------------------------------------------------------------------------------------
+
+  subroutine world_set_comm_inter(comm)
+
+  implicit none
+
+  integer,intent(in) :: comm
+  integer :: unused_i
+
+  stop 'world_set_comm_inter not implemented for serial code'
+  unused_i = comm
+
+  end subroutine world_set_comm_inter
+
+!
+!-----
+!
+
+  subroutine world_probe_any_inter(status)
+
+  ! wait for an arrival of any MPI message
+
+  implicit none
+  integer,dimension(1),intent(inout) :: status
+  integer :: unused_i
+
+  stop 'world_probe_any_inter not implemented for serial code'
+  unused_i = status(1)
+
+  end subroutine world_probe_any_inter
+
+!
+!-----
+!
+
+  subroutine world_probe_tag_inter(tag,status)
+
+  ! wait for an arrival of a specific tag MPI message
+
+  implicit none
+  integer, intent(in) :: tag
+  integer, dimension(1), intent(inout) :: status
+  integer :: unused_i
+
+  stop 'world_probe_tag_inter not implemented for serial code'
+  unused_i = tag
+  status(1) = 0
+
+  end subroutine world_probe_tag_inter
+
+!
+!-----
+!
+
+  subroutine synchronize_inter()
+
+  implicit none
+
+  end subroutine synchronize_inter
+
+!
+!------
+!
+
+  subroutine world_comm_free_inter()
+
+  implicit none
+
+  end subroutine world_comm_free_inter
+
+!
+!------
+!
+
+  subroutine world_comm_split(comm, key, rank, split_comm)
+
+  implicit none
+  integer, intent(in) :: comm, key, rank
+  integer, intent(inout) :: split_comm
+  integer :: unused_i
+
+  stop 'world_comm_split not implemented for serial code'
+  unused_i = comm
+  unused_i = key
+  unused_i = rank
+  split_comm = 0
+
+  end subroutine world_comm_split
+
+!
+!------
+!
+
+  subroutine world_create_intercomm(local_comm, local_leader, group_comm, remote_leader, tag, inter_comm)
+
+  implicit none
+  integer, intent(in) :: local_comm, local_leader, group_comm, remote_leader, tag
+  integer, intent(inout) :: inter_comm
+  integer :: unused_i
+
+  stop 'world_create_intercomm not implemented for serial code'
+  unused_i = local_comm
+  unused_i = local_leader
+  unused_i = group_comm
+  unused_i = remote_leader
+  unused_i = tag
+  inter_comm = 0
+
+  end subroutine world_create_intercomm
+
+!
+!-------
+!
+
+  subroutine recv_i_inter(recvbuf, recvcount, dest, recvtag )
+
+  implicit none
+
+  integer :: dest,recvtag
+  integer :: recvcount
+  integer,dimension(recvcount):: recvbuf
+
+  integer(kind=4) :: unused_i4
+
+  stop 'recv_i_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = recvtag
+  unused_i4 = recvbuf(1)
+
+  end subroutine recv_i_inter
+
+!
+!------
+!
+
+  subroutine recv_dp_inter(recvbuf, recvcount, dest, recvtag)
+
+  implicit none
+
+  integer :: dest,recvtag
+  integer :: recvcount
+  double precision,dimension(recvcount):: recvbuf
+
+  integer(kind=4) :: unused_i4
+  double precision :: unused_dp
+
+  stop 'recv_dp_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = recvtag
+  unused_dp = recvbuf(1)
+
+  end subroutine recv_dp_inter
+
+!
+!------
+!
+
+  subroutine recvv_cr_inter(recvbuf, recvcount, dest, recvtag)
+
+  use constants, only: CUSTOM_REAL
+  implicit none
+
+  integer :: recvcount,dest,recvtag
+  real(kind=CUSTOM_REAL),dimension(recvcount) :: recvbuf
+
+  integer(kind=4) :: unused_i4
+  real(kind=CUSTOM_REAL) :: unused_cr
+
+  stop 'recvv_cr_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = recvtag
+  unused_cr = recvbuf(1)
+
+  end subroutine recvv_cr_inter
+
+!
+!------
+!
+
+  subroutine irecvv_cr_inter(recvbuf, recvcount, dest, recvtag, req)
+
+  use constants, only: CUSTOM_REAL
+  implicit none
+
+  integer :: recvcount,dest,recvtag,req
+  real(kind=CUSTOM_REAL),dimension(recvcount) :: recvbuf
+
+  integer(kind=4) :: unused_i4
+  real(kind=CUSTOM_REAL) :: unused_cr
+
+  stop 'irecvv_cr_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = req
+  unused_i4 = recvtag
+  unused_cr = recvbuf(1)
+
+  end subroutine irecvv_cr_inter
+
+!
+!-------
+!
+
+  subroutine isend_cr_inter(sendbuf, sendcount, dest, sendtag, req)
+
+  use constants, only: CUSTOM_REAL
+  implicit none
+
+  integer :: sendcount, dest, sendtag, req
+  real(kind=CUSTOM_REAL), dimension(sendcount) :: sendbuf
+
+  integer(kind=4) :: unused_i4
+  real(kind=CUSTOM_REAL) :: unused_cr
+
+  stop 'isend_cr_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = sendtag
+  unused_i4 = req
+  unused_cr = sendbuf(1)
+
+  end subroutine isend_cr_inter
+
+!
+!-------
+!
+
+  subroutine send_i_inter(sendbuf, sendcount, dest, sendtag)
+
+  implicit none
+
+  integer :: dest,sendtag
+  integer :: sendcount
+  integer,dimension(sendcount):: sendbuf
+
+  integer(kind=4) :: unused_i4
+
+  stop 'send_i_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = sendtag
+  unused_i4 = sendbuf(1)
+
+  end subroutine send_i_inter
+
+!
+!--------
+!
+
+  subroutine send_dp_inter(sendbuf, sendcount, dest, sendtag)
+
+  implicit none
+
+  integer :: dest,sendtag
+  integer :: sendcount
+  double precision,dimension(sendcount):: sendbuf
+
+  integer(kind=4) :: unused_i4
+  double precision :: unused_dp
+
+  stop 'send_dp_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = sendtag
+  unused_dp = sendbuf(1)
+
+  end subroutine send_dp_inter
+
+!
+!-------
+!
+
+  subroutine sendv_cr_inter(sendbuf, sendcount, dest, sendtag)
+
+  use constants, only: CUSTOM_REAL
+  implicit none
+
+  integer :: sendcount,dest,sendtag
+  real(kind=CUSTOM_REAL),dimension(sendcount) :: sendbuf
+
+  integer(kind=4) :: unused_i4
+  real(kind=CUSTOM_REAL) :: unused_cr
+
+  stop 'send_cr_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = sendtag
+  unused_cr = sendbuf(1)
+
+  end subroutine sendv_cr_inter
+
+!
+!-------
+!
+
+  subroutine gather_all_all_single_ch(sendbuf, recvbuf, NPROC, dim1)
+
+  implicit none
+
+  integer, intent(in) :: dim1 ! character length
+  integer, intent(in) :: NPROC
+  character(len=dim1), intent(in) :: sendbuf
+  character(len=dim1), dimension(0:NPROC-1), intent(inout) :: recvbuf
+
+  character(len=1) :: unused_ch
+
+  stop 'send_cr_inter not implemented for serial code'
+  unused_ch = sendbuf(1:1)
+  recvbuf(:) = ""
+
+  end subroutine gather_all_all_single_ch
+
+!
+!--------
+!
+
+! unused so far...
+
+!  subroutine gatherv_all_cr_inter(sendbuf, sendcnt, recvbuf, recvcount, recvoffset,recvcounttot, NPROC)
+!
+!  use constants, only: CUSTOM_REAL
+!  implicit none
+!
+!  integer :: sendcnt,recvcounttot,NPROC
+!  integer, dimension(NPROC) :: recvcount,recvoffset
+!  real(kind=CUSTOM_REAL), dimension(sendcnt) :: sendbuf
+!  real(kind=CUSTOM_REAL), dimension(recvcounttot) :: recvbuf
+!
+!  integer(kind=4) :: unused_i4
+!  real(kind=CUSTOM_REAL) :: unused_cr
+!
+!  stop 'gatherv_all_cr_inter not implemented for serial code'
+!  unused_i4 = recvcount(1)
+!  unused_i4 = recvoffset(1)
+!  unused_cr = sendbuf(1)
+!  unused_cr = recvbuf(1)
+!
+!  end subroutine gatherv_all_cr_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+! unused so far...
+
+!  subroutine isend_i_inter(sendbuf, sendcount, dest, sendtag, req)
+!
+!  implicit none
+!
+!  integer :: sendcount, dest, sendtag, req
+!  integer, dimension(sendcount) :: sendbuf
+!
+!  integer(kind=4) :: unused_i4
+!
+!  stop 'isend_i_inter not implemented for serial code'
+!  unused_i4 = dest
+!  unused_i4 = sendtag
+!  unused_i4 = req
+!  unused_i4 = sendbuf(1)
+!
+!  end subroutine isend_i_inter

--- a/src/shared/shared_par.F90
+++ b/src/shared/shared_par.F90
@@ -180,7 +180,7 @@ end module constants
 
   ! HDF5 IO server
   ! number of io dedicated nodes
-  integer :: HDF5_IO_NNODES = 0
+  integer :: HDF5_IO_NODES = 0
 
   ! flag for io-dedicated/compute node.
   logical :: IO_storage_task = .false.

--- a/src/shared/shared_par.F90
+++ b/src/shared/shared_par.F90
@@ -36,6 +36,11 @@ module constants
   ! a negative initial value is a convention that indicates that groups (i.e. sub-communicators, one per run) are off by default
   integer :: mygroup = -1
 
+  ! MPI status size (will be set in init_mpi()
+  integer :: my_status_size   = 1
+  integer :: my_status_source = 1
+  integer :: my_status_tag    = 1
+
   ! create a copy of the original output file path, to which we may add a "run0001/", "run0002/", "run0003/" prefix later
   ! if NUMBER_OF_SIMULTANEOUS_RUNS > 1
   character(len=MAX_STRING_LEN) :: OUTPUT_FILES = OUTPUT_FILES_BASE

--- a/src/specfem3D/finalize_simulation.f90
+++ b/src/specfem3D/finalize_simulation.f90
@@ -36,16 +36,19 @@
   use pml_par
   use gravity_perturbation, only: gravity_output, GRAVITY_SIMULATION
 
+  ! hdf5 i/o server
+  use io_server_hdf5, only: finalize_io_server
+
   implicit none
 
-  !#TODO: hdf5 i/o server
+  ! hdf5 i/o server
   ! checks if anything to do
-  !if (.not. IO_compute_task) then
-  !  ! finalizes MPI subgroup for intercommunication
-  !  if (HDF5_IO_NNODES > 0) call finalize_io_server()
-  !  ! all done
-  !  return
-  !endif
+  if (.not. IO_compute_task) then
+    ! finalizes MPI subgroup for intercommunication
+    if (HDF5_IO_NODES > 0) call finalize_io_server()
+    ! all done
+    return
+  endif
 
   ! synchronize all processes, waits until all processes have written their seismograms
   call synchronize_all()
@@ -113,9 +116,9 @@
   ! synchronize all the processes to make sure everybody has finished
   call synchronize_all()
 
-  !#TODO: hdf5 i/o server
+  ! hdf5 i/o server
   ! finalizes MPI subgroup for intercommunication
-  !if (HDF5_IO_NNODES > 0) call finalize_io_server()
+  if (HDF5_IO_NODES > 0) call finalize_io_server()
 
   end subroutine finalize_simulation
 

--- a/src/specfem3D/hdf5_io_server.F90
+++ b/src/specfem3D/hdf5_io_server.F90
@@ -1,0 +1,2257 @@
+!=====================================================================
+!
+!                          S p e c f e m 3 D
+!                          -----------------
+!
+!     Main historical authors: Dimitri Komatitsch and Jeroen Tromp
+!                              CNRS, France
+!                       and Princeton University, USA
+!                 (there are currently many more authors!)
+!                           (c) October 2017
+!
+! This program is free software; you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation; either version 3 of the License, or
+! (at your option) any later version.
+!
+! This program is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License along
+! with this program; if not, write to the Free Software Foundation, Inc.,
+! 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+!
+!=====================================================================
+
+! HDF5 I/O server
+! (works with HDF5 file outputs)
+
+! module for storing info. concering io
+
+module io_server_hdf5
+
+  use constants, only: CUSTOM_REAL
+
+  use shared_parameters, only: HDF5_IO_NODES, &
+    IO_storage_task, IO_compute_task
+
+#ifdef USE_HDF5
+! only with HDF5 support
+
+#ifdef WITH_MPI
+  use my_mpi
+#endif
+
+  implicit none
+
+  ! public routines
+  public :: initialize_io_server
+  public :: finalize_io_server
+  public :: do_io_start_idle
+  public :: pass_info_to_io
+
+  public :: wait_all_send
+  public :: synchronize_inter
+  public :: isend_cr_inter
+  public :: recvv_cr_inter
+  public :: recv_i_inter
+
+  ! public parameters
+  public :: NtoM
+  public :: if_collect_server
+
+  public :: nglob_this_io, nelm_this_io
+  public :: nglob_all_server, nspec_all_server
+
+  ! seismogram arrays
+  public :: seismo_press
+  public :: seismo_displ, seismo_veloc, seismo_accel
+
+  ! movie arrays
+  public :: surf_x,   surf_y,   surf_z, &
+            surf_ux,  surf_uy,  surf_uz
+  public :: surf_x_aug,   surf_y_aug,   surf_z_aug, &
+            surf_ux_aug,  surf_uy_aug,  surf_uz_aug
+  public :: shake_ux, shake_uy, shake_uz, &
+            shake_ux_aug, shake_uy_aug, shake_uz_aug
+
+  public :: vd_pres, vd_divglob, vd_div, &
+            vd_curlx, vd_curly, vd_curlz, &
+            vd_velox, vd_veloy, vd_veloz
+
+  public :: nglob_offset
+  public :: id_proc_loc2glob, id_proc_glob2loc
+  public :: dest_ioids, dest_ionod
+
+  ! mpi message tags
+  public :: io_tag_seismo_body_disp
+  public :: io_tag_seismo_body_velo
+  public :: io_tag_seismo_body_acce
+  public :: io_tag_seismo_body_pres
+
+  public :: io_tag_shake_ux, io_tag_shake_uy, io_tag_shake_uz
+
+  public :: io_tag_surface_ux, io_tag_surface_uy, io_tag_surface_uz
+  public :: io_tag_surface_x, io_tag_surface_y, io_tag_surface_z
+
+  public :: io_tag_vol_curlx, io_tag_vol_curly, io_tag_vol_curlz
+  public :: io_tag_vol_div, io_tag_vol_divglob
+  public :: io_tag_vol_pres
+  public :: io_tag_vol_velox, io_tag_vol_veloy, io_tag_vol_veloz
+
+  public :: io_tag_surface_coord_len
+  public :: io_tag_surface_nfaces
+  public :: io_tag_surface_offset
+
+  public :: io_tag_vol_elmconn
+  public :: io_tag_vol_ioid
+  public :: io_tag_vol_nglob
+  public :: io_tag_vol_nmsg
+  public :: io_tag_vol_nodex, io_tag_vol_nodey, io_tag_vol_nodez
+  public :: io_tag_vol_nspec
+  public :: io_tag_vol_sendlist
+
+  ! mpi requests
+  public :: n_req_surf, n_req_vol
+  public :: req_dump_surf, req_dump_vol
+
+  public :: nproc_io
+  public :: n_msg_vol_each_proc
+
+  public :: my_local_mpi_comm_inter
+
+  ! verbosity
+  public :: VERBOSE
+
+  private
+
+  ! MPI tags for io server implementation
+  !integer :: io_tag_seismo_nrec       = 10  ! unused
+  integer :: io_tag_seismo_ids_rec    = 11
+  integer :: io_tag_seismo_body_disp  = 12
+  integer :: io_tag_seismo_body_velo  = 13
+  integer :: io_tag_seismo_body_acce  = 14
+  integer :: io_tag_seismo_body_pres  = 15
+  integer :: io_tag_seismo_tzero      = 16
+  integer :: io_tag_dt                = 17
+  integer :: io_tag_nstep             = 18
+  integer :: io_tag_seismo_length     = 19
+
+  integer :: io_tag_surface_nfaces    = 20
+  integer :: io_tag_surface_offset    = 21
+  integer :: io_tag_surface_x         = 22
+  integer :: io_tag_surface_y         = 23
+  integer :: io_tag_surface_z         = 24
+  integer :: io_tag_surface_ux        = 25
+  integer :: io_tag_surface_uy        = 26
+  integer :: io_tag_surface_uz        = 27
+  integer :: io_tag_surface_coord_len = 28
+
+  integer :: io_tag_shake_ux          = 30
+  integer :: io_tag_shake_uy          = 31
+  integer :: io_tag_shake_uz          = 32
+
+  integer :: io_tag_vol_pres          = 40
+  integer :: io_tag_vol_divglob       = 41
+  integer :: io_tag_vol_div           = 42
+  integer :: io_tag_vol_curlx         = 43
+  integer :: io_tag_vol_curly         = 44
+  integer :: io_tag_vol_curlz         = 45
+  integer :: io_tag_vol_velox         = 46
+  integer :: io_tag_vol_veloy         = 47
+  integer :: io_tag_vol_veloz         = 48
+  integer :: io_tag_vol_nmsg          = 49
+  integer :: io_tag_vol_nspec         = 50
+  integer :: io_tag_vol_nglob         = 51
+  integer :: io_tag_vol_sendlist      = 52
+  integer :: io_tag_vol_ioid          = 53
+  integer :: io_tag_vol_elmconn       = 54
+  integer :: io_tag_vol_nodex         = 55
+  integer :: io_tag_vol_nodey         = 56
+  integer :: io_tag_vol_nodez         = 57
+  !integer :: io_tag_end               = 60   ! unused
+
+  integer :: io_tag_num_recv          = 61
+  integer :: io_tag_local_rec         = 62
+
+  ! mpi_req dump
+  integer :: n_req_surf = 0
+  integer :: n_req_vol = 0
+  integer, dimension(9) :: req_dump_vol
+  integer, dimension(3) :: req_dump_surf
+
+  ! responsible id of io node
+  integer :: dest_ionod = 0
+
+  ! movie arrays
+  type vol_data_dump
+    integer, dimension(:), allocatable :: req                       !=VAL_NOT_ASSIGNED should be
+    real(kind=CUSTOM_REAL), dimension(:), allocatable :: d1darr
+  end type vol_data_dump
+
+  ! dumps for volume data
+  type(vol_data_dump) :: vd_pres, vd_divglob, vd_div, &
+                         vd_curlx, vd_curly, vd_curlz, &
+                         vd_velox, vd_veloy, vd_veloz
+
+  logical :: NtoM = .true. ! if this option set .false. SPECFEM3D takes N-to-1 I/O strategy,
+                           ! i.e., volume data will be out to one single .h5 file.
+                           ! This gives the output files great simplicity, however I/O performance will be
+                           ! degraded for collective h5 I/O.
+
+  logical :: if_collect_server = .false. ! need to be set .false. for NtoM = .true.
+
+  ! MPI subgroup i/o server
+  integer :: my_local_mpi_comm_inter
+
+  ! number of computer nodes sending info to each io node
+  integer :: nproc_io
+
+  ! id for io node
+  integer :: my_io_id
+
+  ! local-global processor id relation
+  integer, dimension(:), allocatable :: id_proc_glob2loc, id_proc_loc2glob
+
+  ! io node id <-> proc id in compute nodes relation
+  integer, dimension(:), allocatable :: dest_ioids
+
+  ! string length for node name array
+  integer :: n_str_nodename = 64
+
+  integer :: nglob_all_server, nspec_all_server ! total number of elements and nodes for all procs
+  integer :: nglob_this_io, nelm_this_io        ! number of nodes and elements in this IO group
+
+  integer :: n_seismo_type = 0
+  integer :: n_procs_with_rec = 0
+
+  integer :: n_msg_seismo_each_proc = 1
+  integer :: n_msg_surf_each_proc = 3
+  integer :: n_msg_shake_each_proc = 3
+  integer :: n_msg_vol_each_proc = 0
+
+  real(kind=CUSTOM_REAL), dimension(:,:),   allocatable   :: seismo_press
+  real(kind=CUSTOM_REAL), dimension(:,:,:), allocatable   :: seismo_displ, seismo_veloc, seismo_accel
+  integer, dimension(:,:), allocatable                    :: id_rec_globs
+
+  integer, parameter :: VAL_NOT_ASSIGNED = 9999999
+
+  ! movie arrays for hdf5 output
+  integer, dimension(:), allocatable :: nglob_offset
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: surf_x,   surf_y,   surf_z, &
+                                                       surf_ux,  surf_uy,  surf_uz
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: surf_x_aug,   surf_y_aug,   surf_z_aug, &
+                                                       surf_ux_aug,  surf_uy_aug,  surf_uz_aug
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: shake_ux, shake_uy, shake_uz, &
+                                                       shake_ux_aug, shake_uy_aug, shake_uz_aug
+
+  ! verbose output (for debugging)
+  logical, parameter :: VERBOSE = .false.
+
+#endif
+
+contains
+
+
+!-------------------------------------------------------------------------------------------------
+!
+! i/o server setup
+!
+!-------------------------------------------------------------------------------------------------
+
+  subroutine initialize_io_server()
+
+! initialization of IO server splits compute and io nodes
+#ifdef USE_HDF5
+
+  use constants, only: IMAIN,myrank
+  use shared_parameters, only: NUMBER_OF_SIMULTANEOUS_RUNS,NPROC
+
+  implicit none
+
+  integer :: sizeval
+  integer :: split_comm,inter_comm
+  integer :: key,io_start,comp_start
+  integer :: ier
+  ! test node name
+  character(len=n_str_nodename), dimension(:), allocatable :: node_names
+  character(len=n_str_nodename) :: this_node_name
+  integer :: node_len
+
+  ! split comm into computation nodes and io node
+  ! here we use the last HDF5_IO_NODES ranks (intra comm) as the io node
+  ! for using one additional node, xspecfem3D need to be run with + HDF5_IO_NODES node
+  ! thus for running mpirun, it should be like e.g.
+  ! mpirun -n $((NPROC+HDF5_IO_NODES)) ./bin/xspecfem3D
+
+  ! safety check
+  if (HDF5_IO_NODES < 0) stop 'Invalid HDF5_IO_NODES, must be zero or positive'
+
+  ! initializes
+  my_local_mpi_comm_inter = my_local_mpi_comm_world   ! no i/o server
+
+  ! checks if anything to do
+  if (HDF5_IO_NODES == 0) return
+
+  ! select the task of this proc
+  ! get the local mpi_size and rank
+  call world_size(sizeval)
+  call world_rank(myrank)
+
+  ! user output
+  if (myrank == 0) then
+    write(IMAIN,*)
+    write(IMAIN,*) 'HDF5 I/O server run:'
+    write(IMAIN,*) '  number of dedicated HDF5 IO nodes = ',HDF5_IO_NODES
+    write(IMAIN,*) '  total number of MPI processes     = ',sizeval
+    write(IMAIN,*)
+    write(IMAIN,*) '  separating subgroups for compute tasks with ',sizeval - HDF5_IO_NODES,'MPI processes'
+    write(IMAIN,*) '                       for io tasks      with ',HDF5_IO_NODES,'MPI processes'
+    write(IMAIN,*)
+    call flush_IMAIN()
+  endif
+
+  ! checks if solver run with a number of mpi processes equal to (NPROC + HDF5_IO_NODES)
+  if (sizeval /= NPROC + HDF5_IO_NODES) then
+    if (myrank == 0) then
+      print *,"Error: HDF5 IO server needs ",HDF5_IO_NODES," additional process together with NPROC",NPROC,"processes"
+      print *
+      print *,"However, this simulation runs with ",sizeval,"MPI processes,"
+      print *,"where instead it should run with ",NPROC + HDF5_IO_NODES,"MPI processes"
+      print *
+      print *,"Please check your call to 'mpirun -np .. xspecfem3D' and rerun with the correct number of processes"
+      print *
+    endif
+    stop 'Invalid number of MPI processes for HDF5_IO_NODES > 0'
+  endif
+
+  ! to select io node and compute nodes on the same cluster node.
+  allocate(node_names(0:sizeval-1))
+
+#ifdef WITH_MPI
+  call MPI_GET_PROCESSOR_NAME(this_node_name,node_len,ier)
+#else
+  stop 'initialize_io_server not implemented for serial code'
+#endif
+
+  ! share the node name between procs
+  call gather_all_all_single_ch(this_node_name,node_names,sizeval,n_str_nodename)
+
+  call synchronize_all()
+
+  ! select the task of this proc
+  call select_io_node(node_names,myrank,sizeval,key,io_start)
+
+  deallocate(node_names)
+
+  ! split communicator into compute_comm and io_comm
+#ifdef WITH_MPI
+  call MPI_COMM_SPLIT(my_local_mpi_comm_world, key, myrank, split_comm, ier)
+#else
+  stop 'initialize_io_server not implemented for serial code'
+#endif
+
+  ! create inter communicator and set as my_local_mpi_comm_inter
+  if (IO_storage_task) then
+    comp_start = 0
+    call mpi_intercomm_create(split_comm, 0, my_local_mpi_comm_world, comp_start, 1111, inter_comm, ier)
+  else
+    !io_start = sizeval - HDF5_IO_NODES !+dest_ionod
+    call mpi_intercomm_create(split_comm, 0, my_local_mpi_comm_world, io_start,   1111, inter_comm, ier)
+  endif
+
+  ! sets new comm_world subgroup
+  my_local_mpi_comm_world = split_comm
+
+  ! use inter_comm as my_local_mpi_comm_world for all send/recv
+  my_local_mpi_comm_inter = inter_comm
+
+  ! exclude io nodes from the other compute nodes
+  if (NUMBER_OF_SIMULTANEOUS_RUNS > 1) NPROC = NPROC - HDF5_IO_NODES
+
+  ! re-define myrank (within new comm_world subgroup)
+  call world_rank(myrank)
+  call world_size(sizeval)
+
+  ! note: IO compute tasks cover the lower part of MPI processes, i.e., with ranks in
+  !       the initial 0 to (sizeval-HDF5_IO_NODES)-1 range.
+  !       the io nodes with IO_storage_task set to .true. are added at the end, with ranks in
+  !       the upper range (sizeval-HDF5_IO_NODES) to (sizeval-1).
+  !
+  !       for user output, we only have the initial rank 0 as the main process opening the output_solver.txt file.
+  !       after separating the tasks and creating new subgroup, we have a rank 0 process in the compute subgroup
+  !       as well as a rank 0 process in the storage subgroup.
+  !
+  !       from here on, we only want the process with rank 0 in the compute group write output to IMAIN.
+  !
+  ! user output
+  if (IO_compute_task) then
+    if (myrank == 0) then
+      write(IMAIN,*) '  new number of processes in compute group = ',sizeval
+      write(IMAIN,*) '  new addtional processes in io group      = ',HDF5_IO_NODES
+      write(IMAIN,*) '  MPI i/o server setup done'
+      call flush_IMAIN()
+    endif
+  endif
+
+#else
+  ! no HDF5 compilation support
+
+  ! compilation without HDF5 support
+  print *
+  print *, "Error: HDF5 I/O server routine initialize_io_server() called without HDF5 Support."
+  print *, "       HDF5_IO_NODES > 0 requires HDF5 support and HDF5_ENABLED must be set to .true."
+  print *
+  print *, "To enable HDF5 support, reconfigure with --with-hdf5 flag."
+  print *
+
+  ! safety stop
+  stop 'initialize_io_server() called without HDF5 compilation support'
+
+#endif
+
+  end subroutine initialize_io_server
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine finalize_io_server()
+
+#ifdef USE_HDF5
+
+  implicit none
+
+  ! checks if anything to do
+  if (HDF5_IO_NODES == 0) return
+
+  ! finish MPI subgroup
+  call world_unsplit_inter()
+
+#else
+  ! no HDF5 compilation support
+
+  ! compilation without HDF5 support
+  print *
+  print *, "Error: HDF5 I/O server routine finalize_io_server() called without HDF5 Support."
+  print *, "To enable HDF5 support, reconfigure with --with-hdf5 flag."
+  print *
+
+  ! safety stop
+  stop 'finalize_io_server() called without HDF5 compilation support'
+
+#endif
+
+  end subroutine finalize_io_server
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+!
+#ifdef USE_HDF5
+
+  subroutine select_io_node(node_names, myrank, sizeval, key, io_start)
+
+  implicit none
+
+  integer, intent(in)                         :: myrank, sizeval
+  integer, intent(out)                        :: key, io_start
+  character(len=n_str_nodename), dimension(0:sizeval-1), intent(in) :: node_names
+  ! local parameters
+  character(len=n_str_nodename), dimension(sizeval) :: dump_node_names ! names of cluster nodes
+  integer, dimension(sizeval)           :: n_procs_on_node ! number of procs on each cluster node
+  integer, dimension(:), allocatable    :: n_ionode_on_cluster ! number of ionode on the cluster nodes
+  integer :: i,j,c,n_cluster_node,my_cluster_id,n_rest_io,n_ionode,n_comp_node
+  real(kind=CUSTOM_REAL) :: io_ratio ! dum
+
+  ! initialize
+  my_cluster_id = -1
+  n_cluster_node = 0
+  n_procs_on_node(:) = 0
+  dump_node_names(:) = "nan"
+
+  ! BUG: nprocs goes wrong when 2 cluster nodes and 64 compute 8 io procs
+  ! (only 62 compute nodes are assigned)
+
+  ! cluster_node_nums = [n_1,...,n_i,...n_cn,-1,-1,...] ! n_i is the number of procs on
+  ! each cluster node
+  do i = 1, sizeval
+    ! search the node name already found and registered in the dump_node_names array
+    c = 0
+    do j = 1, sizeval
+      if (node_names(i-1) == dump_node_names(j)) c = j
+    enddo
+
+    ! if node_name[i-1] is not registered yet
+    if (c == 0) then
+      ! count the number of cluster node
+      n_cluster_node = n_cluster_node + 1
+
+      dump_node_names(n_cluster_node) = node_names(i-1) ! register the name
+      n_procs_on_node(n_cluster_node) = 1 ! count up the number of procs on this cluster node
+
+      c = n_cluster_node
+    else ! if node_name[i] has already be found, count up the number of procs
+      n_procs_on_node(c) = n_procs_on_node(c) + 1
+    endif
+
+    ! the id of cluster which this process belongs to
+    if (i-1 == myrank) then
+      my_cluster_id = c
+    endif
+  enddo
+
+  ! warning when a cluster node has only one single proc.
+  do i = 1, n_cluster_node
+    if (n_procs_on_node(i) == 1) then
+      print *
+      print *, "***************************************************************************"
+      print *, "IO server Warning:"
+      print *, "  node name: " // trim(dump_node_names(i)) // " has only one procs."
+      print *, "  this may lead a io performance issue by inter-clusternode communication."
+      print *, "***************************************************************************"
+      print *
+    endif
+  enddo
+
+  ! select HDF5_IO_NODES of io nodes
+  allocate(n_ionode_on_cluster(n_cluster_node))
+  !! decide the number of io node on each cluster node
+  ! at least one io node on each cluster node
+  n_ionode_on_cluster(:) = 1
+
+  ! check if the total number of io node > HDF5_IO_NODES
+  if (sum(n_ionode_on_cluster) > HDF5_IO_NODES) then
+    print *, "Error: HDF5_IO_NODES in Par_file is too small,"
+    print *, "       at least one io node for each cluster node is necessary"
+    stop 'Invalid HDF5_IO_NODES value too small'
+  endif
+
+  ! share the rest of ionodes based on the ratio of compute nodes
+  n_rest_io = HDF5_IO_NODES - sum(n_ionode_on_cluster)
+  if (n_rest_io /= 0) then
+    ! add io nodes one by one to the cluster node where
+    ! the io_node/total_node ratio is rowest
+    do i = 1, n_rest_io
+      io_ratio = 9999.0 !initialize at each i
+      do j = 1, n_cluster_node
+        if (io_ratio > real(n_ionode_on_cluster(j))/real(n_procs_on_node(j))) then
+          ! dump if largest
+          io_ratio = real(n_ionode_on_cluster(j))/real(n_procs_on_node(j))
+          ! destination of additional io node
+          c = j
+        endif
+      enddo
+      ! add one additional io node
+      n_ionode_on_cluster(c) = n_ionode_on_cluster(c) + 1
+    enddo
+  endif
+
+  !! choose the io node from the last rank of each cluster node
+  n_ionode = 0
+  do i = 1, n_cluster_node
+    c = 0
+    ! number of compute node on this cluster node
+    n_comp_node = n_procs_on_node(i) - n_ionode_on_cluster(i)
+    do j = 1, sizeval
+      ! if this rank is on i cluster node
+      if (dump_node_names(i) == node_names(j-1)) then
+        c = c + 1
+        if (n_comp_node < c) then
+          ! j is io node
+          if (j-1 == myrank) then
+            ! check  if j is myrank
+            IO_storage_task = .true. ! set io node flag
+            IO_compute_task = .false.
+            key          = 0
+            my_io_id     = n_ionode ! id of io_node
+            nproc_io     = n_comp_node/n_ionode_on_cluster(i) ! number of compute nodes which use this io node
+            dest_ionod   = -1
+            if (c-n_comp_node-1 < mod(n_comp_node,n_ionode_on_cluster(i))) nproc_io = nproc_io + 1
+          endif
+
+          ! rank of io_start
+          if (n_ionode == 0) io_start = j-1
+
+          n_ionode = n_ionode+1
+
+        else
+          ! j is compute node
+          if (j-1 == myrank) then
+            IO_storage_task = .false.
+            IO_compute_task = .true.
+            key          = 1
+            ! set the destination of MPI communication
+            dest_ionod   = mod(c-1,n_ionode_on_cluster(i)) + n_ionode
+          endif
+        endif
+      endif
+    enddo
+  enddo
+
+  ! debug
+  if (VERBOSE) then
+    if (myrank == 0) then
+      print *, "io_server: n_procs_on_node", n_procs_on_node(:)
+      print *, "io_server: n_ionode_on_cluster", n_ionode_on_cluster
+      print *
+    endif
+    call flush_stdout()
+    call synchronize_all()
+
+    if (IO_storage_task) then
+      print *, "io_server: io_task rank ", myrank, " nprocio ",nproc_io
+      print *, "io_server: io_task rank ", myrank, " node ", trim(node_names(myrank)), " my_io_id", my_io_id
+      print *
+    endif
+    call flush_stdout
+    call synchronize_all()
+
+    do i = 0, n_ionode-1
+      if (.not. IO_storage_task) then
+        if (dest_ionod == i) then
+          print *, "io_server: rank ", myrank, " node ", trim(node_names(myrank)), " dest ", dest_ionod
+        endif
+      endif
+      call flush_stdout()
+      call synchronize_all()
+    enddo
+    call flush_stdout()
+    call synchronize_all()
+
+  endif
+
+  deallocate(n_ionode_on_cluster)
+
+  end subroutine select_io_node
+
+#endif
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine do_io_start_idle()
+
+#ifdef USE_HDF5
+
+  use constants, only: myrank
+
+  use shared_parameters, only: NPROC,DT,NSTEP,NTSTEP_BETWEEN_FRAMES, &
+    MOVIE_SURFACE,MOVIE_VOLUME,USE_HIGHRES_FOR_MOVIES,CREATE_SHAKEMAP, &
+    NSTEP,NTSTEP_BETWEEN_OUTPUT_SEISMOS
+
+  use specfem_par, only: nlength_seismogram
+
+  implicit none
+
+  integer :: ier
+
+  ! vars seismo
+  integer,dimension(0:NPROC-1) :: islice_num_rec_local
+#ifdef WITH_MPI
+  integer                      :: status(MPI_STATUS_SIZE)
+#else
+  integer                      :: status(1)
+#endif
+  integer                      :: rec_count_seismo, n_recv_msg_seismo, max_seismo_out
+  integer                      :: it_offset, seismo_out_count
+  !integer, dimension(1)        :: nrec_temp
+
+  ! vars surface movie
+  integer                       :: rec_count_surf, n_recv_msg_surf, surf_out_count, max_surf_out
+  integer                       :: it_io
+  integer, dimension(0:NPROC-1) :: nfaces_perproc, surface_offset
+  integer                       :: num_nodes
+
+  ! vars shakemap
+  integer :: rec_count_shake, n_recv_msg_shake, shake_out_count, max_shake_out
+
+  ! vars volumne movie
+  integer                       :: rec_count_vol, n_recv_msg_vol, vol_out_count, max_vol_out
+  ! storing the number of elements and GLL nodes
+  integer, dimension(0:NPROC-1)           :: nelm_par_proc, nglob_par_proc, nglob_par_proc_offset
+  integer, dimension(0:HDF5_IO_NODES-1)  :: nglob_par_io_offset, nelm_par_io_offset
+  logical, dimension(5)                   :: val_type_mov ! true if movie file will be created,
+                                                          !  (pressure, div_glob, div, curlxyz, velocity_xyz)
+  integer, dimension(1)                   :: tmp_1d_iarr
+  double precision, dimension(1)          :: tmp_1d_darr
+  integer :: tag, tag_src
+
+  ! initialize counters
+  rec_count_seismo  = 0
+  n_recv_msg_seismo = 0
+  it_offset         = 0
+  seismo_out_count  = 0
+  max_seismo_out    = 0
+
+  rec_count_surf    = 0
+  n_recv_msg_surf   = 0
+  surf_out_count    = 0
+  max_surf_out      = 0
+
+  rec_count_shake   = 0
+  n_recv_msg_shake  = 0
+  shake_out_count   = 0
+  max_shake_out     = 0
+
+  rec_count_vol     = 0
+  n_recv_msg_vol    = 0
+  vol_out_count     = 0
+  max_vol_out       = 0
+
+  n_msg_vol_each_proc = 0
+
+  ! prepare for receiving message from write_seismograms
+  if (VERBOSE) then
+    call flush_stdout()
+    print *
+    print *, "io_server: io node rank:", myrank," is waiting for the first message"
+    print *
+    call flush_stdout()
+  endif
+
+  ! obtain DT and NSTEP for each event
+  call recv_i_inter(tmp_1d_iarr, 1, 0, io_tag_nstep)
+  NSTEP = tmp_1d_iarr(1)
+
+  call recv_dp_inter(tmp_1d_darr, 1, 0, io_tag_dt)
+  DT = tmp_1d_darr(1)
+
+  call recv_i_inter(tmp_1d_iarr, 1, 0, io_tag_seismo_length)
+  nlength_seismogram = tmp_1d_iarr(1)
+
+  !
+  ! initialization seismo
+  !
+
+  if (myrank == 0) then
+    ! get receiver info from compute nodes
+    call get_receiver_info(islice_num_rec_local)
+
+    ! initialize output file for seismo
+    call write_output_hdf5_seismogram_init()
+
+    ! count the number of procs having receivers (n_procs_with_rec)
+    ! and the number of receivers on each procs (islice...)
+    call count_nprocs_with_recs(islice_num_rec_local)
+
+    ! check the seismo types to be saved
+    call count_seismo_type()
+
+    ! allocate temporal arrays for seismo signals
+    call allocate_seismo_arrays(islice_num_rec_local)
+
+    ! initialize receive count
+    ! count the number of messages being sent
+    n_recv_msg_seismo = n_procs_with_rec * n_msg_seismo_each_proc * n_seismo_type
+
+    if (NTSTEP_BETWEEN_OUTPUT_SEISMOS < NSTEP) then
+      max_seismo_out = int(NSTEP/NTSTEP_BETWEEN_OUTPUT_SEISMOS)
+      if (mod(NSTEP,NTSTEP_BETWEEN_OUTPUT_SEISMOS) /= 0) max_seismo_out = max_seismo_out+1
+    else
+      max_seismo_out = 1
+    endif
+
+    ! receive the global id of received
+    call recv_id_rec(islice_num_rec_local)
+
+    !
+    ! initialize surface movie
+    !
+    if (MOVIE_SURFACE .or. CREATE_SHAKEMAP) then
+      call surf_mov_io_init_hdf5(nfaces_perproc, surface_offset)
+      if (VERBOSE) print *, "io_server: surf move init done"
+
+      if (.not. USE_HIGHRES_FOR_MOVIES) then
+        num_nodes = size(surf_x)
+      else
+        num_nodes = size(surf_x_aug)
+      endif
+
+      ! surface movie
+      if (MOVIE_SURFACE) then
+        n_recv_msg_surf = n_msg_surf_each_proc * NPROC
+        call write_xdmf_surface_header(num_nodes)
+        if (VERBOSE) print *, "io_server: surface header done"
+        max_surf_out = int(NSTEP/NTSTEP_BETWEEN_FRAMES)
+      endif
+
+      !
+      ! initialize shakemap
+      !
+      if (CREATE_SHAKEMAP) then
+        call shakemap_io_init_hdf5()
+        if (VERBOSE) print *, "io_server: shakemap init done"
+        n_recv_msg_shake = n_msg_shake_each_proc * NPROC
+        max_shake_out = 1  ! only once at final timestep
+      endif
+    endif
+
+  endif ! endif myrank == 0
+
+  !
+  ! initialize volume movie
+  !
+  if (MOVIE_VOLUME) then
+    call movie_volume_io_init_hdf5(nelm_par_proc,nglob_par_proc,nglob_par_proc_offset,nglob_par_io_offset,nelm_par_io_offset)
+    if (VERBOSE) print *, "io_server: movie volume init done"
+
+    n_recv_msg_vol = n_msg_vol_each_proc*nproc_io
+    max_vol_out    = int(NSTEP/NTSTEP_BETWEEN_FRAMES)
+
+    ! initialize flags for the value types to be written out
+    val_type_mov(:) = .false.
+
+    ! allocate dumping arrays
+    allocate(vd_pres%req(0:nproc_io-1),  vd_divglob%req(0:nproc_io-1), vd_div%req(0:nproc_io-1), &
+             vd_curlx%req(0:nproc_io-1), vd_curly%req(0:nproc_io-1),   vd_curlz%req(0:nproc_io-1), &
+             vd_velox%req(0:nproc_io-1), vd_veloy%req(0:nproc_io-1),   vd_veloz%req(0:nproc_io-1),stat=ier)
+    if (ier /= 0) stop 'Error allocating vd_pres%req arrays'
+    vd_pres%req(:)   = VAL_NOT_ASSIGNED
+    vd_divglob%req(:)= VAL_NOT_ASSIGNED
+    vd_div%req(:)    = VAL_NOT_ASSIGNED
+    vd_curlx%req(:)  = VAL_NOT_ASSIGNED
+    vd_curly%req(:)  = VAL_NOT_ASSIGNED
+    vd_curlz%req(:)  = VAL_NOT_ASSIGNED
+    vd_velox%req(:)  = VAL_NOT_ASSIGNED
+    vd_veloy%req(:)  = VAL_NOT_ASSIGNED
+    vd_veloz%req(:)  = VAL_NOT_ASSIGNED
+
+    allocate(vd_pres%d1darr(nglob_par_io_offset(myrank)), &
+             vd_divglob%d1darr(nglob_par_io_offset(myrank)), &
+             vd_div%d1darr(nglob_par_io_offset(myrank)), &
+             vd_curlx%d1darr(nglob_par_io_offset(myrank)), &
+             vd_curly%d1darr(nglob_par_io_offset(myrank)), &
+             vd_curlz%d1darr(nglob_par_io_offset(myrank)), &
+             vd_velox%d1darr(nglob_par_io_offset(myrank)), &
+             vd_veloy%d1darr(nglob_par_io_offset(myrank)), &
+             vd_veloz%d1darr(nglob_par_io_offset(myrank)),stat=ier)
+    if (ier /= 0) stop 'Error allocating vd_pres%d1darr arrays'
+    vd_pres%d1darr(:) = 0.0; vd_divglob%d1darr(:) = 0.0; vd_div%d1darr(:) = 0.0
+    vd_curlx%d1darr(:) = 0.0; vd_curly%d1darr(:) = 0.0; vd_curlz%d1darr(:) = 0.0
+    vd_velox%d1darr(:) = 0.0; vd_veloy%d1darr(:) = 0.0; vd_veloz%d1darr(:) = 0.0
+  endif ! if MOVIE_VOLUME
+
+  if (VERBOSE .and. myrank == 0) then
+    call flush_stdout()
+    print *
+    call flush_stdout()
+  endif
+
+  !
+  ! idling loop
+  !
+  do while (seismo_out_count < max_seismo_out .or. &
+            surf_out_count < max_surf_out .or. &
+            shake_out_count < max_shake_out .or. &
+            vol_out_count < max_vol_out)
+
+    ! waiting for a MPI message
+    call idle_mpi_io(status)
+
+#ifdef WITH_MPI
+    tag = status(MPI_TAG)
+    tag_src = status(MPI_SOURCE)
+#else
+    tag = status(1)
+    tag_src = status(1)
+#endif
+
+    ! debug output
+    if (VERBOSE) then
+      print '(a,i2,2(a,i4),8(a,i2))'," io_server: msg: " , tag , " src/recv rank: ", tag_src, "/",myrank, &
+              "  counters, seismo: " , rec_count_seismo, "/"      , n_recv_msg_seismo, &
+              ", surf: " , rec_count_surf  , "/"      , n_recv_msg_surf, &
+              ", shake: ", rec_count_shake , "/"      , n_recv_msg_shake, &
+              ", vol: "  , rec_count_vol   , "/"      , n_recv_msg_vol
+    endif
+
+    !
+    ! receive seismograms
+    !
+    if (tag == io_tag_seismo_body_disp .or. &
+        tag == io_tag_seismo_body_velo .or. &
+        tag == io_tag_seismo_body_acce .or. &
+        tag == io_tag_seismo_body_pres) then
+      call recv_seismo_data(status,islice_num_rec_local)
+      rec_count_seismo = rec_count_seismo+1
+    endif
+
+    !
+    ! receive surface movie data
+    !
+    if (MOVIE_SURFACE) then
+      if (tag == io_tag_surface_ux .or. &
+          tag == io_tag_surface_uy .or. &
+          tag == io_tag_surface_uz) then
+        call recv_surf_data(status, nfaces_perproc, surface_offset)
+        rec_count_surf = rec_count_surf+1
+      endif
+    endif
+
+    !
+    ! receive shakemap data
+    !
+    if (CREATE_SHAKEMAP) then
+      if (tag == io_tag_shake_ux .or. &
+          tag == io_tag_shake_uy .or. &
+          tag == io_tag_shake_uz) then
+        call recv_shake_data(status, nfaces_perproc, surface_offset)
+        rec_count_shake = rec_count_shake+1
+      endif
+    endif
+
+    !
+    ! receive volume movie data
+    !
+    if (MOVIE_VOLUME) then
+      if (tag == io_tag_vol_pres .or. &
+          tag == io_tag_vol_divglob .or. &
+          tag == io_tag_vol_div .or. &
+          tag == io_tag_vol_curlx .or. &
+          tag == io_tag_vol_curly .or. &
+          tag == io_tag_vol_curlz .or. &
+          tag == io_tag_vol_velox .or. &
+          tag == io_tag_vol_veloy .or. &
+          tag == io_tag_vol_veloz) then
+        it_io = NTSTEP_BETWEEN_FRAMES*(vol_out_count+1)
+        call recv_volume_data(status, val_type_mov, nglob_par_proc_offset)
+        rec_count_vol = rec_count_vol+1
+        ! finish gathering the whole data at each time step
+      endif
+    endif
+
+    !
+    ! check if all data is collected then write
+    !
+
+    ! write seismo
+    if (rec_count_seismo == n_recv_msg_seismo .and. myrank == 0) then
+      ! only io process with rank 0 writes out
+      if (VERBOSE) print *, "io_server: seismo out ",seismo_out_count,"rank",myrank
+
+      it_offset = seismo_out_count * NTSTEP_BETWEEN_OUTPUT_SEISMOS ! calculate the offset of timestep
+      call write_seismograms_io_hdf5(it_offset)
+
+      rec_count_seismo = 0 ! reset the counter then wait for the messages of next iteration.
+      seismo_out_count = seismo_out_count+1
+      if (VERBOSE) print *, "io_server: seismo out done. at it_offset = ",it_offset
+    endif
+
+    ! write surf movie
+    if (MOVIE_SURFACE .and. rec_count_surf == n_recv_msg_surf .and. myrank == 0) then
+      ! only io process with rank 0 writes out
+      if (VERBOSE) print *, "io_server: surf out ",surf_out_count,"rank",myrank
+
+      it_io = NTSTEP_BETWEEN_FRAMES * (surf_out_count+1)
+      call write_surf_io_hdf5(it_io)
+      ! write out xdmf at each timestep
+      if (myrank == 0) call write_xdmf_surface_body(it_io, num_nodes)
+
+      rec_count_surf = 0 ! reset counter
+      surf_out_count = surf_out_count+1
+      if (VERBOSE) print *, "io_server: surface write done. at it_io = ", it_io
+    endif
+
+    ! write volume movie
+    if (MOVIE_VOLUME .and. rec_count_vol == n_recv_msg_vol) then
+      ! all io processes write out
+      if (VERBOSE) print *, "io_server: vol out ",vol_out_count,"rank",myrank
+
+      ! wait all vol data are reached (for all io processes)
+      call wait_volume_recv()
+
+      ! write dumped vol data
+      it_io = NTSTEP_BETWEEN_FRAMES * (vol_out_count+1)
+      call write_vol_data_io_hdf5(it_io,val_type_mov,nglob_par_io_offset)
+      if (vol_out_count == 0) then
+        ! create xdmf header file
+        if (myrank == 0) then
+          if (NtoM) then
+            call write_xdmf_vol_io_mton_hdf5(val_type_mov,nglob_par_io_offset,nelm_par_io_offset)
+          else
+            call write_xdmf_vol_io_hdf5(val_type_mov)
+          endif
+        endif
+      endif
+
+      rec_count_vol = 0 ! reset counter
+      vol_out_count = vol_out_count+1
+      if (VERBOSE) print *, "io_server: volume write done. at it_io = ", it_io
+    endif
+
+    ! write shakemap
+    if (CREATE_SHAKEMAP .and. rec_count_shake == n_recv_msg_shake .and. myrank == 0) then
+      ! only io process with rank 0 writes out
+      if (VERBOSE) print *, "io_server: shake out ",shake_out_count
+
+      call write_shakemap_io_hdf5()
+      ! write out xdmf (last timestep)
+      call write_xdmf_shakemap(num_nodes)
+
+      rec_count_shake = 0
+      shake_out_count = shake_out_count+1
+      if (VERBOSE) print *, "io_server: shakemap write done."
+    endif
+  enddo
+  !
+  !  end of idling loop
+  !
+
+  ! deallocate arrays
+  call deallocate_io_arrays()
+
+  if (VERBOSE .and. myrank == 0) then
+    call flush_stdout()
+    print *
+    call flush_stdout()
+  endif
+  if (VERBOSE) print *,"io_server: rank",myrank,"do_io_start_idle done"
+#else
+  ! no HDF5 compilation support
+
+  ! compilation without HDF5 support
+  print *
+  print *, "Error: HDF5 I/O server routine do_io_start_idle() called without HDF5 Support."
+  print *, "To enable HDF5 support, reconfigure with --with-hdf5 flag."
+  print *
+
+  ! safety stop
+  stop 'do_io_start_idle() called without HDF5 compilation support'
+
+#endif
+
+  end subroutine do_io_start_idle
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine pass_info_to_io()
+
+#ifdef USE_HDF5
+
+  use constants, only: NGLLX,NGLLY,NGLLZ,myrank,NB_RUNS_ACOUSTIC_GPU
+
+  use shared_parameters, only: NPROC,DT,NSTEP, &
+    MOVIE_SURFACE,MOVIE_VOLUME,CREATE_SHAKEMAP, &
+    ACOUSTIC_SIMULATION,ELASTIC_SIMULATION,POROELASTIC_SIMULATION, &
+    WRITE_SEISMOGRAMS_BY_MAIN
+
+  use specfem_par, only: NSPEC_AB,NGLOB_AB, &
+    nrec,nrec_local,number_receiver_global,t0, &
+    nlength_seismogram, &
+    xstore,ystore,zstore
+
+  use specfem_par_movie, only: faces_surface_offset,nfaces_perproc_surface, &
+    store_val_x_all,store_val_y_all,store_val_z_all
+
+  implicit none
+  integer :: nrec_store,irec,irec_local
+  integer :: n_msg_vol_each_proc
+  integer :: i_ionod,ier
+  integer,dimension(:), allocatable :: tmp_irec
+  integer, dimension(:,:), allocatable :: elm_conn_loc
+
+  ! initialization of io node from compute node side
+  n_msg_vol_each_proc = 0
+
+  ! pass DT NSTEP of each event which may differ from DATA/Par_file
+  if (myrank == 0) then
+    do i_ionod = 0,HDF5_IO_NODES-1
+      call send_i_inter((/NSTEP/), 1, i_ionod, io_tag_nstep)
+      call send_dp_inter((/DT/), 1, i_ionod, io_tag_dt)
+      call send_i_inter((/nlength_seismogram/), 1, i_ionod, io_tag_seismo_length)
+      !debug
+      if (VERBOSE) print *,"io_server: rank",myrank,"pass info. DT send to",i_ionod
+    enddo
+  endif
+
+  ! send the receiver information to io node for the outputs of seismo signals
+  ! seismo data is out only from rank=0 of io nodes
+  if (myrank == 0) then
+    ! send nrec
+    call send_i_inter((/nrec/), 1, 0, io_tag_num_recv)
+    ! send t0
+    call send_dp_inter((/t0/), 1, 0, io_tag_seismo_tzero)
+  endif
+
+  ! set number of traces in full seismogram array
+  if (WRITE_SEISMOGRAMS_BY_MAIN) then
+    ! main process collects all traces
+    if (myrank == 0) then
+      ! explicit for pressure/acoustic runs and NB_RUNS_ACOUSTIC_GPU > 1
+      nrec_store = nrec * NB_RUNS_ACOUSTIC_GPU
+    else
+      ! dummy for secondary processes
+      nrec_store = 0
+    endif
+  else
+    ! each process outputs its local traces
+    nrec_store = nrec_local * NB_RUNS_ACOUSTIC_GPU
+  endif
+  ! send the number of local receiver to the io node
+  call send_i_inter((/nrec_store/), 1, 0, io_tag_local_rec)
+  !debug
+  if (VERBOSE) print *,"io_server: rank",myrank,"pass info. nrec_store",nrec_store,"sent to",0
+
+  if (nrec_store > 0) then
+    ! temporary array with irec info
+    allocate(tmp_irec(nrec_store),stat=ier)
+    if (ier /= 0) stop 'Error allocating tmp_irec array'
+    tmp_irec(:) = 0
+
+    ! send global id of stations
+    if (WRITE_SEISMOGRAMS_BY_MAIN) then
+      ! main process collects all traces
+      ! loop on all the receivers
+      do irec_local = 1,nrec_store
+        ! get global number of that receiver
+        if (NB_RUNS_ACOUSTIC_GPU == 1) then
+          irec = irec_local
+        else
+          ! NB_RUNS_ACOUSTIC_GPU > 1
+          if (mod(irec_local,nrec) == 0) then
+            irec = nrec
+          else
+            irec = mod(irec_local,nrec)
+          endif
+        endif
+        tmp_irec(irec_local) = irec
+      enddo
+    else
+      ! each process outputs its local traces
+      ! send global ids of local receivers (integer array)
+      do irec_local = 1,nrec_store    ! nrec_store == nrec_local * NB_RUNS_ACOUSTIC_GPU
+        ! get global number of that receiver
+        if (NB_RUNS_ACOUSTIC_GPU == 1) then
+          irec = number_receiver_global(irec_local)
+        else
+          ! NB_RUNS_ACOUSTIC_GPU > 1
+          ! if irec_local is a multiple of nrec then mod(irec_local,nrec) == 0 and
+          ! the array access at number_receiver_global would be invalid;
+          ! for those cases we want irec associated to irec_local == nrec_store
+          if (mod(irec_local,nrec_local) == 0) then
+            irec = number_receiver_global(nrec_local)
+          else
+            irec = number_receiver_global(mod(irec_local,nrec_local))
+          endif
+        endif
+        tmp_irec(irec_local) = irec
+      enddo
+    endif
+    call send_i_inter(tmp_irec,nrec_store,0,io_tag_seismo_ids_rec)
+    ! free temporary array
+    deallocate(tmp_irec)
+  endif
+
+  ! surface movie/vol/shakemap
+  ! surface and shakemap data will be output from the first rank of io nodes
+  if (myrank == 0) then
+    if (MOVIE_SURFACE .or. CREATE_SHAKEMAP) then
+      ! send nfaces_perproc_surface
+      call send_i_inter(nfaces_perproc_surface,NPROC, 0, io_tag_surface_nfaces)
+      ! send faces_surface_offset
+      call send_i_inter(faces_surface_offset,NPROC, 0, io_tag_surface_offset)
+      ! send size of store_val
+      call send_i_inter((/size(store_val_x_all)/), 1, 0, io_tag_surface_coord_len)
+      ! send store_val_x/y/z_all
+      call sendv_cr_inter(store_val_x_all,size(store_val_x_all), 0, io_tag_surface_x)
+      call sendv_cr_inter(store_val_y_all,size(store_val_y_all), 0, io_tag_surface_y)
+      call sendv_cr_inter(store_val_z_all,size(store_val_z_all), 0, io_tag_surface_z)
+      !debug
+      if (VERBOSE) print *,"io_server: rank",myrank,"pass info. surface xyz size",size(store_val_x_all)
+    endif
+
+    if (MOVIE_VOLUME) then
+      ! count number of messages for volume movie
+      if (ACOUSTIC_SIMULATION .and. .not. ELASTIC_SIMULATION .and. .not. POROELASTIC_SIMULATION) then
+        n_msg_vol_each_proc = n_msg_vol_each_proc+1 ! pressure
+      endif
+      if (ELASTIC_SIMULATION .or. POROELASTIC_SIMULATION) then
+        if (ELASTIC_SIMULATION) n_msg_vol_each_proc = n_msg_vol_each_proc+1 ! div_glob
+        n_msg_vol_each_proc = n_msg_vol_each_proc+4 ! div, curl_x, curl_y, curl_z
+      endif
+      if (ACOUSTIC_SIMULATION .or. ELASTIC_SIMULATION .or. POROELASTIC_SIMULATION) then
+        n_msg_vol_each_proc = n_msg_vol_each_proc+3 ! velocity_x,velocity_y,velocity_z
+      endif
+      ! send the number of messages
+      do i_ionod = 0,HDF5_IO_NODES-1
+        call send_i_inter((/n_msg_vol_each_proc/),1,i_ionod,io_tag_vol_nmsg)
+      enddo
+    endif
+  endif ! endif myrank == 0
+
+  if (MOVIE_VOLUME) then
+    ! send the compute node list to io node
+    call send_i_inter((/0/),1,dest_ionod,io_tag_vol_sendlist)
+
+    do i_ionod = 0,HDF5_IO_NODES-1
+      ! send nspec and nglob in each process
+      call send_i_inter((/NSPEC_AB/),1,i_ionod,io_tag_vol_nspec)
+      call send_i_inter((/NGLOB_AB/),1,i_ionod,io_tag_vol_nglob)
+      ! send the id of ionode which is the destination of this compute node
+      call send_i_inter((/dest_ionod/), 1, i_ionod, io_tag_vol_ioid)
+    enddo
+
+    ! send mesh information to reconstract io node based mesh database on volume movie h5 file
+    ! By this way, the required storage size will be larger but for taking some advantage
+    ! to reduce the IO time.
+    allocate(nglob_offset(0:NPROC-1), stat=ier)
+    if (ier /= 0) call exit_MPI_without_rank('error allocating array nglob_offset')
+    if (ier /= 0) stop 'error allocating arrays for nglob_offset'
+    nglob_offset(:) = 0
+
+    ! gather nglobs of each proc
+    call gather_all_all_singlei(NGLOB_AB,nglob_offset,NPROC)
+
+    ! connectivity
+    allocate(elm_conn_loc(9,NSPEC_AB*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)),stat=ier)
+    if (ier /= 0) stop 'Error allocating elm_conn_loc array'
+    elm_conn_loc(:,:) = 0
+
+    ! create connectivity dataset (it's node base but element base)
+    call get_conn_for_movie(elm_conn_loc, 0)
+
+    ! send elm_conn_loc
+    call send_i_inter(elm_conn_loc(1,1),size(elm_conn_loc),dest_ionod, io_tag_vol_elmconn)
+
+    ! send xstore, ystore, zstore
+    call sendv_cr_inter(xstore, size(xstore), dest_ionod, io_tag_vol_nodex)
+    call sendv_cr_inter(ystore, size(ystore), dest_ionod, io_tag_vol_nodey)
+    call sendv_cr_inter(zstore, size(zstore), dest_ionod, io_tag_vol_nodez)
+
+    deallocate(nglob_offset, elm_conn_loc)
+
+    !debug
+    if (VERBOSE) print *,"io_server: rank",myrank,"pass info. movie sent to",dest_ionod
+  endif
+
+#else
+  ! no HDF5 compilation support
+
+  ! compilation without HDF5 support
+  print *
+  print *, "Error: HDF5 I/O server routine pass_info_to_io() called without HDF5 Support."
+  print *, "To enable HDF5 support, reconfigure with --with-hdf5 flag."
+  print *
+
+  ! safety stop
+  stop 'pass_info_to_io() called without HDF5 compilation support'
+
+#endif
+
+  end subroutine pass_info_to_io
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+#ifdef USE_HDF5
+
+  subroutine recv_volume_data(status, val_type_mov, nglob_par_proc_offset)
+
+  implicit none
+
+#ifdef WITH_MPI
+  integer, intent(in)                  :: status(MPI_STATUS_SIZE)
+#else
+  integer                              :: status(1)
+#endif
+  logical, dimension(5), intent(inout) :: val_type_mov
+  integer, dimension(0:nproc_io-1), intent(in) :: nglob_par_proc_offset ! offset intra io node info
+
+  integer :: sender_glob, sender_loc, tag, msgsize, iglo_sta, iglo_end
+
+#ifdef WITH_MPI
+  sender_glob = status(MPI_SOURCE)
+  sender_loc  = id_proc_glob2loc(sender_glob)
+  tag         = status(MPI_TAG)
+#else
+  sender_glob = status(1)
+  sender_loc  = id_proc_glob2loc(sender_glob)
+  tag         = status(1)
+#endif
+
+  ! get message size
+  call world_get_size_msg(status,msgsize)
+
+  iglo_sta = nglob_par_proc_offset(sender_loc)+1
+  iglo_end = iglo_sta + msgsize -1
+
+  ! receive data and store to dump arrays
+  !
+  ! here necessary to check if file write has already finished before overwriting dump arrays
+  !
+  if (tag == io_tag_vol_pres) then
+    val_type_mov(1) = .true.
+    call irecvv_cr_inter(vd_pres%d1darr(iglo_sta:iglo_end),msgsize,sender_glob,tag,vd_pres%req(sender_loc))
+  else if (tag == io_tag_vol_divglob) then
+    val_type_mov(2) = .true.
+    call irecvv_cr_inter(vd_divglob%d1darr(iglo_sta:iglo_end),msgsize,sender_glob,tag,vd_divglob%req(sender_loc))
+  else if (tag == io_tag_vol_div) then
+    val_type_mov(3) = .true.
+    call irecvv_cr_inter(vd_div%d1darr(iglo_sta:iglo_end),msgsize,sender_glob,tag,vd_div%req(sender_loc))
+  else if (tag == io_tag_vol_curlx) then
+    val_type_mov(4) = .true.
+    call irecvv_cr_inter(vd_curlx%d1darr(iglo_sta:iglo_end),msgsize,sender_glob,tag,vd_curlx%req(sender_loc))
+  else if (tag == io_tag_vol_curly) then
+    call irecvv_cr_inter(vd_curly%d1darr(iglo_sta:iglo_end),msgsize,sender_glob,tag,vd_curly%req(sender_loc))
+  else if (tag == io_tag_vol_curlz) then
+    call irecvv_cr_inter(vd_curlz%d1darr(iglo_sta:iglo_end),msgsize,sender_glob,tag,vd_curlz%req(sender_loc))
+  else if (tag == io_tag_vol_velox) then
+    val_type_mov(5) = .true.
+    call irecvv_cr_inter(vd_velox%d1darr(iglo_sta:iglo_end),msgsize,sender_glob,tag,vd_velox%req(sender_loc))
+  else if (tag == io_tag_vol_veloy) then
+    call irecvv_cr_inter(vd_veloy%d1darr(iglo_sta:iglo_end),msgsize,sender_glob,tag,vd_veloy%req(sender_loc))
+  else if (tag == io_tag_vol_veloz) then
+    call irecvv_cr_inter(vd_veloz%d1darr(iglo_sta:iglo_end),msgsize,sender_glob,tag,vd_veloz%req(sender_loc))
+  endif
+
+  end subroutine recv_volume_data
+
+#endif
+
+!-------------------------------------------------------------------------------------------------
+!
+! MPI communications
+!
+!-------------------------------------------------------------------------------------------------
+
+  subroutine synchronize_inter()
+
+#ifdef USE_HDF5
+
+  implicit none
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  ! synchronizes MPI processes
+  call MPI_BARRIER(my_local_mpi_comm_inter,ier)
+  if (ier /= 0 ) stop 'Error synchronize MPI processes'
+#endif
+
+#else
+  ! no HDF5 compilation support
+
+  ! compilation without HDF5 support
+  print *
+  print *, "Error: HDF5 I/O server routine synchronize_inter() called without HDF5 Support."
+  print *, "To enable HDF5 support, reconfigure with --with-hdf5 flag."
+  print *
+
+  ! safety stop
+  stop 'synchronize_inter() called without HDF5 compilation support'
+
+#endif
+
+  end subroutine synchronize_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine wait_all_send()
+
+#ifdef USE_HDF5
+
+  implicit none
+
+  integer :: ireq
+
+  ! surface movie
+  if (n_req_surf /= 0) then
+    ! wait till all mpi_isends are finished
+    do ireq = 1,n_req_surf
+      call wait_req(req_dump_surf(ireq))
+    enddo
+  endif
+
+  ! volume movie
+  if (n_req_vol /= 0) then
+    ! wait till all mpi_isends are finished
+    do ireq = 1,n_req_vol
+      call wait_req(req_dump_vol(ireq))
+    enddo
+  endif
+
+  n_req_surf = 0; n_req_vol = 0
+
+  call synchronize_all()
+
+#else
+  ! no HDF5 compilation support
+
+  ! compilation without HDF5 support
+  print *
+  print *, "Error: HDF5 I/O server routine wait_all_send() called without HDF5 Support."
+  print *, "To enable HDF5 support, reconfigure with --with-hdf5 flag."
+  print *
+
+  ! safety stop
+  stop 'wait_all_send() called without HDF5 compilation support'
+
+#endif
+
+  end subroutine wait_all_send
+
+
+
+!-------------------------------------------------------------------------------
+!
+! HDF5 io routines (only available with HDF5 compilation support)
+!
+!-------------------------------------------------------------------------------
+
+#if defined(USE_HDF5)
+! only available with HDF5 compilation support
+
+
+  subroutine idle_mpi_io(status)
+
+! wait for an arrival of any MPI message
+
+!  use io_server_hdf5
+
+  implicit none
+#ifdef WITH_MPI
+  integer, intent(inout) :: status(MPI_STATUS_SIZE)
+  integer :: ier
+
+  call mpi_probe(MPI_ANY_SOURCE, MPI_ANY_TAG, my_local_mpi_comm_inter, status, ier)
+#else
+  ! no MPI
+  integer :: status(1)
+  integer :: unused_i4
+
+  stop 'idle_mpi_io not implemented for serial code'
+  unused_i4 = status(1)
+#endif
+
+  end subroutine idle_mpi_io
+
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+! unused so far...
+
+!  subroutine isend_i_inter(sendbuf, sendcount, dest, sendtag, req)
+!
+!!#ifdef WITH_MPI
+!!  use io_server_hdf5
+!!#endif
+!
+!  implicit none
+!
+!  integer :: sendcount, dest, sendtag, req
+!  integer, dimension(sendcount) :: sendbuf
+!
+!#ifdef WITH_MPI
+!  integer :: ier
+!
+!  call MPI_ISEND(sendbuf,sendcount,MPI_INTEGER,dest,sendtag,my_local_mpi_comm_inter,req,ier)
+!#else
+!  ! no MPI
+!  integer(kind=4) :: unused_i4
+!
+!  stop 'isend_i_inter not implemented for serial code'
+!  unused_i4 = dest
+!  unused_i4 = sendtag
+!  unused_i4 = req
+!  unused_i4 = sendbuf(1)
+!#endif
+!
+!  end subroutine isend_i_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine recv_i_inter(recvbuf, recvcount, dest, recvtag )
+
+  implicit none
+
+  integer :: dest,recvtag
+  integer :: recvcount
+  integer,dimension(recvcount):: recvbuf
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  call MPI_RECV(recvbuf,recvcount,MPI_INTEGER,dest,recvtag, &
+                my_local_mpi_comm_inter,MPI_STATUS_IGNORE,ier)
+#else
+  ! no MPI
+  integer(kind=4) :: unused_i4
+
+  stop 'recv_i_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = recvtag
+  unused_i4 = recvbuf(1)
+#endif
+
+  end subroutine recv_i_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine recv_dp_inter(recvbuf, recvcount, dest, recvtag)
+
+  implicit none
+
+  integer :: dest,recvtag
+  integer :: recvcount
+  double precision,dimension(recvcount):: recvbuf
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  call MPI_RECV(recvbuf,recvcount,MPI_DOUBLE_PRECISION,dest,recvtag, &
+                my_local_mpi_comm_inter,MPI_STATUS_IGNORE,ier)
+#else
+  ! no MPI
+  integer(kind=4) :: unused_i4
+  double precision :: unused_dp
+
+  stop 'recv_dp_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = recvtag
+  unused_dp = recvbuf(1)
+#endif
+
+  end subroutine recv_dp_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine recvv_cr_inter(recvbuf, recvcount, dest, recvtag)
+
+  implicit none
+
+#ifdef WITH_MPI
+  include "precision.h"
+#endif
+
+  integer :: recvcount,dest,recvtag
+  real(kind=CUSTOM_REAL),dimension(recvcount) :: recvbuf
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  call MPI_RECV(recvbuf,recvcount,CUSTOM_MPI_TYPE,dest,recvtag, &
+                my_local_mpi_comm_inter,MPI_STATUS_IGNORE,ier)
+#else
+  ! no MPI
+  integer(kind=4) :: unused_i4
+  real(kind=CUSTOM_REAL) :: unused_cr
+
+  stop 'recvv_cr_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = recvtag
+  unused_cr = recvbuf(1)
+#endif
+
+  end subroutine recvv_cr_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine irecvv_cr_inter(recvbuf, recvcount, dest, recvtag, req)
+
+  implicit none
+
+#ifdef WITH_MPI
+  include "precision.h"
+#endif
+
+  integer :: recvcount,dest,recvtag,req
+  real(kind=CUSTOM_REAL),dimension(recvcount) :: recvbuf
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  call MPI_IRECV(recvbuf,recvcount,CUSTOM_MPI_TYPE,dest,recvtag, &
+                my_local_mpi_comm_inter,req,ier)
+#else
+  ! no MPI
+  integer(kind=4) :: unused_i4
+  real(kind=CUSTOM_REAL) :: unused_cr
+
+  stop 'irecvv_cr_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = req
+  unused_i4 = recvtag
+  unused_cr = recvbuf(1)
+#endif
+
+  end subroutine irecvv_cr_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine isend_cr_inter(sendbuf, sendcount, dest, sendtag, req)
+
+  implicit none
+
+#ifdef WITH_MPI
+  include "precision.h"
+#endif
+
+  integer :: sendcount, dest, sendtag, req
+  real(kind=CUSTOM_REAL), dimension(sendcount) :: sendbuf
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  call MPI_ISEND(sendbuf,sendcount,CUSTOM_MPI_TYPE,dest,sendtag,my_local_mpi_comm_inter,req,ier)
+#else
+  ! no MPI
+  integer(kind=4) :: unused_i4
+  real(kind=CUSTOM_REAL) :: unused_cr
+
+  stop 'isend_cr_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = sendtag
+  unused_i4 = req
+  unused_cr = sendbuf(1)
+#endif
+
+  end subroutine isend_cr_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine send_i_inter(sendbuf, sendcount, dest, sendtag)
+
+  implicit none
+
+  integer :: dest,sendtag
+  integer :: sendcount
+  integer,dimension(sendcount):: sendbuf
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  call MPI_SEND(sendbuf,sendcount,MPI_INTEGER,dest,sendtag,my_local_mpi_comm_inter,ier)
+#else
+  ! no MPI
+  integer(kind=4) :: unused_i4
+
+  stop 'send_i_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = sendtag
+  unused_i4 = sendbuf(1)
+#endif
+
+  end subroutine send_i_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine send_dp_inter(sendbuf, sendcount, dest, sendtag)
+
+  implicit none
+
+  integer :: dest,sendtag
+  integer :: sendcount
+  double precision,dimension(sendcount):: sendbuf
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  call MPI_SEND(sendbuf,sendcount,MPI_DOUBLE_PRECISION,dest,sendtag,my_local_mpi_comm_inter,ier)
+#else
+  ! no MPI
+  integer(kind=4) :: unused_i4
+  double precision :: unused_dp
+
+  stop 'send_dp_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = sendtag
+  unused_dp = sendbuf(1)
+#endif
+
+  end subroutine send_dp_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+
+  subroutine sendv_cr_inter(sendbuf, sendcount, dest, sendtag)
+
+  implicit none
+
+#ifdef WITH_MPI
+  include "precision.h"
+#endif
+
+  integer :: sendcount,dest,sendtag
+  real(kind=CUSTOM_REAL),dimension(sendcount) :: sendbuf
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  call MPI_SEND(sendbuf,sendcount,CUSTOM_MPI_TYPE,dest,sendtag,my_local_mpi_comm_inter,ier)
+#else
+  ! no MPI
+  integer(kind=4) :: unused_i4
+  real(kind=CUSTOM_REAL) :: unused_cr
+
+  stop 'send_cr_inter not implemented for serial code'
+  unused_i4 = dest
+  unused_i4 = sendtag
+  unused_cr = sendbuf(1)
+#endif
+
+  end subroutine sendv_cr_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine gather_all_all_single_ch(sendbuf, recvbuf, NPROC, dim1)
+
+#ifdef WITH_MPI
+  use my_mpi
+#endif
+
+  implicit none
+
+  integer                                   :: dim1 ! character length
+  integer                                   :: NPROC
+  character(len=dim1)                       :: sendbuf
+  character(len=dim1), dimension(0:NPROC-1) :: recvbuf
+
+#ifdef WITH_MPI
+  integer :: ier
+
+  call MPI_ALLGATHER(sendbuf,dim1,MPI_CHARACTER, &
+                     recvbuf,dim1,MPI_CHARACTER, &
+                     my_local_mpi_comm_world,ier)
+#else
+  ! no MPI
+  character(len=1) :: unused_ch
+
+  stop 'send_cr_inter not implemented for serial code'
+  unused_ch = sendbuf(1)
+  unused_ch = recvbuf(1)
+#endif
+
+  end subroutine gather_all_all_single_ch
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+! unused so far...
+
+!  subroutine gatherv_all_cr_inter(sendbuf, sendcnt, recvbuf, recvcount, recvoffset,recvcounttot, NPROC)
+!
+!!  use io_server_hdf5
+!
+!  implicit none
+!
+!#ifdef WITH_MPI
+!  include "precision.h"
+!#endif
+!
+!  integer :: sendcnt,recvcounttot,NPROC
+!  integer, dimension(NPROC) :: recvcount,recvoffset
+!  real(kind=CUSTOM_REAL), dimension(sendcnt) :: sendbuf
+!  real(kind=CUSTOM_REAL), dimension(recvcounttot) :: recvbuf
+!
+!#ifdef WITH_MPI
+!  integer :: ier
+!
+!  call MPI_GATHERV(sendbuf,sendcnt,CUSTOM_MPI_TYPE, &
+!                   recvbuf,recvcount,recvoffset,CUSTOM_MPI_TYPE, &
+!                   0,my_local_mpi_comm_inter,ier)
+!#else
+!  ! no MPI
+!  integer(kind=4) :: unused_i4
+!  real(kind=CUSTOM_REAL) :: unused_cr
+!
+!  stop 'gatherv_all_cr_inter not implemented for serial code'
+!  unused_i4 = recvcount(1)
+!  unused_i4 = recvoffset(1)
+!  unused_cr = sendbuf(1)
+!  unused_cr = recvbuf(1)
+!#endif
+!
+!  end subroutine gatherv_all_cr_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine world_get_size_msg(status,size)
+
+#ifdef WITH_MPI
+  use my_mpi
+
+  implicit none
+
+  integer, intent(in)  :: status(MPI_STATUS_SIZE)
+  integer, intent(out) :: size
+  integer              :: ier
+
+  call MPI_GET_COUNT(status, MPI_INT, size, ier);
+#else
+  ! no MPI
+  integer, intent(in)  :: status(1)
+  integer, intent(out) :: size
+  integer(kind=4) :: unused_i4
+
+  stop 'world_get_size_msg not implemented for serial code'
+  size = 0
+  unused_i4 = status(1)
+#endif
+
+  end subroutine world_get_size_msg
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine world_unsplit_inter()
+
+  implicit none
+  integer :: ier
+
+  if (HDF5_IO_NODES > 0) then
+    call synchronize_inter()
+
+#ifdef WITH_MPI
+    call MPI_COMM_FREE(my_local_mpi_comm_inter,ier)
+#else
+  stop 'world_unsplit_inter not implemented for serial code'
+#endif
+
+  endif
+
+  end subroutine world_unsplit_inter
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine wait_volume_recv()
+
+  implicit none
+
+  integer :: i
+
+  do i = 0, nproc_io-1
+    if (vd_pres%req(i) /= VAL_NOT_ASSIGNED) call wait_req(vd_pres%req(i))
+    if (vd_divglob%req(i) /= VAL_NOT_ASSIGNED) call wait_req(vd_divglob%req(i))
+    if (vd_div%req(i) /= VAL_NOT_ASSIGNED) call wait_req(vd_div%req(i))
+    if (vd_curlx%req(i) /= VAL_NOT_ASSIGNED) call wait_req(vd_curlx%req(i))
+    if (vd_curly%req(i) /= VAL_NOT_ASSIGNED) call wait_req(vd_curly%req(i))
+    if (vd_curlz%req(i) /= VAL_NOT_ASSIGNED) call wait_req(vd_curlz%req(i))
+    if (vd_velox%req(i) /= VAL_NOT_ASSIGNED) call wait_req(vd_velox%req(i))
+    if (vd_veloy%req(i) /= VAL_NOT_ASSIGNED) call wait_req(vd_veloy%req(i))
+    if (vd_veloz%req(i) /= VAL_NOT_ASSIGNED) call wait_req(vd_veloz%req(i))
+  enddo
+
+  end subroutine wait_volume_recv
+
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine count_nprocs_with_recs(islice_num_rec_local)
+
+! counts number of local receivers for each slice
+
+  use shared_parameters, only: NPROC
+
+  implicit none
+
+  integer, dimension(0:NPROC-1) :: islice_num_rec_local
+  integer                       :: iproc
+
+  do iproc = 0, NPROC-1
+    if (islice_num_rec_local(iproc) > 0) &
+      n_procs_with_rec = n_procs_with_rec + 1
+  enddo
+
+  end subroutine count_nprocs_with_recs
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine recv_shake_data(status, nfaces_perproc, surface_offset)
+
+  use shared_parameters, only: NPROC
+
+  implicit none
+
+  integer, dimension(0:NPROC-1), intent(in)         :: nfaces_perproc, surface_offset
+  integer                                           :: ier, sender, tag, i
+#ifdef WITH_MPI
+  integer, intent(in)                               :: status(MPI_STATUS_SIZE)
+#else
+  integer                                           :: status(1)
+#endif
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: temp_array
+
+#ifdef WITH_MPI
+  sender = status(MPI_SOURCE)
+  tag    = status(MPI_TAG)
+#else
+  sender = status(1)
+  tag    = status(1)
+#endif
+
+  allocate(temp_array(nfaces_perproc(sender)), stat=ier)
+
+  call recvv_cr_inter(temp_array,nfaces_perproc(sender),sender,tag)
+
+  if (tag == io_tag_shake_ux) then
+    do i = 1, size(temp_array)
+      shake_ux(i+surface_offset(sender)) = temp_array(i)
+    enddo
+  else if (tag == io_tag_shake_uy) then
+    do i = 1, size(temp_array)
+      shake_uy(i+surface_offset(sender)) = temp_array(i)
+    enddo
+  else if (tag == io_tag_shake_uz) then
+    do i = 1, size(temp_array)
+      shake_uz(i+surface_offset(sender)) = temp_array(i)
+    enddo
+  endif
+
+  deallocate(temp_array)
+
+  end subroutine recv_shake_data
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine recv_surf_data(status, nfaces_perproc, surface_offset)
+
+  use shared_parameters, only: NPROC
+
+  implicit none
+
+  integer, dimension(0:NPROC-1), intent(in)         :: nfaces_perproc, surface_offset
+  integer                                           :: ier, sender, tag, i
+  integer                                           :: msgsize
+#ifdef WITH_MPI
+  integer, intent(in)                               :: status(MPI_STATUS_SIZE)
+#else
+  integer                                           :: status(1)
+#endif
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: temp_array
+
+#ifdef WITH_MPI
+  sender = status(MPI_SOURCE)
+  tag    = status(MPI_TAG)
+#else
+  sender = status(1)
+  tag    = status(1)
+#endif
+
+  allocate(temp_array(nfaces_perproc(sender)), stat=ier)
+  temp_array(:) = 0._CUSTOM_REAL
+
+  call world_get_size_msg(status, msgsize)
+
+  call recvv_cr_inter(temp_array,nfaces_perproc(sender),sender,tag)
+
+  if (tag == io_tag_surface_ux) then
+    do i = 1, size(temp_array)
+      surf_ux(i+surface_offset(sender)) = temp_array(i)
+    enddo
+  else if (tag == io_tag_surface_uy) then
+    do i = 1, size(temp_array)
+      surf_uy(i+surface_offset(sender)) = temp_array(i)
+    enddo
+  else if (tag == io_tag_surface_uz) then
+    do i = 1, size(temp_array)
+      surf_uz(i+surface_offset(sender)) = temp_array(i)
+    enddo
+  endif
+
+  deallocate(temp_array)
+
+  end subroutine recv_surf_data
+
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+!
+! seismo
+!
+  subroutine get_receiver_info(islice_num_rec_local)
+
+  use shared_parameters, only: NPROC
+  use specfem_par, only: t0,nrec
+
+  implicit none
+
+  integer                      :: iproc
+  integer, dimension(1)        :: tmp_1d_iarr
+  integer,dimension(0:NPROC-1) :: islice_num_rec_local
+  double precision, dimension(1) :: tmp_1d_darr
+
+  call recv_i_inter(tmp_1d_iarr, 1, 0, io_tag_num_recv)
+  nrec = tmp_1d_iarr(1)
+
+  call recv_dp_inter(tmp_1d_darr, 1, 0, io_tag_seismo_tzero)
+  t0 = tmp_1d_darr(1)
+
+  do iproc = 0, NPROC-1
+    call recv_i_inter(tmp_1d_iarr, 1, iproc, io_tag_local_rec)
+    islice_num_rec_local(iproc) = tmp_1d_iarr(1)
+  enddo
+
+  end subroutine get_receiver_info
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine allocate_seismo_arrays(islice_num_rec_local)
+
+  use constants, only: NDIM
+
+  use shared_parameters, only: NPROC,NSTEP, &
+    SAVE_SEISMOGRAMS_DISPLACEMENT,SAVE_SEISMOGRAMS_VELOCITY, &
+    SAVE_SEISMOGRAMS_ACCELERATION,SAVE_SEISMOGRAMS_PRESSURE
+
+  use specfem_par, only: nlength_seismogram,nrec
+
+  implicit none
+
+  integer, dimension(0:NPROC-1), intent(in) :: islice_num_rec_local
+  integer                                   :: ier, max_num_rec, nstep_temp
+
+  if (nlength_seismogram >= NSTEP) then
+    nstep_temp = NSTEP
+  else
+    nstep_temp = nlength_seismogram
+  endif
+
+  ! allocate id_rec_globs for storing global id of receivers
+  max_num_rec = maxval(islice_num_rec_local)
+  allocate(id_rec_globs(max_num_rec,0:NPROC-1),stat=ier)
+  if (ier /= 0) call exit_MPI_without_rank('error allocating array id_rec_globs')
+  if (ier /= 0) stop 'error allocating array id_rec_globs'
+  ! initialize
+  id_rec_globs(:,:) = 0
+
+  if (SAVE_SEISMOGRAMS_DISPLACEMENT) then
+    allocate(seismo_displ(NDIM,nstep_temp,nrec),stat=ier)
+    if (ier /= 0) call exit_MPI_without_rank('error allocating array seimo_disp')
+    if (ier /= 0) stop 'error allocating array seismo_displ'
+    seismo_displ(:,:,:) = 0._CUSTOM_REAL
+  endif
+  if (SAVE_SEISMOGRAMS_VELOCITY) then
+    allocate(seismo_veloc(NDIM,nstep_temp,nrec),stat=ier)
+    if (ier /= 0) call exit_MPI_without_rank('error allocating array seismo_veloc')
+    if (ier /= 0) stop 'error allocating array seismo_veloc'
+    seismo_veloc(:,:,:) = 0._CUSTOM_REAL
+  endif
+  if (SAVE_SEISMOGRAMS_ACCELERATION) then
+    allocate(seismo_accel(NDIM,nstep_temp,nrec),stat=ier)
+    if (ier /= 0) call exit_MPI_without_rank('error allocating array seismo_accel')
+    if (ier /= 0) stop 'error allocating array seismo_accel'
+    seismo_accel(:,:,:) = 0._CUSTOM_REAL
+  endif
+  if (SAVE_SEISMOGRAMS_PRESSURE) then
+    allocate(seismo_press(nstep_temp,nrec),stat=ier)
+    if (ier /= 0) call exit_MPI_without_rank('error allocating array seismo_press')
+    if (ier /= 0) stop 'error allocating array seismo_press'
+    seismo_press(:,:) = 0._CUSTOM_REAL
+  endif
+
+  end subroutine allocate_seismo_arrays
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine deallocate_io_arrays()
+
+  use shared_parameters, only: MOVIE_VOLUME,USE_HIGHRES_FOR_MOVIES
+
+  implicit none
+
+  ! seismo
+  if (allocated(id_rec_globs)) deallocate(id_rec_globs)
+  if (allocated(seismo_displ)) deallocate(seismo_displ)
+  if (allocated(seismo_veloc)) deallocate(seismo_veloc)
+  if (allocated(seismo_accel)) deallocate(seismo_accel)
+  if (allocated(seismo_press)) deallocate(seismo_press)
+
+  ! surface movie
+  if (allocated(surf_x)) deallocate(surf_x,surf_y,surf_z)
+  if (allocated(surf_ux)) deallocate(surf_ux,surf_uy,surf_uz)
+
+  ! shake map
+  if (allocated(shake_ux)) deallocate(shake_ux,shake_uy,shake_uz)
+
+  if (USE_HIGHRES_FOR_MOVIES) then
+    ! surface movie
+    if (allocated(surf_x_aug)) deallocate(surf_x_aug,surf_y_aug,surf_z_aug)
+    if (allocated(surf_ux_aug)) deallocate(surf_ux_aug,surf_uy_aug,surf_uz_aug)
+    ! shake map
+    if (allocated(shake_ux_aug)) deallocate(shake_ux_aug,shake_uy_aug,shake_uz_aug)
+  endif
+
+  if (MOVIE_VOLUME) then
+    deallocate(vd_pres%req ,vd_divglob%req,   vd_div%req, &
+               vd_curlx%req,  vd_curly%req, vd_curlz%req, &
+               vd_velox%req,  vd_veloy%req, vd_veloz%req)
+    deallocate(vd_pres%d1darr, &
+               vd_divglob%d1darr, &
+               vd_div%d1darr, &
+               vd_curlx%d1darr, vd_curly%d1darr, vd_curlz%d1darr, &
+               vd_velox%d1darr, vd_veloy%d1darr, vd_veloz%d1darr)
+
+    deallocate(id_proc_loc2glob, id_proc_glob2loc, dest_ioids)
+  endif
+
+  end subroutine deallocate_io_arrays
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine count_seismo_type()
+
+  use shared_parameters, only: SAVE_SEISMOGRAMS_DISPLACEMENT,SAVE_SEISMOGRAMS_VELOCITY, &
+    SAVE_SEISMOGRAMS_ACCELERATION,SAVE_SEISMOGRAMS_PRESSURE
+
+  implicit none
+
+  integer :: n_type = 0
+
+  if (SAVE_SEISMOGRAMS_DISPLACEMENT) n_type = n_type+1
+  if (SAVE_SEISMOGRAMS_VELOCITY)     n_type = n_type+1
+  if (SAVE_SEISMOGRAMS_ACCELERATION) n_type = n_type+1
+  if (SAVE_SEISMOGRAMS_PRESSURE)     n_type = n_type+1
+
+  n_seismo_type = n_type
+
+  end subroutine count_seismo_type
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine recv_id_rec(islice_num_rec_local)
+
+  use shared_parameters, only: NPROC
+
+  implicit none
+
+  integer :: sender
+  integer, dimension(0:NPROC-1), intent(in) :: islice_num_rec_local
+
+  do sender = 0, NPROC-1
+    if (islice_num_rec_local(sender) /= 0) then
+      call recv_i_inter(id_rec_globs(:,sender), size(id_rec_globs(:,sender)), sender, io_tag_seismo_ids_rec)
+    endif
+  enddo
+
+  end subroutine recv_id_rec
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine recv_seismo_data(status, islice_num_rec_local)
+
+  use constants, only: NDIM
+  use shared_parameters, only: NPROC
+
+  implicit none
+
+  integer, dimension(0:NPROC-1), intent(in) :: islice_num_rec_local
+#ifdef WITH_MPI
+  integer, intent(in)                       :: status(MPI_STATUS_SIZE)
+#else
+  integer                                   :: status(1)
+#endif
+
+  integer :: sender, nrec_passed, irec_passed, tag, id_rec_glob, ier
+  real(kind=CUSTOM_REAL), dimension(:,:,:), allocatable :: seismo_temp
+  integer                                               :: msg_size,time_window
+
+#ifdef WITH_MPI
+  sender = status(MPI_SOURCE)
+  tag    = status(MPI_TAG)
+#else
+  sender = status(1)
+  tag    = status(1)
+#endif
+
+  nrec_passed  = islice_num_rec_local(sender)
+
+  call world_get_size_msg(status,msg_size)
+
+  if (nrec_passed > 0) then
+    ! get seismogram vector values
+    ! allocate temp array size
+    time_window = int(msg_size/NDIM/nrec_passed)
+    allocate(seismo_temp(NDIM,time_window,nrec_passed),stat=ier)
+    if (ier /= 0) call exit_MPI_without_rank('error allocating array seismo_temp')
+    if (ier /= 0) stop 'error allocating array seismo_temp'
+    seismo_temp(:,:,:) = 0.0
+
+    call recvv_cr_inter(seismo_temp, msg_size, sender, tag)
+
+    ! set local array to the global array
+    do irec_passed = 1,nrec_passed
+      id_rec_glob = id_rec_globs(irec_passed,sender)
+
+      if (tag == io_tag_seismo_body_disp) then
+        ! displacement
+        seismo_displ(:,:,id_rec_glob) = seismo_temp(:,:,irec_passed)
+
+      else if (tag == io_tag_seismo_body_velo) then
+        ! velocity
+        seismo_veloc(:,:,id_rec_glob) = seismo_temp(:,:,irec_passed)
+
+      else if (tag == io_tag_seismo_body_acce) then
+        ! acceleration
+        seismo_accel(:,:,id_rec_glob) = seismo_temp(:,:,irec_passed)
+
+      else if (tag == io_tag_seismo_body_pres) then
+        ! pressure (single component only)
+        seismo_press(:,id_rec_glob) = seismo_temp(1,:,irec_passed)
+      endif
+    enddo
+
+    ! deallocate temp array
+    deallocate(seismo_temp)
+
+  endif
+
+  end subroutine recv_seismo_data
+
+
+! USE_HDF5
+#endif
+
+end module io_server_hdf5
+

--- a/src/specfem3D/initialize_simulation.F90
+++ b/src/specfem3D/initialize_simulation.F90
@@ -28,12 +28,14 @@
 
   subroutine initialize_simulation()
 
-  use manager_adios
   use specfem_par
   use specfem_par_elastic
   use specfem_par_acoustic
   use specfem_par_poroelastic
   use specfem_par_movie
+
+  use manager_adios
+  use io_server_hdf5
 
   implicit none
 
@@ -71,16 +73,16 @@
   BROADCAST_AFTER_READ = .true.
   call read_parameter_file(BROADCAST_AFTER_READ)
 
-  !#TODO: hdf5 i/o server
+  ! hdf5 i/o server
   ! HDF5 separate nodes for i/o server
-  !if (HDF5_IO_NNODES > 0) call initialize_io_server()
+  if (HDF5_IO_NODES > 0) call initialize_io_server()
   ! checks if anything to do
-  !if (.not. IO_compute_task) then
-  !  ! i/o server synchronization
-  !  if (HDF5_IO_NNODES > 0) call synchronize_inter()
-  !  ! all done
-  !  return
-  !endif
+  if (.not. IO_compute_task) then
+    ! i/o server synchronization
+    if (HDF5_IO_NODES > 0) call synchronize_inter()
+    ! all done
+    return
+  endif
 
   ! checks flags
   call initialize_simulation_check()
@@ -197,58 +199,58 @@
   endif
 
   allocate(irregular_element_number(NSPEC_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2388')
-  if (ier /= 0) stop 'error allocating arrays for irregular element numbering'
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2388')
+  if (ier /= 0) stop 'Error allocating arrays for irregular element numbering'
   irregular_element_number(:) = 0
 
   ! allocate arrays for storing the databases
   allocate(ibool(NGLLX,NGLLY,NGLLZ,NSPEC_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2389')
-  if (ier /= 0) stop 'error allocating ibool'
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2389')
+  if (ier /= 0) stop 'Error allocating ibool'
   ibool(:,:,:,:) = 0
 
   if (NSPEC_IRREGULAR > 0) then
      allocate(xixstore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2390')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2390')
      allocate(xiystore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2391')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2391')
      allocate(xizstore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2392')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2392')
      allocate(etaxstore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2393')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2393')
      allocate(etaystore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2394')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2394')
      allocate(etazstore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2395')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2395')
      allocate(gammaxstore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2396')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2396')
      allocate(gammaystore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2397')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2397')
      allocate(gammazstore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2398')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2398')
      allocate(jacobianstore(NGLLX,NGLLY,NGLLZ,NSPEC_IRREGULAR),stat=ier)
-     if (ier /= 0) call exit_MPI_without_rank('error allocating array 2399')
+     if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2399')
   else
     allocate(xixstore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2400')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2400')
     allocate(xiystore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2401')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2401')
     allocate(xizstore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2402')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2402')
     allocate(etaxstore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2403')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2403')
     allocate(etaystore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2404')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2404')
     allocate(etazstore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2405')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2405')
     allocate(gammaxstore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2406')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2406')
     allocate(gammaystore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2407')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2407')
     allocate(gammazstore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2408')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2408')
     allocate(jacobianstore(1,1,1,1),stat=ier)
-    if (ier /= 0) call exit_MPI_without_rank('error allocating array 2409')
+    if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2409')
   endif
   xixstore(:,:,:,:) = 0.0_CUSTOM_REAL; xiystore(:,:,:,:) = 0.0_CUSTOM_REAL; xizstore(:,:,:,:) = 0.0_CUSTOM_REAL
   etaxstore(:,:,:,:) = 0.0_CUSTOM_REAL; etaystore(:,:,:,:) = 0.0_CUSTOM_REAL; etazstore(:,:,:,:) = 0.0_CUSTOM_REAL
@@ -256,32 +258,32 @@
 
   ! mesh node locations
   allocate(xstore(NGLOB_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2410')
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2410')
   allocate(ystore(NGLOB_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2411')
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2411')
   allocate(zstore(NGLOB_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2412')
-  if (ier /= 0) stop 'error allocating arrays for mesh nodes'
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2412')
+  if (ier /= 0) stop 'Error allocating arrays for mesh nodes'
   xstore(:) = 0.0_CUSTOM_REAL; ystore(:) = 0.0_CUSTOM_REAL; zstore(:) = 0.0_CUSTOM_REAL
 
   ! material properties
   allocate(kappastore(NGLLX,NGLLY,NGLLZ,NSPEC_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2413')
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2413')
   allocate(mustore(NGLLX,NGLLY,NGLLZ,NSPEC_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2414')
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2414')
   allocate(rhostore(NGLLX,NGLLY,NGLLZ,NSPEC_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating rho array 2414')
-  if (ier /= 0) stop 'error allocating arrays for material properties'
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating rho array 2414')
+  if (ier /= 0) stop 'Error allocating arrays for material properties'
   kappastore(:,:,:,:) = 0.0_CUSTOM_REAL; mustore(:,:,:,:) = 0.0_CUSTOM_REAL; rhostore(:,:,:,:) = 0.0_CUSTOM_REAL
 
   ! material flags
   allocate(ispec_is_acoustic(NSPEC_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2415')
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2415')
   allocate(ispec_is_elastic(NSPEC_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2416')
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2416')
   allocate(ispec_is_poroelastic(NSPEC_AB),stat=ier)
-  if (ier /= 0) call exit_MPI_without_rank('error allocating array 2417')
-  if (ier /= 0) stop 'error allocating arrays for material flags'
+  if (ier /= 0) call exit_MPI_without_rank('Error allocating array 2417')
+  if (ier /= 0) stop 'Error allocating arrays for material flags'
   ispec_is_acoustic(:) = .false.
   ispec_is_elastic(:) = .false.
   ispec_is_poroelastic(:) = .false.
@@ -298,9 +300,9 @@
   ! synchronizes processes
   call synchronize_all()
 
-  !#TODO: hdf5 i/o server
+  ! hdf5 i/o server
   ! i/o server synchronization
-  !if (HDF5_IO_NNODES > 0) call synchronize_inter()
+  if (HDF5_IO_NODES > 0) call synchronize_inter()
 
   end subroutine initialize_simulation
 
@@ -332,11 +334,11 @@
   ! check that the code is running with the requested nb of processes
   if (sizeprocs /= NPROC) then
     if (myrank == 0) then
-      write(IMAIN,*) 'error: number of processors supposed to run on: ',NPROC
-      write(IMAIN,*) 'error: number of MPI processors actually run on: ',sizeprocs
+      write(IMAIN,*) 'Error: number of processors supposed to run on: ',NPROC
+      write(IMAIN,*) 'Error: number of MPI processors actually run on: ',sizeprocs
       print *
-      print *, 'error specfem3D: number of processors supposed to run on: ',NPROC
-      print *, 'error specfem3D: number of MPI processors actually run on: ',sizeprocs
+      print *, 'Error specfem3D: number of processors supposed to run on: ',NPROC
+      print *, 'Error specfem3D: number of MPI processors actually run on: ',sizeprocs
       print *
     endif
     call exit_MPI(myrank,'wrong number of MPI processes')
@@ -386,12 +388,12 @@
 
   if (STACEY_INSTEAD_OF_FREE_SURFACE .and. PML_INSTEAD_OF_FREE_SURFACE) then
     print *, 'please modify Par_file and recompile solver'
-    stop 'error: STACEY_INSTEAD_OF_FREE_SURFACE and PML_INSTEAD_OF_FREE_SURFACE are both set to .true.'
+    stop 'Error: STACEY_INSTEAD_OF_FREE_SURFACE and PML_INSTEAD_OF_FREE_SURFACE are both set to .true.'
   endif
 
   ! checks the MOVIE_TYPE parameter
   if (MOVIE_TYPE < 1 .or. MOVIE_TYPE > 3) then
-    stop 'error: MOVIE_TYPE must be either 1, 2 or 3! Please modify Par_file and recompile solver'
+    stop 'Error: MOVIE_TYPE must be either 1, 2 or 3! Please modify Par_file and recompile solver'
   endif
 
   ! check that the code has been compiled with the right values
@@ -400,10 +402,10 @@
 
     open(unit=IOUT,file=trim(HEADER_FILE),status='old',iostat=ier)
     if (ier /= 0) then
-      print *,'error opening file: ',trim(HEADER_FILE)
+      print *,'Error opening file: ',trim(HEADER_FILE)
       print *
       print *,'please check if xgenerate_databases has been run before this solver, exiting now...'
-      stop 'error opening file values_from_mesher.h'
+      stop 'Error opening file values_from_mesher.h'
     endif
     read(IOUT,NML=MESHER)
     close(IOUT)
@@ -424,7 +426,7 @@
     open(IOUT,file=trim(OUTPUT_FILES)//'/dummy.txt',status='unknown',iostat=ier)
     if (ier /= 0) then
       print *,"OUTPUT_FILES directory does not work: ",trim(OUTPUT_FILES)
-      call exit_MPI(myrank,'error OUTPUT_FILES directory')
+      call exit_MPI(myrank,'Error OUTPUT_FILES directory')
     endif
     close(IOUT,status='delete')
 
@@ -433,7 +435,7 @@
     open(IOUT,file=trim(LOCAL_PATH)//'/dummy.txt',status='unknown',iostat=ier)
     if (ier /= 0) then
       print *,"LOCAL_PATH directory does not work: ",trim(LOCAL_PATH)
-      call exit_MPI(myrank,'error LOCAL_PATH directory')
+      call exit_MPI(myrank,'Error LOCAL_PATH directory')
     endif
     close(IOUT,status='delete')
   endif

--- a/src/specfem3D/iterate_time.F90
+++ b/src/specfem3D/iterate_time.F90
@@ -37,7 +37,7 @@
   use gravity_perturbation, only: gravity_timeseries, GRAVITY_SIMULATION
 
   ! hdf5 i/o server
-  use io_server_hdf5, only: do_io_start_idle,pass_info_to_io,synchronize_inter
+  use io_server_hdf5, only: do_io_start_idle,pass_info_to_io
 
   implicit none
 

--- a/src/specfem3D/iterate_time_undoatt.F90
+++ b/src/specfem3D/iterate_time_undoatt.F90
@@ -37,7 +37,7 @@
   use gravity_perturbation, only: gravity_timeseries, GRAVITY_SIMULATION
 
   ! hdf5 i/o server
-  use io_server_hdf5, only: do_io_start_idle,pass_info_to_io,synchronize_inter
+  use io_server_hdf5, only: do_io_start_idle,pass_info_to_io
 
   implicit none
 

--- a/src/specfem3D/iterate_time_undoatt.F90
+++ b/src/specfem3D/iterate_time_undoatt.F90
@@ -36,6 +36,9 @@
 
   use gravity_perturbation, only: gravity_timeseries, GRAVITY_SIMULATION
 
+  ! hdf5 i/o server
+  use io_server_hdf5, only: do_io_start_idle,pass_info_to_io,synchronize_inter
+
   implicit none
 
   ! local parameters
@@ -66,6 +69,24 @@
     call exit_MPI(myrank,'for undo_attenuation, POROELASTIC kernel simulation is not supported yet') ! not working yet...
   if (SIMULATION_TYPE == 3 .and. NOISE_TOMOGRAPHY /= 0) &
     call exit_MPI(myrank,'for undo_attenuation, noise kernel simulation is not supported yet') ! not working yet...
+
+  ! hdf5 i/o server
+  if (HDF5_IO_NODES > 0) then
+    ! start io server
+    if (IO_storage_task) then
+      call do_io_start_idle()
+    else
+      ! compute node passes necessary info to io node
+      call pass_info_to_io()
+    endif
+    ! checks if anything to do
+    if (.not. IO_compute_task) then
+      ! i/o server synchronization
+      call synchronize_inter()
+      ! all done
+      return
+    endif
+  endif
 
   ! note: NSTEP must not be a multiple of NT_DUMP_ATTENUATION, but should be equal or larger
   !
@@ -235,6 +256,7 @@
 !   s t a r t   t i m e   i t e r a t i o n s
 !
 
+  ! user output
   if (myrank == 0) then
     write(IMAIN,*)
     write(IMAIN,*) 'Starting time iteration loop in undoing attenuation...'
@@ -263,24 +285,6 @@
 
   ! get MPI starting
   time_start = wtime()
-
-  !#TODO: hdf5 i/o server
-  ! start io server
-  !if (HDF5_IO_NNODES > 0) then
-  !  if (IO_storage_task) then
-  !    call do_io_start_idle()
-  !  else
-  !    ! compute node passes necessary info to io node
-  !    call pass_info_to_io()
-  !  endif
-  !  ! checks if anything to do
-  !  if (.not. IO_compute_task) then
-  !    ! i/o server synchronization
-  !    call synchronize_inter()
-  !    ! all done
-  !    return
-  !  endif
-  !endif
 
   ! *********************************************************
   ! ************* MAIN LOOP OVER THE TIME STEPS *************
@@ -619,8 +623,8 @@
     call exit_MPI(myrank,'Error invalid time increment ending')
   endif
 
-  !#TODO: hdf5 i/o server
+  ! hdf5 i/o server
   ! i/o server synchronization
-  !if (HDF5_IO_NNODES > 0) call synchronize_inter()
+  if (HDF5_IO_NODES > 0) call synchronize_inter()
 
   end subroutine iterate_time_undoatt

--- a/src/specfem3D/read_mesh_databases_hdf5.F90
+++ b/src/specfem3D/read_mesh_databases_hdf5.F90
@@ -56,7 +56,7 @@
     call world_get_comm(comm)
     call world_get_info_null(info)
 
-    call h5_init()
+    call h5_initialize()
     call h5_set_mpi_info(comm, info, myrank, NPROC)
 
     ! opens file
@@ -75,7 +75,7 @@
 
     ! close hdf5
     call h5_close_file()
-    call h5_destructor()
+    call h5_finalize()
   endif
 
   call bcast_all_i_for_database(NSPEC_AB, 1)
@@ -181,7 +181,7 @@
     call world_get_comm(comm)
     call world_get_info_null(info)
 
-    call h5_init()
+    call h5_initialize()
     call h5_set_mpi_info(comm, info, myrank, NPROC)
 
     ! open file
@@ -1614,7 +1614,7 @@
   if (I_should_read_the_database) then
     ! close hdf5
     call h5_close_file()
-    call h5_destructor()
+    call h5_finalize()
   endif
 
   ! checks MPI interface arrays

--- a/src/specfem3D/rules.mk
+++ b/src/specfem3D/rules.mk
@@ -90,6 +90,7 @@ specfem3D_OBJECTS = \
 	$O/get_elevation.spec.o \
 	$O/get_force.spec.o \
 	$O/gravity_perturbation.spec.o \
+	$O/hdf5_io_server.spec_hdf5.o \
 	$O/initialize_simulation.spec.o \
 	$O/iterate_time.spec.o \
 	$O/iterate_time_undoatt.spec.o \
@@ -179,6 +180,7 @@ specfem3D_MODULES = \
 	$(FC_MODDIR)/fault_solver_dynamic.$(FC_MODEXT) \
 	$(FC_MODDIR)/fault_solver_kinematic.$(FC_MODEXT) \
 	$(FC_MODDIR)/gravity_perturbation.$(FC_MODEXT) \
+	$(FC_MODDIR)/io_server_hdf5.$(FC_MODEXT) \
 	$(FC_MODDIR)/image_pnm_par.$(FC_MODEXT) \
 	$(FC_MODDIR)/manager_adios.$(FC_MODEXT) \
 	$(FC_MODDIR)/pml_par.$(FC_MODEXT) \
@@ -355,6 +357,14 @@ $O/setup_sources_receivers.spec.o: $O/search_kdtree.shared.o
 ## HDF5 file i/o
 $O/prepare_attenuation.spec.o: $O/hdf5_manager.shared_hdf5_module.o
 
+$O/finalize_simulation.spec.o: $O/hdf5_io_server.spec_hdf5.o
+$O/initialize_simulation.spec.o: $O/hdf5_io_server.spec_hdf5.o
+$O/iterate_time.spec.o: $O/hdf5_io_server.spec_hdf5.o
+$O/iterate_time_undoatt.spec.o: $O/hdf5_io_server.spec_hdf5.o
+$O/write_movie_output.o: $O/hdf5_io_server.spec_hdf5.o
+$O/write_movie_output_HDF5.o: $O/hdf5_io_server.spec_hdf5.o
+$O/write_output_HDF5.o: $O/hdf5_io_server.spec_hdf5.o
+
 ####
 #### rule to build each .o file below
 ####
@@ -392,10 +402,10 @@ $O/%.spec_noadios.o: $S/%.f90 $O/specfem3D_par.spec_module.o $O/pml_par.spec_mod
 
 ## HDF5 file i/o
 $O/%.spec_hdf5.o: $S/%.f90 $O/specfem3D_par.spec_module.o $O/hdf5_manager.shared_hdf5_module.o
-	${FCCOMPILE_CHECK} ${FCFLAGS_f90} -c -o $@ $<
+	${MPIFCCOMPILE_CHECK} ${FCFLAGS_f90} $(COND_MPI_CPPFLAGS) -c -o $@ $<
 
 $O/%.spec_hdf5.o: $S/%.F90 $O/specfem3D_par.spec_module.o $O/hdf5_manager.shared_hdf5_module.o
-	${FCCOMPILE_CHECK} ${FCFLAGS_f90} -c -o $@ $<
+	${MPIFCCOMPILE_CHECK} ${FCFLAGS_f90} $(COND_MPI_CPPFLAGS) -c -o $@ $<
 
 
 ###

--- a/src/specfem3D/rules.mk
+++ b/src/specfem3D/rules.mk
@@ -361,9 +361,9 @@ $O/finalize_simulation.spec.o: $O/hdf5_io_server.spec_hdf5.o
 $O/initialize_simulation.spec.o: $O/hdf5_io_server.spec_hdf5.o
 $O/iterate_time.spec.o: $O/hdf5_io_server.spec_hdf5.o
 $O/iterate_time_undoatt.spec.o: $O/hdf5_io_server.spec_hdf5.o
-$O/write_movie_output.o: $O/hdf5_io_server.spec_hdf5.o
-$O/write_movie_output_HDF5.o: $O/hdf5_io_server.spec_hdf5.o
-$O/write_output_HDF5.o: $O/hdf5_io_server.spec_hdf5.o
+$O/write_movie_output.spec.o: $O/hdf5_io_server.spec_hdf5.o
+$O/write_movie_output_HDF5.spec_hdf5.o: $O/hdf5_io_server.spec_hdf5.o
+$O/write_output_HDF5.spec_hdf5.o: $O/hdf5_io_server.spec_hdf5.o
 
 ####
 #### rule to build each .o file below
@@ -402,10 +402,10 @@ $O/%.spec_noadios.o: $S/%.f90 $O/specfem3D_par.spec_module.o $O/pml_par.spec_mod
 
 ## HDF5 file i/o
 $O/%.spec_hdf5.o: $S/%.f90 $O/specfem3D_par.spec_module.o $O/hdf5_manager.shared_hdf5_module.o
-	${MPIFCCOMPILE_CHECK} ${FCFLAGS_f90} $(COND_MPI_CPPFLAGS) -c -o $@ $<
+	${FCCOMPILE_CHECK} ${FCFLAGS_f90} -c -o $@ $<
 
 $O/%.spec_hdf5.o: $S/%.F90 $O/specfem3D_par.spec_module.o $O/hdf5_manager.shared_hdf5_module.o
-	${MPIFCCOMPILE_CHECK} ${FCFLAGS_f90} $(COND_MPI_CPPFLAGS) -c -o $@ $<
+	${FCCOMPILE_CHECK} ${FCFLAGS_f90} -c -o $@ $<
 
 
 ###

--- a/src/specfem3D/write_movie_output.F90
+++ b/src/specfem3D/write_movie_output.F90
@@ -35,6 +35,9 @@
   use specfem_par_elastic
   use specfem_par_acoustic
 
+  ! hdf5 i/o server
+  use io_server_hdf5, only: wait_all_send
+
   implicit none
 
   if (.not. MOVIE_SIMULATION) return
@@ -68,9 +71,9 @@
 
   ! file output
   if (mod(it,NTSTEP_BETWEEN_FRAMES) == 0) then
-    !#TODO: hdf5 i/o server
+    ! hdf5 i/o server
     ! i/o server wait
-    !if (HDF5_IO_NNODES > 0) call wait_all_send()
+    if (HDF5_IO_NODES > 0) call wait_all_send()
 
     ! saves MOVIE on the SURFACE
     if (MOVIE_SURFACE) then

--- a/src/specfem3D/write_movie_output_HDF5.F90
+++ b/src/specfem3D/write_movie_output_HDF5.F90
@@ -240,7 +240,7 @@ contains
   len_array_aug = nfaces_actual * nfaces_aug * nnodes_per_face_aug
 
   ! initialization of h5 file
-  call h5_init()
+  call h5_initialize()
 
   if (myrank == 0) then
     ! create a hdf5 file
@@ -363,7 +363,7 @@ contains
 
   call h5_close_group()
   call h5_close_file()
-  call h5_destructor()
+  call h5_finalize()
 
 #else
   ! no HDF5 compilation support
@@ -512,7 +512,7 @@ contains
   len_array_aug = nfaces_actual * nfaces_aug * nnodes_per_face_aug
 
   ! initialization of h5 file
-  call h5_init()
+  call h5_initialize()
 
   ! main process creates file on first occurrence
   if (it == NTSTEP_BETWEEN_FRAMES .and. myrank == 0) then
@@ -643,7 +643,7 @@ contains
 
   call h5_close_group()
   call h5_close_file()
-  call h5_destructor()
+  call h5_finalize()
 #else
   ! no HDF5 compilation support
 
@@ -1037,7 +1037,7 @@ contains
   fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume.h5"
 
   ! initializes
-  call h5_init()
+  call h5_initialize()
 
   ! group for storing node coordinates and mesh element connectivity
   group_name = "mesh"
@@ -1096,7 +1096,7 @@ contains
 
   call h5_close_group()
   call h5_close_file()
-  call h5_destructor()
+  call h5_finalize()
 
   end subroutine prepare_vol_movie_hdf5
 
@@ -1126,7 +1126,7 @@ contains
   fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume.h5"
 
   ! initializes
-  call h5_init()
+  call h5_initialize()
 
   ! create a group for each io step
   write(tempstr, "(i6.6)") it
@@ -1157,7 +1157,7 @@ contains
 
   call h5_close_group()
   call h5_close_file()
-  call h5_destructor()
+  call h5_finalize()
 
   end subroutine write_vol_data_hdf5
 

--- a/src/specfem3D/write_movie_output_HDF5.F90
+++ b/src/specfem3D/write_movie_output_HDF5.F90
@@ -37,9 +37,6 @@
   use shared_parameters, only: NPROC,NSTEP,NTSTEP_BETWEEN_FRAMES,USE_HIGHRES_FOR_MOVIES, &
     ACOUSTIC_SIMULATION,ELASTIC_SIMULATION,POROELASTIC_SIMULATION
 
-  !#TODO: hdf5 i/o server
-  !use shared_parameters, only: HDF5_IO_NNODES
-
   use specfem_par, only: NSPEC_AB,NGLOB_AB,ibool,it,DT,t0,xstore,ystore,zstore
 
   use specfem_par_movie, only: faces_surface_offset, &
@@ -50,6 +47,10 @@
     div_glob,div,curl_x,curl_y,curl_z
 
   use manager_hdf5
+
+  ! hdf5 i/o server
+  use shared_parameters, only: HDF5_IO_NODES
+  use io_server_hdf5
 
   implicit none
 
@@ -63,12 +64,16 @@
 
   ! surface movie arrays
   integer :: size_surf_array = 0
-  real(kind=CUSTOM_REAL), dimension(:), allocatable :: surf_x,   surf_y,   surf_z, &
-                                                       surf_ux,  surf_uy,  surf_uz
-  real(kind=CUSTOM_REAL), dimension(:), allocatable :: surf_x_aug,   surf_y_aug,   surf_z_aug, &
-                                                       surf_ux_aug,  surf_uy_aug,  surf_uz_aug
-  real(kind=CUSTOM_REAL), dimension(:), allocatable :: shake_ux, shake_uy, shake_uz, &
-                                                       shake_ux_aug, shake_uy_aug, shake_uz_aug
+
+  !moved these arrays to hdf5_io_server.F90 as they are used to communicate to i/o nodes
+  !
+  !real(kind=CUSTOM_REAL), dimension(:), allocatable :: surf_x,   surf_y,   surf_z, &
+  !                                                     surf_ux,  surf_uy,  surf_uz
+  !real(kind=CUSTOM_REAL), dimension(:), allocatable :: surf_x_aug,   surf_y_aug,   surf_z_aug, &
+  !                                                     surf_ux_aug,  surf_uy_aug,  surf_uz_aug
+  !real(kind=CUSTOM_REAL), dimension(:), allocatable :: shake_ux, shake_uy, shake_uz, &
+  !                                                     shake_ux_aug, shake_uy_aug, shake_uz_aug
+  !integer, dimension(:), allocatable :: nglob_offset
 
   ! volume movie arrays
   real(kind=CUSTOM_REAL), dimension(:), allocatable :: div_on_node, curl_x_on_node, curl_y_on_node, curl_z_on_node
@@ -76,7 +81,6 @@
 
   ! arrays for hdf5 output
   integer, dimension(:), allocatable :: nelm_par_proc_nio, nglob_par_proc_nio
-  integer, dimension(:), allocatable :: nglob_offset
   integer, dimension(:), allocatable :: nelm_offset
 
 contains
@@ -153,43 +157,6 @@ contains
 
   end subroutine elm2node_base
 
-  !-------------------------------------------
-
-  subroutine get_conn_for_movie(elm_conn,offset)
-
-  implicit none
-
-  integer, dimension(9,NSPEC_AB*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)), intent(out) :: elm_conn
-  integer, intent(in) :: offset ! node id offset (starting global element id of each proc)
-
-  ! local parameters
-  integer :: ispec,ii,icub,jcub,kcub
-  integer,parameter :: cell_type = 9
-
-  do ispec = 1,NSPEC_AB
-    ! extract information from full GLL grid
-    ! node order follows vtk format
-    do icub = 0,NGLLX-2
-      do jcub = 0,NGLLY-2
-        do kcub = 0,NGLLZ-2
-          ii = 1+(ispec-1)*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1) + (icub*(NGLLY-1)*(NGLLZ-1)+jcub*(NGLLZ-1)+kcub)
-          elm_conn(1, ii)  = cell_type
-          elm_conn(2, ii)  = ibool(icub+1,jcub+1,kcub+1,ispec)-1 + offset   ! node id starts 0 in xdmf rule
-          elm_conn(3, ii)  = ibool(icub+2,jcub+1,kcub+1,ispec)-1 + offset
-          elm_conn(4, ii)  = ibool(icub+2,jcub+2,kcub+1,ispec)-1 + offset
-          elm_conn(5, ii)  = ibool(icub+1,jcub+2,kcub+1,ispec)-1 + offset
-          elm_conn(6, ii)  = ibool(icub+1,jcub+1,kcub+2,ispec)-1 + offset
-          elm_conn(7, ii)  = ibool(icub+2,jcub+1,kcub+2,ispec)-1 + offset
-          elm_conn(8, ii)  = ibool(icub+2,jcub+2,kcub+2,ispec)-1 + offset
-          elm_conn(9, ii)  = ibool(icub+1,jcub+2,kcub+2,ispec)-1 + offset
-        enddo
-      enddo
-    enddo
-  enddo
-
-  end subroutine get_conn_for_movie
-
-
   end module specfem_par_movie_hdf5
 #endif
 
@@ -201,6 +168,7 @@ contains
 
 #ifdef USE_HDF5
 
+  use specfem_par_movie, only: nfaces_surface_points
   use specfem_par_movie_hdf5
 
   implicit none
@@ -211,18 +179,19 @@ contains
   character(len=64) :: dset_name, group_name
   real(kind=CUSTOM_REAL) :: aug_factor
   character(len=MAX_STRING_LEN) :: fname_h5_data_shake
+  integer :: req
 
   logical, parameter :: if_corrective = .true.
 
-  !#TODO: hdf5 i/o server
-  !if (HDF5_IO_NNODES > 0) then
-  !  ! send shakemap arrays to io node
-  !  call isend_cr_inter(shakemap_ux,nfaces_surface_points,0,io_tag_shake_ux,req)
-  !  call isend_cr_inter(shakemap_uy,nfaces_surface_points,0,io_tag_shake_uy,req)
-  !  call isend_cr_inter(shakemap_uz,nfaces_surface_points,0,io_tag_shake_uz,req)
-  !  ! all done
-  !  return
-  !endif
+  ! hdf5 i/o server
+  if (HDF5_IO_NODES > 0) then
+    ! send shakemap arrays to io node
+    call isend_cr_inter(shakemap_ux,nfaces_surface_points,0,io_tag_shake_ux,req)
+    call isend_cr_inter(shakemap_uy,nfaces_surface_points,0,io_tag_shake_uy,req)
+    call isend_cr_inter(shakemap_uz,nfaces_surface_points,0,io_tag_shake_uz,req)
+    ! all done
+    return
+  endif
 
   fname_h5_data_shake = trim(OUTPUT_FILES) // "/shakemap.h5"
 
@@ -467,7 +436,9 @@ contains
 
 #ifdef USE_HDF5
 
+  use specfem_par_movie, only: nfaces_surface_points
   use specfem_par_movie_hdf5
+  use io_server_hdf5
 
   implicit none
 
@@ -482,16 +453,16 @@ contains
   integer, parameter :: nnodes_per_face_aug = 4
   logical, parameter :: if_corrective = .true.
 
-  !#TODO: hdf5 i/o server
-  !if (HDF5_IO_NNODES > 0) then
-  !  ! send surface body to io node
-  !  call isend_cr_inter(store_val_ux,nfaces_surface_points,0,io_tag_surface_ux,req_dump_surf(1))
-  !  call isend_cr_inter(store_val_uy,nfaces_surface_points,0,io_tag_surface_uy,req_dump_surf(2))
-  !  call isend_cr_inter(store_val_uz,nfaces_surface_points,0,io_tag_surface_uz,req_dump_surf(3))
-  !  n_req_surf = 3
-  !  ! all done
-  !  return
-  !endif
+  ! hdf5 i/o server
+  if (HDF5_IO_NODES > 0) then
+    ! send surface body to io node
+    call isend_cr_inter(store_val_ux,nfaces_surface_points,0,io_tag_surface_ux,req_dump_surf(1))
+    call isend_cr_inter(store_val_uy,nfaces_surface_points,0,io_tag_surface_uy,req_dump_surf(2))
+    call isend_cr_inter(store_val_uz,nfaces_surface_points,0,io_tag_surface_uz,req_dump_surf(3))
+    n_req_surf = 3
+    ! all done
+    return
+  endif
 
   ! initialize h5 and xdmf  if it == 0
   fname_h5_data_surf = trim(OUTPUT_FILES) // "/movie_surface.h5"
@@ -821,6 +792,7 @@ contains
 #ifdef USE_HDF5
 
   use specfem_par_movie_hdf5
+  use io_server_hdf5
 
   implicit none
 
@@ -828,8 +800,8 @@ contains
   real(kind=CUSTOM_REAL),dimension(:), allocatable :: d_p
   integer :: ier
   logical :: pressure_io, divglob_io, div_io, veloc_io, curl_io
-  !#TODO: hdf5 i/o server
-  !integer :: req_count
+  ! hdf5 i/o server
+  integer :: req_count
 
   ! initializes
   pressure_io = .false.
@@ -838,15 +810,16 @@ contains
   veloc_io = .false.
   curl_io = .false.
 
-  !#TODO: hdf5 i/o server
-  !req_count = 1
+  ! hdf5 i/o server request index
+  req_count = 1
 
   ! prepares hdf5 file
   if (it == NTSTEP_BETWEEN_FRAMES) then
-    !#TODO: hdf5 i/o server
-    !if (HDF5_IO_NNODES == 0) then
+    ! hdf5 i/o server
+    if (HDF5_IO_NODES == 0) then
+      ! direct io
       call prepare_vol_movie_hdf5()
-    !endif
+    endif
   endif
 
   ! saves fields
@@ -858,16 +831,16 @@ contains
       if (ier /= 0) stop 'Error allocating d_p array'
       call elm2node_base(wavefield_pressure, d_p)
       ! saves pressure field
-      !#TODO: hdf5 i/o server
-      !if (HDF5_IO_NNODES > 0) then
-      !  ! send pressure_loc
-      !  call isend_cr_inter(d_p,NGLOB_AB,dest_ionod,io_tag_vol_pres,req_dump_vol(req_count))
-      !  req_count = req_count+1
-      !else
+      ! hdf5 i/o server
+      if (HDF5_IO_NODES > 0) then
+        ! send pressure_loc
+        call isend_cr_inter(d_p,NGLOB_AB,dest_ionod,io_tag_vol_pres,req_dump_vol(req_count))
+        req_count = req_count + 1
+      else
         ! direct io
         pressure_io = .true.
         call write_vol_data_hdf5(d_p,"pressure")
-      !endif
+      endif
       deallocate(d_p)
     endif
   endif ! acoustic
@@ -888,16 +861,16 @@ contains
     endif
 
     ! saves div field
-    !#TODO: hdf5 i/o server
-    !if (HDF5_IO_NNODES > 0) then
-    !  ! send div_glob
-    !  call isend_cr_inter(div_glob,NGLOB_AB,dest_ionod,io_tag_vol_divglob,req_dump_vol(req_count))
-    !  req_count = req_count+1
-    !else
+    ! hdf5 i/o server
+    if (HDF5_IO_NODES > 0) then
+      ! send div_glob
+      call isend_cr_inter(div_glob,NGLOB_AB,dest_ionod,io_tag_vol_divglob,req_dump_vol(req_count))
+      req_count = req_count + 1
+    else
       ! direct io
       divglob_io = .true.
       call write_vol_data_hdf5(div_glob,"div_glob")
-    !endif
+    endif
 
     ! div and curl on elemental level
     call elm2node_base(div,div_on_node)
@@ -906,19 +879,19 @@ contains
     call elm2node_base(curl_x,curl_x_on_node)
 
     ! writes our divergence/curl
-    !#TODO: hdf5 i/o server
-    !if (HDF5_IO_NNODES > 0) then
-    !  ! div
-    !  call isend_cr_inter(div_on_node,NGLOB_AB,dest_ionod,io_tag_vol_div,req_dump_vol(req_count))
-    !  req_count = req_count+1
-    !  ! writes out curl
-    !  call isend_cr_inter(curl_x_on_node,NGLOB_AB,dest_ionod,io_tag_vol_curlx,req_dump_vol(req_count))
-    !  req_count = req_count+1
-    !  call isend_cr_inter(curl_y_on_node,NGLOB_AB,dest_ionod,io_tag_vol_curly,req_dump_vol(req_count))
-    !  req_count = req_count+1
-    !  call isend_cr_inter(curl_z_on_node,NGLOB_AB,dest_ionod,io_tag_vol_curlz,req_dump_vol(req_count))
-    !  req_count = req_count+1
-    !else
+    ! hdf5 i/o server
+    if (HDF5_IO_NODES > 0) then
+      ! div
+      call isend_cr_inter(div_on_node,NGLOB_AB,dest_ionod,io_tag_vol_div,req_dump_vol(req_count))
+      req_count = req_count + 1
+      ! writes out curl
+      call isend_cr_inter(curl_x_on_node,NGLOB_AB,dest_ionod,io_tag_vol_curlx,req_dump_vol(req_count))
+      req_count = req_count + 1
+      call isend_cr_inter(curl_y_on_node,NGLOB_AB,dest_ionod,io_tag_vol_curly,req_dump_vol(req_count))
+      req_count = req_count + 1
+      call isend_cr_inter(curl_z_on_node,NGLOB_AB,dest_ionod,io_tag_vol_curlz,req_dump_vol(req_count))
+      req_count = req_count + 1
+    else
       ! direct io
       div_io = .true.
       curl_io = .true.
@@ -926,7 +899,7 @@ contains
       call write_vol_data_hdf5(curl_x_on_node,"curl_x")
       call write_vol_data_hdf5(curl_y_on_node,"curl_y")
       call write_vol_data_hdf5(curl_z_on_node,"curl_z")
-    !endif
+    endif
   endif ! elastic or poroelastic
 
   ! velocity
@@ -951,32 +924,33 @@ contains
   call elm2node_base(wavefield_z, velocity_z_on_node)
 
   ! saves wavefield components
-  !#TODO: hdf5 i/o server
-  !if (HDF5_IO_NNODES > 0) then
-  !  call isend_cr_inter(velocity_x_on_node,NGLOB_AB,dest_ionod,io_tag_vol_velox,req_dump_vol(req_count))
-  !  req_count = req_count+1
-  !  call isend_cr_inter(velocity_y_on_node,NGLOB_AB,dest_ionod,io_tag_vol_veloy,req_dump_vol(req_count))
-  !  req_count = req_count+1
-  !  call isend_cr_inter(velocity_z_on_node,NGLOB_AB,dest_ionod,io_tag_vol_veloz,req_dump_vol(req_count))
-  !  req_count = req_count+1
-  !else
+  ! hdf5 i/o server
+  if (HDF5_IO_NODES > 0) then
+    call isend_cr_inter(velocity_x_on_node,NGLOB_AB,dest_ionod,io_tag_vol_velox,req_dump_vol(req_count))
+    req_count = req_count + 1
+    call isend_cr_inter(velocity_y_on_node,NGLOB_AB,dest_ionod,io_tag_vol_veloy,req_dump_vol(req_count))
+    req_count = req_count + 1
+    call isend_cr_inter(velocity_z_on_node,NGLOB_AB,dest_ionod,io_tag_vol_veloz,req_dump_vol(req_count))
+    req_count = req_count + 1
+  else
     ! direct io
     veloc_io = .true.
     call write_vol_data_hdf5(velocity_x_on_node,"veloc_x")
     call write_vol_data_hdf5(velocity_y_on_node,"veloc_y")
     call write_vol_data_hdf5(velocity_z_on_node,"veloc_z")
-  !endif
+  endif
 
-  !#TODO: hdf5 i/o server
+  ! hdf5 i/o server
   ! store the number of mpi_isend reqs
-  !n_req_vol = req_count-1
+  n_req_vol = req_count - 1
 
   if (it == NTSTEP_BETWEEN_FRAMES) then
-    !#TODO: hdf5 i/o server
-    !if (HDF5_IO_NNODES == 0) then
+    ! hdf5 i/o server
+    if (HDF5_IO_NODES == 0) then
+      ! direct io
       ! create xdmf header
       call write_xdmf_vol_hdf5(pressure_io, divglob_io, div_io, veloc_io, curl_io)
-    !endif
+    endif
   endif
 
 #else
@@ -1011,24 +985,29 @@ contains
   character(len=64) :: dset_name
   integer           :: iproc, ier, nglob_all, nspec_all
   character(len=MAX_STRING_LEN) :: fname_h5_data_vol
-  logical,parameter :: if_collective = .true. ! in io_server.f90
+
+  logical,parameter :: if_collective = .true.
 
   allocate(nglob_par_proc_nio(0:NPROC-1), stat=ier)
   if (ier /= 0) call exit_MPI_without_rank('error allocating array nglob_par_proc')
   if (ier /= 0) stop 'error allocating arrays for nglob_par_proc'
   nglob_par_proc_nio(:) = 0
-   allocate(nelm_par_proc_nio(0:NPROC-1), stat=ier)
+
+  allocate(nelm_par_proc_nio(0:NPROC-1), stat=ier)
   if (ier /= 0) call exit_MPI_without_rank('error allocating array nelm_par_proc')
   if (ier /= 0) stop 'error allocating arrays for nelm_par_proc'
   nelm_par_proc_nio(:) = 0
+
   allocate(nglob_offset(0:NPROC-1), stat=ier)
   if (ier /= 0) call exit_MPI_without_rank('error allocating array nglob_offset')
   if (ier /= 0) stop 'error allocating arrays for nglob_offset'
   nglob_offset(:) = 0
+
   allocate(nelm_offset(0:NPROC-1), stat=ier)
   if (ier /= 0) call exit_MPI_without_rank('error allocating array nelm_offset')
   if (ier /= 0) stop 'error allocating arrays for nelm_offset'
   nelm_offset(:) = 0
+
   allocate(elm_conn_loc(9,NSPEC_AB*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)),stat=ier)
   if (ier /= 0) call exit_MPI_without_rank('error allocating array elm_conn_loc')
   if (ier /= 0) stop 'error allocating arrays for elm_conn_loc'
@@ -1317,5 +1296,1221 @@ contains
   close(xdmf_vol)
 
   end subroutine write_xdmf_vol_hdf5
+
+#endif
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+#ifdef USE_HDF5
+
+
+! moved this routine out of the specfem_par_movie_hdf5 module as it is also called in
+! module io_server_hdf5 from file hdf5_io_server.F90, which in turn gets used in some routines
+! in this file - thus, there would be no way to compile these module dependencies.
+!
+! having it as a stand-alone routine works as it is "connected" at link-time.
+
+  subroutine get_conn_for_movie(elm_conn,offset)
+
+  use constants, only: NGLLX,NGLLY,NGLLZ
+  use specfem_par, only: NSPEC_AB, ibool
+
+  implicit none
+
+  integer, dimension(9,NSPEC_AB*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)), intent(out) :: elm_conn
+  integer, intent(in) :: offset ! node id offset (starting global element id of each proc)
+
+  ! local parameters
+  integer :: ispec,ii,icub,jcub,kcub
+  integer,parameter :: cell_type = 9
+
+  do ispec = 1,NSPEC_AB
+    ! extract information from full GLL grid
+    ! node order follows vtk format
+    do icub = 0,NGLLX-2
+      do jcub = 0,NGLLY-2
+        do kcub = 0,NGLLZ-2
+          ii = 1+(ispec-1)*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1) + (icub*(NGLLY-1)*(NGLLZ-1)+jcub*(NGLLZ-1)+kcub)
+          elm_conn(1, ii)  = cell_type
+          elm_conn(2, ii)  = ibool(icub+1,jcub+1,kcub+1,ispec)-1 + offset   ! node id starts 0 in xdmf rule
+          elm_conn(3, ii)  = ibool(icub+2,jcub+1,kcub+1,ispec)-1 + offset
+          elm_conn(4, ii)  = ibool(icub+2,jcub+2,kcub+1,ispec)-1 + offset
+          elm_conn(5, ii)  = ibool(icub+1,jcub+2,kcub+1,ispec)-1 + offset
+          elm_conn(6, ii)  = ibool(icub+1,jcub+1,kcub+2,ispec)-1 + offset
+          elm_conn(7, ii)  = ibool(icub+2,jcub+1,kcub+2,ispec)-1 + offset
+          elm_conn(8, ii)  = ibool(icub+2,jcub+2,kcub+2,ispec)-1 + offset
+          elm_conn(9, ii)  = ibool(icub+1,jcub+2,kcub+2,ispec)-1 + offset
+        enddo
+      enddo
+    enddo
+  enddo
+
+  end subroutine get_conn_for_movie
+
+#endif
+
+
+!-------------------------------------------------------------------------------------------------
+!
+! HDF5 i/o server routines
+!
+!-------------------------------------------------------------------------------------------------
+
+#ifdef USE_HDF5
+
+
+!
+! shakemap
+!
+  subroutine shakemap_io_init_hdf5()
+
+  use constants, only: OUTPUT_FILES,MAX_STRING_LEN
+  use shared_parameters, only: USE_HIGHRES_FOR_MOVIES
+
+  use specfem_par_movie_hdf5
+  use io_server_hdf5
+  use manager_hdf5
+
+  implicit none
+
+  ! local parameters
+  integer                                   :: ier, len_array_aug
+  character(len=64)                         :: dset_name
+  character(len=64)                         :: group_name
+  character(len=MAX_STRING_LEN) :: fname_h5_data_shake
+
+  ! checks if anything to do
+  if (size_surf_array == 0) return
+
+  fname_h5_data_shake = trim(OUTPUT_FILES) // "/shakemap.h5"
+
+  ! initialization of h5 file
+  call h5_initialize()
+
+  ! create a hdf5 file
+  call h5_create_file(fname_h5_data_shake)
+
+  ! information for computer node
+  allocate(shake_ux(size_surf_array),stat=ier)
+  allocate(shake_uy(size_surf_array),stat=ier)
+  allocate(shake_uz(size_surf_array),stat=ier)
+
+  if (USE_HIGHRES_FOR_MOVIES) then
+    len_array_aug = size(surf_x_aug)
+    allocate(shake_ux_aug(len_array_aug),stat=ier)
+    allocate(shake_uy_aug(len_array_aug),stat=ier)
+    allocate(shake_uz_aug(len_array_aug),stat=ier)
+  endif
+
+  ! write xyz coords in h5
+  group_name = "surf_coord"
+  call h5_create_group(group_name)
+  call h5_open_group(group_name)
+
+  if (.not. USE_HIGHRES_FOR_MOVIES) then
+    dset_name = "x"
+    call h5_write_dataset(dset_name, surf_x)
+    call h5_close_dataset()
+    dset_name = "y"
+    call h5_write_dataset(dset_name, surf_y)
+    call h5_close_dataset()
+    dset_name = "z"
+    call h5_write_dataset(dset_name, surf_z)
+    call h5_close_dataset()
+  else
+    dset_name = "x"
+    call h5_write_dataset(dset_name, surf_x_aug)
+    call h5_close_dataset()
+    dset_name = "y"
+    call h5_write_dataset(dset_name, surf_y_aug)
+    call h5_close_dataset()
+    dset_name = "z"
+    call h5_write_dataset(dset_name, surf_z_aug)
+    call h5_close_dataset()
+  endif
+
+  call h5_close_group()
+  call h5_close_file()
+
+  end subroutine shakemap_io_init_hdf5
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine write_shakemap_io_hdf5()
+
+  use constants, only: MAX_STRING_LEN,OUTPUT_FILES
+  use shared_parameters, only: USE_HIGHRES_FOR_MOVIES
+
+  use specfem_par_movie_hdf5
+  use io_server_hdf5
+  use manager_hdf5
+
+  implicit none
+
+  character(len=64) :: dset_name
+  character(len=64) :: group_name
+  character(len=MAX_STRING_LEN) :: fname_h5_data_shake
+
+  fname_h5_data_shake = trim(OUTPUT_FILES) // "/shakemap.h5"
+
+  ! continue opening hdf5 file till the end of write process
+  call h5_initialize()
+
+  call h5_open_file(fname_h5_data_shake)
+
+  ! create a group for each io step
+  group_name = "shakemap"
+  call h5_create_group(group_name)
+  call h5_open_group(group_name)
+  if (.not. USE_HIGHRES_FOR_MOVIES) then
+    dset_name = "shakemap_ux"
+    call h5_write_dataset(dset_name, shake_ux)
+    call h5_close_dataset()
+    dset_name = "shakemap_uy"
+    call h5_write_dataset(dset_name, shake_uy)
+    call h5_close_dataset()
+    dset_name = "shakemap_uz"
+    call h5_write_dataset(dset_name, shake_uz)
+    call h5_close_dataset()
+  else
+    dset_name = "shakemap_ux"
+    call recompose_for_hires(shake_ux, shake_ux_aug)
+    call h5_write_dataset(dset_name, shake_ux_aug)
+    call h5_close_dataset()
+    dset_name = "shakemap_uy"
+     call recompose_for_hires(shake_uy, shake_uy_aug)
+    call h5_write_dataset(dset_name, shake_uy_aug)
+    call h5_close_dataset()
+    dset_name = "shakemap_uz"
+    call recompose_for_hires(shake_uz, shake_uz_aug)
+    call h5_write_dataset(dset_name, shake_uz_aug)
+    call h5_close_dataset()
+  endif
+
+  call h5_close_group()
+  call h5_close_file()
+
+  end subroutine write_shakemap_io_hdf5
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+!
+! surface movie
+!
+  subroutine surf_mov_io_init_hdf5(nfaces_perproc, surface_offset)
+
+! creates initial file for movie_surface.h5
+
+  use constants, only: NGLLX,NGLLY,OUTPUT_FILES,MAX_STRING_LEN
+  use shared_parameters, only: NPROC,USE_HIGHRES_FOR_MOVIES
+
+  use specfem_par_movie_hdf5
+  use io_server_hdf5
+
+  implicit none
+
+  integer, dimension(0:NPROC-1), intent(in)         :: nfaces_perproc, surface_offset
+  integer                                           :: ier, nfaces_actual
+  integer                                           :: len_array_aug
+  character(len=64)                                 :: dset_name
+  character(len=64)                                 :: group_name
+  integer, dimension(1)                             :: tmp_1d_arr
+  character(len=MAX_STRING_LEN) :: fname_h5_data_surf
+
+  integer, parameter :: nfaces_aug = (NGLLX-1)*(NGLLY-1)
+  integer, parameter :: nnodes_per_face_aug = 4
+
+  fname_h5_data_surf = trim(OUTPUT_FILES) // "/movie_surface.h5"
+
+  ! initialization of h5 file
+  call h5_initialize()
+
+  ! create a hdf5 file
+  call h5_create_file(fname_h5_data_surf)
+
+  ! information for computer node
+  ! get nfaces_perproc_surface
+  call recv_i_inter(nfaces_perproc,NPROC,0,io_tag_surface_nfaces)
+  ! get faces_surface_offset
+  call recv_i_inter(surface_offset,NPROC,0,io_tag_surface_offset)
+
+  ! get xyz coordinates
+  call recv_i_inter(tmp_1d_arr, 1, 0, io_tag_surface_coord_len)
+  size_surf_array = tmp_1d_arr(1)
+
+  ! debug
+  if (VERBOSE) print *, "io_server: size surf array received: ", size_surf_array
+
+  allocate(surf_x(size_surf_array),stat=ier)
+  allocate(surf_y(size_surf_array),stat=ier)
+  allocate(surf_z(size_surf_array),stat=ier)
+  allocate(surf_ux(size_surf_array),stat=ier)
+  allocate(surf_uy(size_surf_array),stat=ier)
+  allocate(surf_uz(size_surf_array),stat=ier)
+
+  if (USE_HIGHRES_FOR_MOVIES) then
+    nfaces_actual = size_surf_array / (NGLLX*NGLLY)
+    len_array_aug = nfaces_actual * nfaces_aug * nnodes_per_face_aug
+    allocate(surf_x_aug(len_array_aug),stat=ier)
+    allocate(surf_y_aug(len_array_aug),stat=ier)
+    allocate(surf_z_aug(len_array_aug),stat=ier)
+    allocate(surf_ux_aug(len_array_aug),stat=ier)
+    allocate(surf_uy_aug(len_array_aug),stat=ier)
+    allocate(surf_uz_aug(len_array_aug),stat=ier)
+  endif
+
+  ! x
+  call recvv_cr_inter(surf_x, size_surf_array, 0, io_tag_surface_x)
+  ! y
+  call recvv_cr_inter(surf_y, size_surf_array, 0, io_tag_surface_y)
+  ! z
+  call recvv_cr_inter(surf_z, size_surf_array, 0, io_tag_surface_z)
+
+  ! write xyz coords in h5
+  group_name = "surf_coord"
+  call h5_create_group(group_name)
+  call h5_open_group(group_name)
+
+  ! writes coordinates
+  if (.not. USE_HIGHRES_FOR_MOVIES) then
+    ! low resolution output
+    dset_name = "x"
+    call h5_write_dataset(dset_name, surf_x)
+    call h5_close_dataset()
+    dset_name = "y"
+    call h5_write_dataset(dset_name, surf_y)
+    call h5_close_dataset()
+    dset_name = "z"
+    call h5_write_dataset(dset_name, surf_z)
+    call h5_close_dataset()
+  else
+    ! high resolution output
+    ! nfaces*25nodes => n*16faces*4
+    dset_name = "x"
+    call recompose_for_hires(surf_x,surf_x_aug)
+    call h5_write_dataset(dset_name, surf_x_aug)
+    call h5_close_dataset()
+    dset_name = "y"
+    call recompose_for_hires(surf_y,surf_y_aug)
+    call h5_write_dataset(dset_name, surf_y_aug)
+    call h5_close_dataset()
+    dset_name = "z"
+    call recompose_for_hires(surf_z,surf_z_aug)
+    call h5_write_dataset(dset_name, surf_z_aug)
+    call h5_close_dataset()
+  endif
+
+  call h5_close_group()
+  call h5_close_file()
+
+  end subroutine surf_mov_io_init_hdf5
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine write_surf_io_hdf5(it_io)
+
+! writes out surface wavefield snapshot
+
+  use constants, only: CUSTOM_REAL,MAX_STRING_LEN,OUTPUT_FILES
+  use shared_parameters, only: USE_HIGHRES_FOR_MOVIES
+
+  use specfem_par_movie_hdf5
+  use io_server_hdf5
+  use manager_hdf5
+
+  implicit none
+
+  integer, intent(in)                               :: it_io
+  character(len=64)                                 :: dset_name
+  character(len=64)                                 :: group_name
+  character(len=10)                                 :: tempstr
+  character(len=MAX_STRING_LEN) :: fname_h5_data_surf
+
+  fname_h5_data_surf = trim(OUTPUT_FILES) // "/movie_surface.h5"
+
+  ! continue opening hdf5 file till the end of write process
+  call h5_initialize()
+
+  call h5_open_file(fname_h5_data_surf)
+
+  ! create a group for each io step
+  write(tempstr, "(i6.6)") it_io
+  group_name = "it_" // tempstr
+
+  call h5_create_group(group_name)
+  call h5_open_group(group_name)
+
+  if (.not. USE_HIGHRES_FOR_MOVIES) then
+    dset_name = "ux"
+    call h5_write_dataset(dset_name, surf_ux)
+    call h5_close_dataset()
+    dset_name = "uy"
+    call h5_write_dataset(dset_name, surf_uy)
+    call h5_close_dataset()
+    dset_name = "uz"
+    call h5_write_dataset(dset_name, surf_uz)
+    call h5_close_dataset()
+
+    surf_ux(:) = 0._CUSTOM_REAL
+    surf_uy(:) = 0._CUSTOM_REAL
+    surf_uz(:) = 0._CUSTOM_REAL
+  else
+    dset_name = "ux"
+    call recompose_for_hires(surf_ux, surf_ux_aug)
+    call h5_write_dataset(dset_name, surf_ux_aug)
+    call h5_close_dataset()
+    dset_name = "uy"
+    call recompose_for_hires(surf_uy, surf_uy_aug)
+    call h5_write_dataset(dset_name, surf_uy_aug)
+    call h5_close_dataset()
+    dset_name = "uz"
+    call recompose_for_hires(surf_uz, surf_uz_aug)
+    call h5_write_dataset(dset_name, surf_uz_aug)
+    call h5_close_dataset()
+
+    surf_ux_aug(:) = 0._CUSTOM_REAL
+    surf_uy_aug(:) = 0._CUSTOM_REAL
+    surf_uz_aug(:) = 0._CUSTOM_REAL
+  endif
+
+  call h5_close_group()
+  call h5_close_file()
+
+  end subroutine write_surf_io_hdf5
+
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+!
+! volume movie
+!
+  subroutine movie_volume_io_init_hdf5(nelm_par_proc,nglob_par_proc,nglob_par_proc_offset,nglob_par_io_offset,nelm_par_io_offset)
+
+! creates initial movie_volume***.h5 file
+
+  use constants, only: CUSTOM_REAL,NGLLX,NGLLY,NGLLZ,MAX_STRING_LEN,OUTPUT_FILES,myrank
+  use shared_parameters, only: NPROC
+
+  use specfem_par_movie_hdf5
+  use io_server_hdf5
+
+#ifdef WITH_MPI
+  use my_mpi
+#endif
+
+  implicit none
+
+  ! storing the number of elements and GLL nodes
+  integer, dimension(0:NPROC-1), intent(inout)        :: nelm_par_proc, nglob_par_proc
+  ! offset intra io node info
+  integer, dimension(0:nproc_io-1), intent(out)       :: nglob_par_proc_offset
+  ! offset inter io node info
+  integer, dimension(0:HDF5_IO_NODES-1), intent(out) :: nglob_par_io_offset
+  ! offset inter io node
+  integer, dimension(0:HDF5_IO_NODES-1), intent(out) :: nelm_par_io_offset
+
+  ! local parameters
+  integer :: iproc, iproc2, comm, info, sender, ier
+  ! offset intra io node
+  integer, dimension(0:nproc_io-1)                    :: nelm_par_proc_offset
+#ifdef WITH_MPI
+  integer :: status(MPI_STATUS_SIZE)
+#else
+  integer :: status(1)
+#endif
+  ! arrays for storing elm_conn and xyzstore
+  !integer                                           :: nglob_this_io=0, nelm_this_io=0
+  integer, dimension(:,:), allocatable              :: elm_conn_tmp
+  integer, dimension(:), allocatable                :: elm_conn_subtmp
+  real(kind=CUSTOM_REAL), dimension(:), allocatable :: xstore_tmp, ystore_tmp, zstore_tmp
+  integer :: nelm_tmp,nglo_tmp,ielm_sta,ielm_end,iglo_sta,iglo_end
+  integer :: node_id_off, node_id_off_inter
+  integer :: nelms_factor = (NGLLX-1)*(NGLLY-1)*(NGLLZ-1) ! divide one spectral element to
+  ! small rectangles for visualization purpose
+  integer, dimension(1) :: tmp_1d_arr
+  ! dummy array
+  integer, dimension(1) :: dump
+  ! make output file
+  character(len=64) :: group_name
+  character(len=64) :: dset_name
+  character(len=64) :: proc_str
+  character(len=MAX_STRING_LEN) :: fname_h5_data_vol
+
+  write(proc_str, "(i6.6)") myrank
+
+  if (NtoM) then
+    ! write out one h5 for each IO server process
+    fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume_" // trim(proc_str) // ".h5"
+  else
+    ! write one single h5 for all IO server processes
+    fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume.h5"
+  endif
+
+  ! initialization of h5 file
+  ! get MPI parameters
+  call world_get_comm(comm)
+  call world_get_info_null(info)
+
+  ! initialize h5 object
+  call h5_initialize()
+  call h5_set_mpi_info(comm, info, myrank, NPROC)
+
+  ! get n_msg_vol_each_proc
+  call recv_i_inter(tmp_1d_arr, 1, 0, io_tag_vol_nmsg)
+  n_msg_vol_each_proc = tmp_1d_arr(1)
+
+  ! make an array of local2global relation of sending compute node ids
+  allocate(id_proc_loc2glob(0:nproc_io-1))
+  ! make an array of global2local relation of sending compute node ids
+  allocate(id_proc_glob2loc(0:NPROC-1))
+  id_proc_glob2loc(:) = -999999
+
+  allocate(dest_ioids(0:NPROC-1))
+
+  ! debug
+  if (VERBOSE) print *, "io_server: number of compute node: ", nproc_io, ", for io node rank: ", myrank
+
+  ! make a sender list which communicate with this io node
+  do iproc = 0, nproc_io-1
+#ifdef WITH_MPI
+    call mpi_probe(MPI_ANY_SOURCE, io_tag_vol_sendlist, my_local_mpi_comm_inter, status, ier)
+    sender = status(MPI_SOURCE)
+#else
+    sender = status(1)
+#endif
+    dump(1) = 1  ! dummy value, just to get sender
+    call recv_i_inter(dump,1,sender,io_tag_vol_sendlist)
+    id_proc_loc2glob(iproc) = sender
+    id_proc_glob2loc(sender) = iproc
+  enddo
+
+  ! gather other informations for making a volume data output
+  do iproc = 0, NPROC-1
+    ! get nspec and nglob from each process
+    call recv_i_inter(nelm_par_proc(iproc),  1, iproc, io_tag_vol_nspec) ! NSPEC_AB
+    call recv_i_inter(nglob_par_proc(iproc), 1, iproc, io_tag_vol_nglob) ! NGLOB_AB
+    ! array if io node ids of each compute procs
+    call recv_i_inter(dest_ioids(iproc), 1, iproc, io_tag_vol_ioid)
+  enddo
+
+  ! calculate nglob and nelm for this io_node
+  nglob_par_proc_offset(:) = 0
+  nelm_par_proc_offset(:)  = 0
+
+  ! count the number of nodes and elements in this IO group
+  nglob_this_io = 0
+  nelm_this_io  = 0
+  do iproc=0, nproc_io-1
+    nglob_this_io = nglob_this_io + nglob_par_proc(id_proc_loc2glob(iproc))
+    nelm_this_io  = nelm_this_io  + nelm_par_proc (id_proc_loc2glob(iproc))
+    if (iproc > 0) then
+      do iproc2=0, iproc-1
+        nglob_par_proc_offset(iproc) = nglob_par_proc_offset(iproc)+nglob_par_proc(id_proc_loc2glob(iproc2))
+        nelm_par_proc_offset(iproc)  = nelm_par_proc_offset(iproc) +nelm_par_proc (id_proc_loc2glob(iproc2))
+      enddo
+    endif
+  enddo
+
+  ! prepare intra io node offset array
+  call gather_all_all_singlei(nglob_this_io, nglob_par_io_offset, HDF5_IO_NODES)
+  call gather_all_all_singlei(nelm_this_io, nelm_par_io_offset, HDF5_IO_NODES)
+
+  ! prepare arrays for storing elm_conn_loc and xyzstore
+  allocate(xstore_tmp(nglob_this_io)) ! 1d array for this io_node
+  allocate(ystore_tmp(nglob_this_io))
+  allocate(zstore_tmp(nglob_this_io))
+  allocate(elm_conn_tmp(9,nelm_this_io*nelms_factor))
+
+  nspec_all_server = sum(nelm_par_proc(:))
+  nglob_all_server = sum(nglob_par_proc(:))
+
+  ! node id offset inter io nodes
+  if (NtoM) then
+    node_id_off_inter = 0 ! no offsets for inter io nodes
+  else
+    node_id_off_inter = sum(nglob_par_io_offset(0:myrank-1))
+  endif
+
+  do iproc = 0,nproc_io-1
+    nelm_tmp = nelm_par_proc(id_proc_loc2glob(iproc))
+    nglo_tmp = nglob_par_proc(id_proc_loc2glob(iproc))
+    ielm_sta = nelm_par_proc_offset(iproc)+1
+    ielm_end = ielm_sta + nelm_tmp-1
+    iglo_sta = nglob_par_proc_offset(iproc)+1
+    iglo_end = iglo_sta + nglo_tmp-1
+
+    ! debug
+    if (VERBOSE) then
+      print *,"io_server: iorank, iproc, ielm_sta, ielm_end, nelm_tmp, nspec_all", &
+              myrank, iproc, ielm_sta, ielm_end, nelm_tmp, nspec_all_server
+      print *,"io_server: iorank, iproc, iglo_sta, iglo_end, nglo_tmp, nglob_all", &
+              myrank, iproc, iglo_sta, iglo_end, nglo_tmp, nglob_all_server
+    endif
+
+    allocate(elm_conn_subtmp(9*nelm_tmp*nelms_factor))
+
+    ! receive elm_conn_loc
+    call recv_i_inter(elm_conn_subtmp, &
+                      9*nelm_tmp*nelms_factor,id_proc_loc2glob(iproc),io_tag_vol_elmconn)
+
+    elm_conn_tmp(:,(ielm_sta-1)*nelms_factor+1:ielm_end*nelms_factor) &
+        = reshape(elm_conn_subtmp,(/9,nelm_tmp*nelms_factor/))
+
+    ! node id offset intra io node
+    node_id_off = 0
+    do iproc2 = 0,iproc-1
+      node_id_off = node_id_off + nglob_par_proc(id_proc_loc2glob(iproc2))
+    enddo
+
+    ! debug
+    if (VERBOSE) print *, "io_server: iorank, iproc, off, off_inter", myrank, iproc, node_id_off, node_id_off_inter
+
+    elm_conn_tmp(2:9,(ielm_sta-1)*nelms_factor+1:ielm_end*nelms_factor) &
+        = elm_conn_tmp(2:9,(ielm_sta-1)*nelms_factor+1:ielm_end*nelms_factor) &
+          + node_id_off + node_id_off_inter
+
+    ! receive xstore, ystore, zstore
+    call recvv_cr_inter(xstore_tmp(iglo_sta:iglo_end),nglo_tmp,id_proc_loc2glob(iproc),io_tag_vol_nodex)
+    call recvv_cr_inter(ystore_tmp(iglo_sta:iglo_end),nglo_tmp,id_proc_loc2glob(iproc),io_tag_vol_nodey)
+    call recvv_cr_inter(zstore_tmp(iglo_sta:iglo_end),nglo_tmp,id_proc_loc2glob(iproc),io_tag_vol_nodez)
+
+    deallocate(elm_conn_subtmp)
+  enddo
+
+  ! write mesh database in movie_volue.h5
+  group_name = "mesh"
+
+  ! write mesh info. of each IO server into each movie_volume_*.h5 file
+  if (NtoM) then
+    ! N-to-M stategy
+    ! create a hdf5 file
+    call h5_create_file(fname_h5_data_vol)
+
+    ! create coordinate dataset
+    call h5_open_or_create_group(group_name)
+
+    dset_name = "elm_conn"
+    call h5_create_dataset_gen_in_group(dset_name, (/9,nelm_this_io*nelms_factor/), 2, 1)
+    dset_name = "x"
+    call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+    dset_name = "y"
+    call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+    dset_name = "z"
+    call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+
+    ! write data
+    dset_name = "elm_conn"
+    call h5_write_dataset_collect_hyperslab_in_group(dset_name,elm_conn_tmp, &
+                (/0,0/),if_collect_server)
+    dset_name = "x"
+    call h5_write_dataset_collect_hyperslab_in_group(dset_name,xstore_tmp, &
+                (/0/),if_collect_server)
+    dset_name = "y"
+    call h5_write_dataset_collect_hyperslab_in_group(dset_name,ystore_tmp, &
+                (/0/),if_collect_server)
+    dset_name = "z"
+    call h5_write_dataset_collect_hyperslab_in_group(dset_name,zstore_tmp, &
+                (/0/),if_collect_server)
+
+    call h5_close_group()
+    call h5_close_file()
+
+  else
+    ! for N-to-1 strategy
+    if (myrank == 0) then
+      ! create a hdf5 file
+      call h5_create_file(fname_h5_data_vol)
+      ! create coordinate dataset
+      call h5_open_or_create_group(group_name)
+
+      dset_name = "elm_conn"
+      call h5_create_dataset_gen_in_group(dset_name, (/9,nspec_all_server*nelms_factor/), 2, 1)
+      dset_name = "x"
+      call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+      dset_name = "y"
+      call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+      dset_name = "z"
+      call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+
+      call h5_close_group()
+      call h5_close_file()
+    endif
+
+    call synchronize_all()
+
+    call h5_open_file_p(fname_h5_data_vol)
+    call h5_open_group(group_name)
+
+    dset_name = "elm_conn"
+    call h5_write_dataset_collect_hyperslab_in_group(dset_name,elm_conn_tmp, &
+                (/0,sum(nelm_par_io_offset(0:myrank-1))*nelms_factor/),if_collect_server)
+    dset_name = "x"
+    call h5_write_dataset_collect_hyperslab_in_group(dset_name,xstore_tmp, &
+                (/sum(nglob_par_io_offset(0:myrank-1))/),if_collect_server)
+    dset_name = "y"
+    call h5_write_dataset_collect_hyperslab_in_group(dset_name,ystore_tmp, &
+                (/sum(nglob_par_io_offset(0:myrank-1))/),if_collect_server)
+    dset_name = "z"
+    call h5_write_dataset_collect_hyperslab_in_group(dset_name,zstore_tmp, &
+                (/sum(nglob_par_io_offset(0:myrank-1))/),if_collect_server)
+
+    call h5_close_group()
+    call h5_close_file()
+
+  endif ! NtoM or Nto1
+
+  call synchronize_all()
+
+  deallocate(elm_conn_tmp)
+  deallocate(xstore_tmp, ystore_tmp, zstore_tmp)
+
+  end subroutine movie_volume_io_init_hdf5
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine write_vol_data_io_hdf5(it_io, val_type_mov,nglob_par_io_offset)
+
+! writes out volumetric wavefield snapshot
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+
+  integer, intent(in) :: it_io
+  logical, dimension(5), intent(inout) :: val_type_mov
+  integer :: j
+  integer :: num_max_type=5
+  integer, dimension(0:HDF5_IO_NODES-1), intent(in) :: nglob_par_io_offset   ! offset inter io node info
+  integer :: io_offset
+  ! make output file
+  character(len=10) :: tempstr
+  character(len=64) :: dset_name
+  character(len=64) :: group_name
+  character(len=64) :: proc_str
+  character(len=MAX_STRING_LEN) :: fname_h5_data_vol
+
+  write(proc_str, "(i6.6)") myrank
+
+  if (NtoM) then
+    ! write out one h5 for each IO server process
+    fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume_" // trim(proc_str) // ".h5"
+  else
+    ! write one single h5 for all IO server processes
+    fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume.h5"
+  endif
+
+  ! calculate total number of nglob
+  !nglob_all = sum(nglob_par_io_offset(:))
+  if (NtoM) then
+    io_offset = 0
+  else
+    io_offset = sum(nglob_par_io_offset(0:myrank-1))
+  endif
+
+  ! initialization of h5 file
+  call h5_initialize()
+
+  ! create time group in h5
+  write(tempstr, "(i6.6)") it_io
+  group_name = "it_" // tempstr
+
+  ! create dataset
+  if (NtoM) then
+    ! for NtoM strategy
+    ! create it group
+    call h5_open_file(fname_h5_data_vol)
+    ! check if group_name exists
+    call h5_open_or_create_group(group_name)
+
+    ! loop for each value type
+    do j=1, num_max_type
+      if (val_type_mov(j) .eqv. .true.) then
+        if (j == 1) then
+          dset_name = "pressure"
+          call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+        else if (j == 2) then
+          dset_name = "div_glob"
+          call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+        else if (j == 3) then
+          dset_name = "div"
+          call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+        else if (j == 4) then
+          dset_name = "curl_x"
+          call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+          dset_name = "curl_y"
+          call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+          dset_name = "curl_z"
+          call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+        else if (j == 5) then
+          dset_name = "veloc_x"
+          call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+          dset_name = "veloc_y"
+          call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+          dset_name = "veloc_z"
+          call h5_create_dataset_gen_in_group(dset_name, (/nglob_this_io/), 1, CUSTOM_REAL)
+        endif
+      endif
+    enddo
+
+    call h5_close_group()
+    call h5_close_file()
+
+  else
+    ! for N-to-1 strategy
+    if (myrank == 0) then
+      ! create it group
+      call h5_open_file(fname_h5_data_vol)
+
+      ! check if group_name exists
+      call h5_open_or_create_group(group_name)
+
+      ! loop for each value type
+      do j = 1, num_max_type
+        if (val_type_mov(j) .eqv. .true.) then
+          if (j == 1) then
+            dset_name = "pressure"
+            call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+          else if (j == 2) then
+            dset_name = "div_glob"
+            call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+          else if (j == 3) then
+            dset_name = "div"
+            call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+          else if (j == 4) then
+            dset_name = "curl_x"
+            call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+            dset_name = "curl_y"
+            call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+            dset_name = "curl_z"
+            call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+          else if (j == 5) then
+            dset_name = "veloc_x"
+            call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+            dset_name = "veloc_y"
+            call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+            dset_name = "veloc_z"
+            call h5_create_dataset_gen_in_group(dset_name, (/nglob_all_server/), 1, CUSTOM_REAL)
+          endif
+        endif
+      enddo
+
+      call h5_close_group()
+      call h5_close_file()
+    endif ! if myrank == 0
+
+    call synchronize_all()
+
+  endif ! Nto1
+
+  if (NtoM) then
+    call h5_open_file(fname_h5_data_vol)
+  else
+    call h5_open_file_p(fname_h5_data_vol)
+  endif
+
+  call h5_open_group(group_name)
+
+  ! loop for each value type
+  do j = 1, num_max_type
+    if (val_type_mov(j) .eqv. .true.) then
+      if (j == 1) then
+        dset_name = "pressure"
+        call h5_write_dataset_collect_hyperslab_in_group(dset_name, vd_pres%d1darr, (/io_offset/), if_collect_server)
+      else if (j == 2) then
+        dset_name = "div_glob"
+        call h5_write_dataset_collect_hyperslab_in_group(dset_name, vd_divglob%d1darr, (/io_offset/), if_collect_server)
+      else if (j == 3) then
+        dset_name = "div"
+        call h5_write_dataset_collect_hyperslab_in_group(dset_name, vd_div%d1darr, (/io_offset/), if_collect_server)
+      else if (j == 4) then
+        dset_name = "curl_x"
+        call h5_write_dataset_collect_hyperslab_in_group(dset_name, vd_curlx%d1darr, (/io_offset/), if_collect_server)
+        dset_name = "curl_y"
+        call h5_write_dataset_collect_hyperslab_in_group(dset_name, vd_curly%d1darr, (/io_offset/), if_collect_server)
+        dset_name = "curl_z"
+        call h5_write_dataset_collect_hyperslab_in_group(dset_name, vd_curlz%d1darr, (/io_offset/), if_collect_server)
+      else if (j == 5) then
+        dset_name = "veloc_x"
+        call h5_write_dataset_collect_hyperslab_in_group(dset_name, vd_velox%d1darr, (/io_offset/), if_collect_server)
+        dset_name = "veloc_y"
+        call h5_write_dataset_collect_hyperslab_in_group(dset_name, vd_veloy%d1darr, (/io_offset/), if_collect_server)
+        dset_name = "veloc_z"
+        call h5_write_dataset_collect_hyperslab_in_group(dset_name, vd_veloz%d1darr, (/io_offset/), if_collect_server)
+      endif
+    endif
+  enddo
+
+  call h5_close_group()
+  call h5_close_file()
+
+  end subroutine write_vol_data_io_hdf5
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine write_xdmf_vol_io_hdf5(val_type_mov)
+
+  use constants, only: CUSTOM_REAL,OUTPUT_FILES,NGLLX,NGLLY,NGLLZ,MAX_STRING_LEN
+  use shared_parameters, only: NSTEP,NTSTEP_BETWEEN_FRAMES
+
+  use specfem_par_movie_hdf5
+
+  implicit none
+  logical, dimension(5), intent(inout) :: val_type_mov
+  ! local parameters
+  integer                              :: i, ii
+  logical                              :: pressure_io, divglob_io, div_io, veloc_io, curl_io
+  character(len=20)                    :: it_str, nelm_str, nglo_str
+  character(len=MAX_STRING_LEN)        :: fname_xdmf_vol
+  character(len=MAX_STRING_LEN)        :: fname_h5_data_vol_xdmf
+
+  pressure_io = val_type_mov(1)
+  divglob_io  = val_type_mov(2)
+  div_io      = val_type_mov(3)
+  curl_io     = val_type_mov(4)
+  veloc_io    = val_type_mov(5)
+
+  ! writeout xdmf file for volume movie
+  fname_xdmf_vol = trim(OUTPUT_FILES) // "/movie_volume.xmf"
+  fname_h5_data_vol_xdmf = "./movie_volume.h5"   ! relative to xmf file
+
+  open(unit=xdmf_vol, file=trim(fname_xdmf_vol), recl=256)
+
+  ! definition of topology and geometry
+  ! refer only control nodes (8 or 27) as a coarse output
+  ! data array need to be extracted from full data array on GLL points
+  write(xdmf_vol,'(a)') '<?xml version="1.0" ?>'
+  write(xdmf_vol,*) '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>'
+  write(xdmf_vol,*) '<Xdmf xmlns:xi="http://www.w3.org/2003/XInclude" Version="3.0">'
+  write(xdmf_vol,*) '<Domain name="mesh">'
+
+  ! loop for writing information of mesh partitions
+  nelm_str = i2c(nspec_all_server*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1))
+  nglo_str = i2c(nglob_all_server)
+
+  write(xdmf_vol,*) '<Topology TopologyType="Mixed" NumberOfElements="'//trim(nelm_str)//'">'
+  write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Int" Precision="4" Dimensions="'&
+                         //trim(nelm_str)//' 9">'
+  write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/elm_conn'
+  write(xdmf_vol,*) '</DataItem>'
+  write(xdmf_vol,*) '</Topology>'
+  write(xdmf_vol,*) '<Geometry GeometryType="X_Y_Z">'
+  write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                      //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+  write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/x'
+  write(xdmf_vol,*) '</DataItem>'
+  write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                      //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+  write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/y'
+  write(xdmf_vol,*) '</DataItem>'
+  write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                      //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+  write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/z'
+  write(xdmf_vol,*) '</DataItem>'
+  write(xdmf_vol,*) '</Geometry>'
+  write(xdmf_vol,*) '<Grid Name="time_col" GridType="Collection" CollectionType="Temporal">'
+
+  do i = 1, int(NSTEP/NTSTEP_BETWEEN_FRAMES)
+    ii = i*NTSTEP_BETWEEN_FRAMES
+    write(it_str, "(i6.6)") ii
+
+    write(xdmf_vol,*) '<Grid Name="vol_mov" GridType="Uniform">'
+    write(xdmf_vol,*) '<Time Value="'//trim(r2c(sngl((ii-1)*DT-t0)))//'" />'
+    write(xdmf_vol,*) '<Topology Reference="/Xdmf/Domain/Topology" />'
+    write(xdmf_vol,*) '<Geometry Reference="/Xdmf/Domain/Geometry" />'
+
+    if (pressure_io) then
+      write(xdmf_vol,*) '<Attribute Name="pressure" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '     '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/pressure'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    if (divglob_io) then
+      write(xdmf_vol,*) '<Attribute Name="div_glob" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '     '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/div_glob'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    if (div_io) then
+      write(xdmf_vol,*) '<Attribute Name="div" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '     '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/div'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    if (veloc_io) then
+      write(xdmf_vol,*) '<Attribute Name="veloc_x" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '     '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/veloc_x'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+      write(xdmf_vol,*) '<Attribute Name="veloc_y" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '     '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/veloc_y'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+      write(xdmf_vol,*) '<Attribute Name="veloc_z" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                         //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '     '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/veloc_z'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    if (curl_io) then
+      write(xdmf_vol,*) '<Attribute Name="curl_x" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                     //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '     '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/curl_x'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+      write(xdmf_vol,*) '<Attribute Name="curl_y" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                     //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '     '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/curl_y'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+      write(xdmf_vol,*) '<Attribute Name="curl_z" AttributeType="Scalar" Center="Node">'
+      write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                     //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+      write(xdmf_vol,*) '     '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/curl_z'
+      write(xdmf_vol,*) '</DataItem>'
+      write(xdmf_vol,*) '</Attribute>'
+    endif
+
+    write(xdmf_vol,*) '</Grid>'
+  enddo
+
+  write(xdmf_vol,*) '</Grid>'
+  write(xdmf_vol,*) '</Domain>'
+  write(xdmf_vol,*) '</Xdmf>'
+
+  close(xdmf_vol)
+
+  end subroutine write_xdmf_vol_io_hdf5
+
+!
+!-------------------------------------------------------------------------------------------------
+!
+
+  subroutine write_xdmf_vol_io_mton_hdf5(val_type_mov,nglob_par_io_offset,nelm_par_io_offset)
+
+  use constants, only: OUTPUT_FILES,NGLLX,NGLLY,NGLLZ,MAX_STRING_LEN
+  use shared_parameters, only: DT,NSTEP,NTSTEP_BETWEEN_FRAMES
+
+  use specfem_par, only: t0
+  use specfem_par_movie_hdf5
+
+  implicit none
+
+  logical, dimension(5), intent(inout)               :: val_type_mov
+  integer, dimension(0:HDF5_IO_NODES-1), intent(in) :: nglob_par_io_offset, nelm_par_io_offset
+  ! local parameters
+  integer                                     :: i, ii, iproc
+  logical                                     :: pressure_io, divglob_io, div_io, veloc_io, curl_io
+  character(len=20)                           :: proc_str, it_str,nelm_str, nglo_str
+  character(len=MAX_STRING_LEN)               :: fname_xdmf_vol
+  character(len=MAX_STRING_LEN)               :: fname_h5_data_vol_xdmf
+
+  pressure_io = val_type_mov(1)
+  divglob_io  = val_type_mov(2)
+  div_io      = val_type_mov(3)
+  curl_io     = val_type_mov(4)
+  veloc_io    = val_type_mov(5)
+
+  ! writeout xdmf file for volume movie
+  fname_xdmf_vol = trim(OUTPUT_FILES) // "/movie_volume.xmf"
+
+  open(unit=xdmf_vol, file=trim(fname_xdmf_vol), recl=256)
+
+  ! definition of topology and geometry
+  ! refer only control nodes (8 or 27) as a coarse output
+  ! data array need to be extracted from full data array on GLL points
+  write(xdmf_vol,'(a)') '<?xml version="1.0" ?>'
+  write(xdmf_vol,*) '<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd" []>'
+  write(xdmf_vol,*) '<Xdmf xmlns:xi="http://www.w3.org/2003/XInclude" Version="3.0">'
+  write(xdmf_vol,*) '<Domain>'
+  write(xdmf_vol,*) '<!-- mesh info -->'
+  write(xdmf_vol,*) '<Grid Name="mesh" GridType="Collection"  CollectionType="Spatial">'
+
+  ! loop for writing information of mesh partitions
+  do iproc = 0,HDF5_IO_NODES-1
+    write(proc_str, "(i6.6)") iproc
+    if (NtoM) then
+      ! write out one h5 par 1 IO server process
+      fname_h5_data_vol_xdmf = "./movie_volume_"//trim(proc_str)//".h5"  ! relative to xmf file
+    else
+      ! write one single h5 from all IO server
+      fname_h5_data_vol_xdmf = "./movie_volume.h5"  ! relative to xmf file
+    endif
+
+    ! loop for writing information of mesh partitions
+    nelm_str = i2c(nelm_par_io_offset(iproc)*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1))
+    nglo_str = i2c(nglob_par_io_offset(iproc))
+
+    write(xdmf_vol,*) '<Grid Name="mesh_'//trim(proc_str)//'">'
+    write(xdmf_vol,*) '<Topology TopologyType="Mixed" NumberOfElements="'//trim(nelm_str)//'">'
+    write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Int" Precision="4" Dimensions="'&
+                           //trim(nelm_str)//' 9">'
+    write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/elm_conn'
+    write(xdmf_vol,*) '</DataItem>'
+    write(xdmf_vol,*) '</Topology>'
+    write(xdmf_vol,*) '<Geometry GeometryType="X_Y_Z">'
+    write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                        //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+    write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/x'
+    write(xdmf_vol,*) '</DataItem>'
+    write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                        //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+    write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/y'
+    write(xdmf_vol,*) '</DataItem>'
+    write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                        //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+    write(xdmf_vol,*) '       '//trim(fname_h5_data_vol_xdmf)//':/mesh/z'
+    write(xdmf_vol,*) '</DataItem>'
+    write(xdmf_vol,*) '</Geometry>'
+    write(xdmf_vol,*) '</Grid>'
+
+  enddo ! loop for writing mesh info
+
+  write(xdmf_vol,*) '</Grid>'
+
+  ! write the data by
+  ! loop for iteration
+  !   loop for IONODES
+
+  write(xdmf_vol,*) '<Grid Name="time_col" GridType="Collection" CollectionType="Temporal">'
+  do i = 1, int(NSTEP/NTSTEP_BETWEEN_FRAMES)
+    ii = i*NTSTEP_BETWEEN_FRAMES
+    write(it_str, "(i6.6)") ii
+
+    write(xdmf_vol,*) '<Grid Name="vol_mov" GridType="Collection" CollectionType="Spatial">'
+    write(xdmf_vol,*) '<Time Value="'//trim(r2c(sngl((ii-1)*DT-t0)))//'" />'
+
+    do iproc = 0,HDF5_IO_NODES-1
+      write(proc_str, "(i6.6)") iproc
+      if (NtoM) then
+        ! write out one h5 par 1 IO server process
+        fname_h5_data_vol_xdmf = "./movie_volume_"//trim(proc_str)//".h5" ! relative to xmf file
+      else
+        ! write one single h5 from all IO server
+        fname_h5_data_vol_xdmf = "./movie_volume.h5"  ! relative to xmf file
+      endif
+
+      nglo_str = i2c(nglob_par_io_offset(iproc))
+
+      write(xdmf_vol, *)  '<Grid Name="data_'//trim(proc_str)//'" Type="Uniform">'
+      write(xdmf_vol, *)  '<Topology Reference="/Xdmf/Domain/Grid[@Name=''mesh'']/Grid[@Name=''mesh_'&
+                                        //trim(proc_str)//''']/Topology" />'
+      write(xdmf_vol, *)  '<Geometry Reference="/Xdmf/Domain/Grid[@Name=''mesh'']/Grid[@Name=''mesh_'&
+                                        //trim(proc_str)//''']/Geometry" />'
+
+      if (pressure_io) then
+        write(xdmf_vol,*) '<Attribute Name="pressure" AttributeType="Scalar" Center="Node">'
+        write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                           //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+        write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/pressure'
+        write(xdmf_vol,*) '</DataItem>'
+        write(xdmf_vol,*) '</Attribute>'
+      endif
+
+      if (divglob_io) then
+        write(xdmf_vol,*) '<Attribute Name="div_glob" AttributeType="Scalar" Center="Node">'
+        write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                           //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+        write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/div_glob'
+        write(xdmf_vol,*) '</DataItem>'
+        write(xdmf_vol,*) '</Attribute>'
+      endif
+
+      if (div_io) then
+        write(xdmf_vol,*) '<Attribute Name="div" AttributeType="Scalar" Center="Node">'
+        write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                           //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+        write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/div'
+        write(xdmf_vol,*) '</DataItem>'
+        write(xdmf_vol,*) '</Attribute>'
+      endif
+
+      if (veloc_io) then
+        write(xdmf_vol,*) '<Attribute Name="veloc_x" AttributeType="Scalar" Center="Node">'
+        write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                           //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+        write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/veloc_x'
+        write(xdmf_vol,*) '</DataItem>'
+        write(xdmf_vol,*) '</Attribute>'
+        write(xdmf_vol,*) '<Attribute Name="veloc_y" AttributeType="Scalar" Center="Node">'
+        write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                           //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+        write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/veloc_y'
+        write(xdmf_vol,*) '</DataItem>'
+        write(xdmf_vol,*) '</Attribute>'
+        write(xdmf_vol,*) '<Attribute Name="veloc_z" AttributeType="Scalar" Center="Node">'
+        write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                           //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+        write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/veloc_z'
+        write(xdmf_vol,*) '</DataItem>'
+        write(xdmf_vol,*) '</Attribute>'
+      endif
+
+      if (curl_io) then
+        write(xdmf_vol,*) '<Attribute Name="curl_x" AttributeType="Scalar" Center="Node">'
+        write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                       //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+        write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/curl_x'
+        write(xdmf_vol,*) '</DataItem>'
+        write(xdmf_vol,*) '</Attribute>'
+        write(xdmf_vol,*) '<Attribute Name="curl_y" AttributeType="Scalar" Center="Node">'
+        write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                       //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+        write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/curl_y'
+        write(xdmf_vol,*) '</DataItem>'
+        write(xdmf_vol,*) '</Attribute>'
+        write(xdmf_vol,*) '<Attribute Name="curl_z" AttributeType="Scalar" Center="Node">'
+        write(xdmf_vol,*) '<DataItem ItemType="Uniform" Format="HDF" NumberType="Float" Precision="'&
+                                                       //trim(i2c(CUSTOM_REAL))//'" Dimensions="'//trim(nglo_str)//'">'
+        write(xdmf_vol,*) '      '//trim(fname_h5_data_vol_xdmf)//':/it_'//trim(it_str)//'/curl_z'
+        write(xdmf_vol,*) '</DataItem>'
+        write(xdmf_vol,*) '</Attribute>'
+      endif
+
+      write(xdmf_vol,*) '</Grid>'
+
+    enddo  ! loop proc
+
+    write(xdmf_vol,*) '</Grid>'
+
+  enddo ! loop time
+
+  write(xdmf_vol,*) '</Grid>'
+  write(xdmf_vol,*) '</Domain>'
+  write(xdmf_vol,*) '</Xdmf>'
+
+  close(xdmf_vol)
+
+  end subroutine write_xdmf_vol_io_mton_hdf5
+
 
 #endif

--- a/src/specfem3D/write_output_HDF5.F90
+++ b/src/specfem3D/write_output_HDF5.F90
@@ -112,7 +112,7 @@
   end select
 
   ! initialze hdf5
-  call h5_init()
+  call h5_initialize()
 
   ! note:
   ! - the total array length for a seismogram is NSTEP / NTSTEP_BETWEEN_OUTPUT_SAMPLE
@@ -160,7 +160,7 @@
 
   ! finish writing
   call h5_close_file()
-  call h5_destructor()
+  call h5_finalize()
 
 #else
   ! no HDF5 compilation support
@@ -212,7 +212,7 @@
   if (myrank /= 0) return
 
   ! initialze hdf5
-  call h5_init()
+  call h5_initialize()
 
   ! create file
   call h5_create_file(filename)
@@ -240,7 +240,6 @@
 
   ! time array
   call h5_write_dataset_no_group("time", time_array)
-  call h5_close_dataset()
 
   ! free array
   deallocate(time_array)
@@ -265,15 +264,10 @@
 
   ! coordination
   call h5_write_dataset_no_group("coords", rec_coords)
-  call h5_close_dataset()
-
   ! station name
   call h5_write_dataset_no_group("station", stations)
-  call h5_close_dataset()
-
   ! network name
   call h5_write_dataset_no_group("network", networks)
-  call h5_close_dataset()
 
   ! free arrays
   deallocate(stations,networks,rec_coords)
@@ -308,7 +302,7 @@
   endif
 
   call h5_close_file()
-  call h5_destructor()
+  call h5_finalize()
 
   end subroutine write_output_hdf5_seismogram_init
 

--- a/src/tomography/rules.mk
+++ b/src/tomography/rules.mk
@@ -178,9 +178,27 @@ xmodel_update_OBJECTS = \
 xmodel_update_SHARED_OBJECTS = \
 	$O/specfem3D_par.spec_module.o \
 	$O/pml_par.spec_module.o \
+	$O/comp_source_time_function.spec.o \
+	$O/compute_add_sources_viscoelastic.spec.o \
+	$O/compute_adj_source_frechet.spec.o \
+	$O/compute_arrays_source.spec.o \
+	$O/compute_element_strain.spec.o \
+	$O/compute_gradient_in_acoustic.spec.o \
+	$O/compute_interpolated_dva.spec.o \
+	$O/compute_seismograms.spec.o \
+	$O/hdf5_io_server.spec_hdf5.o \
 	$O/initialize_simulation.spec.o \
+	$O/noise_tomography.spec.o \
 	$O/read_mesh_databases.spec.o \
 	$O/read_mesh_databases_hdf5.spec_hdf5.o \
+	$O/write_movie_output_HDF5.spec_hdf5.o \
+	$O/write_output_ASCII_or_binary.spec.o \
+	$O/write_output_HDF5.spec_hdf5.o \
+	$O/write_output_SU.spec.o \
+	$O/write_seismograms.spec.o \
+	$(EMPTY_MACRO)
+
+xmodel_update_SHARED_OBJECTS += \
 	$O/shared_par.shared_module.o \
 	$O/adios_manager.shared_adios_module.o \
 	$O/check_mesh_resolution.shared.o \
@@ -191,9 +209,12 @@ xmodel_update_SHARED_OBJECTS = \
 	$O/gll_library.shared.o \
 	$O/hdf5_manager.shared_hdf5_module.o \
 	$O/init_openmp.shared.o \
+	$O/lagrange_poly.shared.o \
+	$O/netlib_specfun_erf.shared.o \
 	$O/param_reader.cc.o \
 	$O/read_parameter_file.shared.o \
 	$O/read_value_parameters.shared.o \
+	$O/write_c_binary.cc.o \
 	$O/write_VTK_data.shared.o \
 	$(EMPTY_MACRO)
 

--- a/utils/plot_HDF5_data_info.py
+++ b/utils/plot_HDF5_data_info.py
@@ -249,7 +249,13 @@ def plot_HDF5_data_info(file_in,show_plot,convert_waveforms):
                     ncomp = 3
                 for icomp in range(ncomp):
                     # trace data
-                    trace = data[irec, :, icomp]
+                    if "press" in label:
+                        # pressure single-component w/ shape (nrec,nstep)
+                        trace = data[irec, :]
+                    else:
+                        # displ/veloc/accel w/ shape (nrec,nstep,ndim)
+                        trace = data[irec, :, icomp]
+
                     length = len(trace)
 
                     # check if time and trace have same length

--- a/utils/plot_HDF5_data_info.py
+++ b/utils/plot_HDF5_data_info.py
@@ -5,7 +5,7 @@
 #
 from __future__ import print_function
 
-import sys
+import sys,os
 
 try:
     import h5py
@@ -52,13 +52,13 @@ do_compare_ref = False
 ######################################################################
 
 # read and plot the seismograms in hdf5 format
-def plot_HDF5_data_info(file,show_plot):
+def plot_HDF5_data_info(file_in,show_plot,convert_waveforms):
     print("")
-    print("reading file: ",filename)
+    print("reading file: ",file_in)
     print("")
 
     # open
-    with h5py.File(file, "r") as f:
+    with h5py.File(file_in, "r") as f:
         # contents
         # coords                   Dataset {3, 4}
         # displ                    Dataset {4, 5000, 3}
@@ -94,6 +94,12 @@ def plot_HDF5_data_info(file,show_plot):
         if "time" in keys:
             time = f["time"][:]
             print("  time   : shape = ",time.shape)
+        if "channel_press" in keys:
+            channel_press = f["channel_press"][:]
+            print("  channel_press: shape = ",channel_press.shape)
+        if "channel" in keys:
+            channel = f["channel"][:]
+            print("  channel: shape = ",channel.shape)
         print("")
 
         # info
@@ -178,11 +184,23 @@ def plot_HDF5_data_info(file,show_plot):
                     net = network[ista]
                     # avoid bytes string issues with strings like b'Hello', converts to text string
                     if isinstance(net, (bytes, bytearray)): net = net.decode("utf-8")
+                    # channel
+                    if "press" in label:
+                        cha = channel_press[0]
+                    else:
+                        cha = channel[2]
+                    # avoid bytes string issues with strings like b'Hello', converts to text string
+                    if isinstance(cha, (bytes, bytearray)): cha = cha.decode("utf-8")
 
-                    name = "{}.{}".format(net,sta)
+                    name = "{}.{}.{}".format(net,sta,cha)
                     print("  station: ",name)
-                    # plot z component
-                    ax[i // 2, i % 2].plot(time, data[ista, :, 1], "b")
+
+                    if "press" in label:
+                        # pressure single component
+                        ax[i // 2, i % 2].plot(time, data[ista, :, 2], "b")
+                    else:
+                        # plot z component
+                        ax[i // 2, i % 2].plot(time, data[ista, :, 2], "b")
 
                     # trace comparisons
                     if do_compare_ref:
@@ -199,32 +217,135 @@ def plot_HDF5_data_info(file,show_plot):
         # Wait for the user input to terminate the program
         input("Press any key to terminate the program")
 
+    if convert_waveforms:
+        print("converting to ASCII:")
+
+        # takes same output directory as input file
+        # for example: ./plot_HDF5_data_info.py OUTPUT_FILES/seismograms.h5
+        #              -> output in OUTPUT_FILES/ directory
+        out_dir = os.path.dirname(file_in)
+        if out_dir == '':
+            out_dir = "./"  # -> ./ + DB.STA.XXX.semd
+        else:
+            out_dir = out_dir + "/"  # OUTPUT_FILES -> OUTPUT_FILES/ + DB.STA.XXX.semd
+
+        for id,data in enumerate(data):
+            # label
+            label = data_label[id]
+            for irec in range(nrec):
+                # station name
+                sta = station[irec]
+                # avoid bytes string issues with strings like b'Hello', converts to text string
+                if isinstance(sta, (bytes, bytearray)): sta = sta.decode("utf-8")
+                # network name
+                net = network[irec]
+                # avoid bytes string issues with strings like b'Hello', converts to text string
+                if isinstance(net, (bytes, bytearray)): net = net.decode("utf-8")
+
+                # components
+                if "press" in label:
+                    ncomp = 1
+                else:
+                    ncomp = 3
+                for icomp in range(ncomp):
+                    # trace data
+                    trace = data[irec, :, icomp]
+                    length = len(trace)
+
+                    # check if time and trace have same length
+                    if length != len(time):
+                        print("Error: different trace / time lengths: {} / {}".format(length,len(time)))
+                        sys.exit(1)
+
+                    # channel
+                    if "press" in label:
+                        cha = channel_press[icomp]
+                    else:
+                        cha = channel[icomp]
+                    # avoid bytes string issues with strings like b'Hello', converts to text string
+                    if isinstance(cha, (bytes, bytearray)): cha = cha.decode("utf-8")
+
+                    # file ending
+                    if "displ" in label:
+                        ending = ".semd"
+                    elif "veloc" in label:
+                        ending = ".semv"
+                    elif "accel" in label:
+                        ending = ".sema"
+                    elif "press" in label:
+                        ending = ".semp"
+                    else:
+                        print("unknown data type")
+                        sys.exit(1)
+
+                    name = "{}.{}.{}".format(net,sta,cha)
+                    print("  station: ",name)
+
+                    filename = out_dir + name + ending
+
+                    # single file per station and component
+                    # file output
+                    f = open(filename, "w")
+
+                    t0 = time[0]
+                    # file header
+                    f.write("# STATION %s\n" % (sta))
+                    f.write("# CHANNEL %s\n" % (cha))
+                    f.write("# START_TIME %s\n" % (str(t0)))
+                    #f.write("# SAMP_FREQ %f\n" % (tr.stats.sampling_rate))
+                    f.write("# NDAT %d\n" % (length))
+
+                    # data section
+                    # fills numpy array
+                    xy = np.empty(shape=(0,2))
+                    for ii in range(length):
+                        t = time[ii]
+                        val = trace[ii]
+                        xy = np.append(xy,[[t,val]],axis=0)
+
+                    # data column
+                    #print(xy[:,1])
+                    #print(xy[0,1],xy[1,1],xy[2,1],xy[3,1])
+
+                    # saves as ascii
+                    np.savetxt(f, xy, fmt="%f\t%e")
+                    f.close()
+
+                    # user output
+                    print("  written file: ",filename)
+
     print("")
     print("all done")
     print("")
 
 
 def usage():
-    print("usage: ./plot_HDF5_data_info.py filename[e.g. seismograms.h5] [show]")
+    print("usage: ./plot_HDF5_data_info.py filename[e.g. seismograms.h5] [show] [convert]")
     print(" with")
-    print("   filename - e.g. OUTPUT_FILES/seismograms.h5")
-    print("   show   - (optional) plot waveforms")
+    print("   filename  - e.g. OUTPUT_FILES/seismograms.h5")
+    print("   show      - (optional) plot waveforms")
+    print("   convert   - (optional) convert seismograms to ASCII traces")
     sys.exit(1)
 
 
 if __name__ == "__main__":
     # gets arguments
     do_plot_waveforms = False
+    do_convert_waveforms = False
 
     if len(sys.argv) == 2:
         filename = sys.argv[1]
     elif len(sys.argv) == 3:
         filename = sys.argv[1]
         if sys.argv[2] == "show": do_plot_waveforms = True
+    elif len(sys.argv) == 4:
+        filename = sys.argv[1]
+        if sys.argv[2] == "show": do_plot_waveforms = True
+        if sys.argv[3] == "convert": do_convert_waveforms = True
     else:
         usage()
         sys.exit(1)
 
-    plot_HDF5_data_info(filename,do_plot_waveforms)
+    plot_HDF5_data_info(filename,do_plot_waveforms,do_convert_waveforms)
 
 


### PR DESCRIPTION
setting the additional parameter `HDF5_IO_NODES` in the `Par_file` to a value >0 will turn on the I/O server. for example, with:
```
..
HDF5_FORMAT              = .true.
..
HDF5_ENABLED             = .true.
HDF5_FOR_MOVIES          = .true.
HDF5_IO_NODES            =  1
``` 
the solver will use `NPROC + HDF5_IO_NODES` mpi processes, where the last mpi process is dedicated to performing all file outputs for movie snapshots, shakemap and seismograms.