### PR TITLE
minor edits in geocubit subroutines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ doc/USER_MANUAL/Schedule
 .*swo
 .*swn
 *~
+*.pyc

--- a/CUBIT_GEOCUBIT/geocubitlib/absorbing_boundary.py
+++ b/CUBIT_GEOCUBIT/geocubitlib/absorbing_boundary.py
@@ -119,6 +119,16 @@ def define_parallel_absorbing_surf():
             if dz <= topographic_surface_distance_tolerance and dn < topographic_surface_normal_tolerance:
                 top_surf.append(k)
 
+    # checking list sizes before return
+    len_return_items = [len(liste) for liste in \
+                absorbing_surf_xmin,absorbing_surf_xmax,absorbing_surf_ymin,absorbing_surf_ymax,\
+                absorbing_surf_bottom,top_surf]
+    if (0 in len_return_items ): 
+        print ('WARNING::define_parallel_absorbing_surf:: empty return list(s). try increasing tolerance!')
+        import sys
+        sys.exit()
+    ##    
+
     return absorbing_surf_xmin,absorbing_surf_xmax,absorbing_surf_ymin,absorbing_surf_ymax,absorbing_surf_bottom,top_surf
 
 def define_top_bottom_absorbing_surf(zmin_box,zmax_box):

--- a/CUBIT_GEOCUBIT/geocubitlib/save_fault_nodes_elements.py
+++ b/CUBIT_GEOCUBIT/geocubitlib/save_fault_nodes_elements.py
@@ -33,7 +33,8 @@ class fault_input:
         print('len(Ad):',len(quads_Ad))
 
         if not (len(quads_Au) == len(quads_Ad)):
-            print('Number of elements for each fauld side up and down do not concide')
+            print('Number of elements for up and down fault sides does not coincide!')
+            import sys
             sys.exit('goodbye')
 
         save_elements_nodes(self.name,quads_Au,quads_Ad)


### PR DESCRIPTION
- CUBIT_GEOCUBIT/geocubitlib/absorbing_boundary.py: for some models, the default tolerance fails to find boundary surfaces. I put a warning to try increasing tolerance. (The current version searches for the surfaces of which the distance to boundary limit is below the preset criterion. Perhaps a better version can search for the surface with the minimum distance to the bounding limit.)

- CUBIT_GEOCUBIT/geocubitlib/save_fault_nodes_elements.py: Minor edit for importing "sys" where the code aborts if fault faces do not match. 