### PR TITLE
Hdf5 update

### DIFF
--- a/src/generate_databases/read_partition_files_hdf5.F90
+++ b/src/generate_databases/read_partition_files_hdf5.F90
@@ -195,7 +195,7 @@
   if (ier /= 0) stop 'Error allocating array nodes_coords_ext_mesh'
   nodes_coords_ext_mesh(:,:) = 0.0
 
-  call h5_read_dataset_collect_hyperslab(dsetname, nodes_coords_ext_mesh, (/0,sum(offset_nnodes(0:myrank-1))/),.true.)
+  call h5_read_dataset_collect_hyperslab(dsetname, nodes_coords_ext_mesh, (/0,sum(offset_nnodes(0:myrank-1))/),.true.) !!!!!!!!!!!!!!
 
   call sum_all_i(nnodes_ext_mesh,num)
   if (myrank == 0) then

--- a/src/generate_databases/read_partition_files_hdf5.F90
+++ b/src/generate_databases/read_partition_files_hdf5.F90
@@ -195,7 +195,7 @@
   if (ier /= 0) stop 'Error allocating array nodes_coords_ext_mesh'
   nodes_coords_ext_mesh(:,:) = 0.0
 
-  call h5_read_dataset_collect_hyperslab(dsetname, nodes_coords_ext_mesh, (/0,sum(offset_nnodes(0:myrank-1))/),.true.) !!!!!!!!!!!!!!
+  call h5_read_dataset_collect_hyperslab(dsetname, nodes_coords_ext_mesh, (/0,sum(offset_nnodes(0:myrank-1))/),.true.)
 
   call sum_all_i(nnodes_ext_mesh,num)
   if (myrank == 0) then

--- a/src/generate_databases/save_arrays_solver_hdf5.F90
+++ b/src/generate_databases/save_arrays_solver_hdf5.F90
@@ -36,7 +36,7 @@
   use shared_parameters, only: ACOUSTIC_SIMULATION, ELASTIC_SIMULATION, POROELASTIC_SIMULATION, &
     APPROXIMATE_OCEAN_LOAD, ANISOTROPY, &
     COUPLE_WITH_INJECTION_TECHNIQUE, MESH_A_CHUNK_OF_THE_EARTH,NPROC, &
-    HDF5_IO_COLLECTIVE
+    H5_COL
 
   ! global indices
   use generate_databases_par, only: NSPEC_AB, ibool, NGLOB_AB
@@ -892,149 +892,149 @@
     call flush_IMAIN()
   endif
 
-  ! set dwrite flagHDF5_IO_COLLECTIVEto pre_define the dataset on file before write.
+  ! set dwrite flagH5_COLto pre_define the dataset on file before write.
 
   dset_name = "nspec" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/nspec_ab/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/nspec_ab/), (/myrank/),H5_COL)
   dset_name = "nglob" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/nglob_ab/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/nglob_ab/), (/myrank/),H5_COL)
   dset_name = "nspec_irregular" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/nspec_irregular/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/nspec_irregular/), (/myrank/),H5_COL)
   dset_name = "ibool" ! 4 i (/0,0,0, offset_nglobs/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ibool, (/0,0,0,sum(offset_nglob(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, ibool, (/0,0,0,sum(offset_nglob(0:myrank-1))/), H5_COL)
   dset_name = "xstore_unique" ! 1 r (/offset_nglobs/)
-  call h5_write_dataset_collect_hyperslab(dset_name,xstore_unique,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,xstore_unique,(/sum(offset_nglob(0:myrank-1))/),H5_COL)
   dset_name = "ystore_unique" ! 1 r (/offset_nglobs/)
-  call h5_write_dataset_collect_hyperslab(dset_name,ystore_unique,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,ystore_unique,(/sum(offset_nglob(0:myrank-1))/),H5_COL)
   dset_name = "zstore_unique" ! 1 r (/offset_nglobs/)
-  call h5_write_dataset_collect_hyperslab(dset_name,zstore_unique,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,zstore_unique,(/sum(offset_nglob(0:myrank-1))/),H5_COL)
   dset_name = "irregular_element_number" ! 1 i (/offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,irregular_element_number,(/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,irregular_element_number,(/sum(offset_nspec(0:myrank-1))/),H5_COL)
   dset_name = "xix_regular" ! 1 r (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/xix_regular/),(/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/xix_regular/),(/myrank/),H5_COL)
   dset_name = "jacobian_regular" ! 1 r (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/jacobian_regular/),(/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/jacobian_regular/),(/myrank/),H5_COL)
   dset_name = "xixstore" ! 4 r  (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,xixstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,xixstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "xiystore" ! 4 r  (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,xiystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,xiystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "xizstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,xizstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,xizstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "etaxstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,etaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,etaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "etaystore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,etaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,etaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "etazstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,etazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,etazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "gammaxstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,gammaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,gammaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "gammaystore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,gammaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,gammaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "gammazstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,gammazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,gammazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "jacobianstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,jacobianstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,jacobianstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
   dset_name = "kappastore" ! 4 r (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,kappastore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,kappastore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
   dset_name = "mustore" ! 4 r (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,mustore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name,mustore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
   dset_name = "ispec_is_acoustic" ! 1 l (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_acoustic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_acoustic, (/sum(offset_nspec(0:myrank-1))/),H5_COL)
   dset_name = "ispec_is_elastic" ! 1 l (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_elastic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_elastic, (/sum(offset_nspec(0:myrank-1))/),H5_COL)
   dset_name = "ispec_is_poroelastic" ! 1 l (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_poroelastic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_poroelastic, (/sum(offset_nspec(0:myrank-1))/),H5_COL)
 
   ! acoustic
   if (ACOUSTIC_SIMULATION) then
     dset_name = "rmass_acoustic" ! 1 r (/offset_nglob/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rmass_acoustic,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rmass_acoustic,(/sum(offset_nglob(0:myrank-1))/),H5_COL)
   endif
 
   ! this array is needed for acoustic simulations but also for elastic simulations with CPML,
   ! thus we allocate it and read it in all cases (whether the simulation is acoustic, elastic, or acoustic/elastic)
   dset_name = "rhostore" ! 4 r (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, rhostore, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, rhostore, (/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
 
   ! elastic
   if (ELASTIC_SIMULATION) then
     dset_name = "rmass" ! 1 r (/offset_nglob/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rmass, (/sum(offset_nglob(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rmass, (/sum(offset_nglob(0:myrank-1))/), H5_COL)
     if (APPROXIMATE_OCEAN_LOAD) then
       dset_name = "rmass_ocean_load" ! 1 r (/offset_nglob_ocean/)
-      call h5_write_dataset_collect_hyperslab(dset_name, rmass_ocean_load, (/sum(offset_nglob_ocean(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, rmass_ocean_load, (/sum(offset_nglob_ocean(0:myrank-1))/),H5_COL)
     endif
     !pll Stacey
     dset_name = "rho_vp" ! 4 r (/0,0,0,offset_nspec/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vp, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vp, (/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
     dset_name = "rho_vs" ! 4 r (/0,0,0,offset_nspec/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vs, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vs, (/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
   endif
 
   ! poroelastic
   if (POROELASTIC_SIMULATION) then
     dset_name = "rmass_solid_poroelastic" ! 1 r (/offset_nglob/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rmass_solid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rmass_solid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),H5_COL)
     dset_name = "rmass_fluid_poroelastic" ! 1 r (/offset_nglob/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rmass_fluid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rmass_fluid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),H5_COL)
     dset_name = "rhoarraystore" ! 5 r (/0,0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rhoarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rhoarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
     dset_name = "kappaarraystore" ! 5 r (/0,0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, kappaarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, kappaarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
     dset_name = "etastore" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, etastore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, etastore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
     dset_name = "tortstore" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, tortstore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, tortstore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
     dset_name = "permstore" ! 5 r (/0,0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, permstore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, permstore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
     dset_name = "phistore" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, phistore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, phistore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
     dset_name = "rho_vpI" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vpI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vpI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
     dset_name = "rho_vpII" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vpII, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vpII, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
     dset_name = "rho_vsI" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vsI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vsI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
   endif
 
   ! C-PML absorbing boundary conditions
   if (PML_CONDITIONS) then
     dset_name = "nspec_cpml" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_cpml/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_cpml/), (/myrank/),H5_COL)
     dset_name = "CPML_width_x" ! 1 r (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_x/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_x/), (/myrank/),H5_COL)
     dset_name = "CPML_width_y" ! 1 r (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_y/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_y/), (/myrank/),H5_COL)
     dset_name = "CPML_width_z" ! 1 r (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_z/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_z/), (/myrank/),H5_COL)
     dset_name = "min_distance_between_CPML_parameter" ! 1 r (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/min_distance_between_CPML_parameter/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/min_distance_between_CPML_parameter/), (/myrank/),H5_COL)
 
     if (sum(offset_nspeccpml) > 0) then
       dset_name = "CPML_regions" ! 1 i (/offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, CPML_regions, (/sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, CPML_regions, (/sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "CPML_to_spec" ! 1 i (/offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, CPML_to_spec, (/sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, CPML_to_spec, (/sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "is_CPML" ! 1 l (/offset_nspecab/)
-      call h5_write_dataset_collect_hyperslab(dset_name, is_CPML, (/sum(offset_nspec_ab(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, is_CPML, (/sum(offset_nspec_ab(0:myrank-1))/),H5_COL)
       dset_name = "d_store_x" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, d_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, d_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "d_store_y" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, d_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, d_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "d_store_z" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, d_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, d_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "k_store_x" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, k_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, k_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "k_store_y" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, k_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, k_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "k_store_z" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, k_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, k_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "alpha_store_x" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "alpha_store_y" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       dset_name = "alpha_store_z" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
 
       ! --------------------------------------------------------------------------------------------
       ! for adjoint tomography
@@ -1042,18 +1042,18 @@
       ! --------------------------------------------------------------------------------------------
       if ((SIMULATION_TYPE == 1 .and. SAVE_FORWARD) .or. SIMULATION_TYPE == 3) then
         dset_name = "nglob_interface_PML_acoustic" ! 1 i (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/nglob_interface_PML_acoustic/), (/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/nglob_interface_PML_acoustic/), (/myrank/),H5_COL)
         dset_name = "nglob_interface_PML_elastic" ! 1 i (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/nglob_interface_PML_elastic/), (/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/nglob_interface_PML_elastic/), (/myrank/),H5_COL)
         if (sum(offset_nglob_interface_PML_acoustic) > 0) then
           dset_name = "points_interface_PML_acoustic" ! 1 i (/offset_nglob_interface_PML_acoustic/)
           call h5_write_dataset_collect_hyperslab(dset_name, &
-              points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_acoustic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_acoustic(0:myrank-1))/),H5_COL)
         endif
         if (sum(offset_nglob_interface_PML_elastic) > 0) then
           dset_name = "points_interface_PML_elastic" ! 1 i (/offset_nglob_interface_PML_elastic/)
           call h5_write_dataset_collect_hyperslab(dset_name, &
-              points_interface_PML_elastic, (/sum(offset_nglob_interface_PML_elastic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              points_interface_PML_elastic, (/sum(offset_nglob_interface_PML_elastic(0:myrank-1))/),H5_COL)
         endif
       endif
     endif
@@ -1061,348 +1061,348 @@
 
   ! absorbing boundary surface
   dset_name = "num_abs_boundary_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_abs_boundary_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_abs_boundary_faces/), (/myrank/),H5_COL)
 
   if (sum(offset_num_abs_boundary_faces) > 0) then
     dset_name = "abs_boundary_ispec" ! 1 i (/offset_num_abs_boundary_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, abs_boundary_ispec, &
-            (/sum(offset_num_abs_boundary_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/sum(offset_num_abs_boundary_faces(0:myrank-1))/),H5_COL)
     dset_name = "abs_boundary_ijk" ! 3 i (/0,0,offset_num_abs_boundary_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, abs_boundary_ijk, &
-            (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+            (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), H5_COL)
     dset_name = "abs_boundary_jacobian2Dw" ! 2 r (/0,offset_num_abs_boundary_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, abs_boundary_jacobian2Dw, &
-            (/0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+            (/0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), H5_COL)
     dset_name = "abs_boundary_normal" ! 3 r (/0,0,offset_num_abs_boundary_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, abs_boundary_normal, &
-            (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+            (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), H5_COL)
 
     if (STACEY_ABSORBING_CONDITIONS .and. (.not. PML_CONDITIONS)) then
       ! store mass matrix contributions
       if (ELASTIC_SIMULATION) then
         dset_name = "rmassx" ! 1 r (/offset_nglob_xy/)
-        call h5_write_dataset_collect_hyperslab(dset_name, rmassx, (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, rmassx, (/sum(offset_nglob_xy(0:myrank-1))/),H5_COL)
         dset_name = "rmassy" ! 1 r (/offset_nglob_xy/)
-        call h5_write_dataset_collect_hyperslab(dset_name, rmassy, (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, rmassy, (/sum(offset_nglob_xy(0:myrank-1))/),H5_COL)
         dset_name = "rmassz" ! 1 r (/offset_nglob_xy/)
-        call h5_write_dataset_collect_hyperslab(dset_name, rmassz, (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, rmassz, (/sum(offset_nglob_xy(0:myrank-1))/),H5_COL)
      endif
       if (ACOUSTIC_SIMULATION) then
         dset_name = "rmassz_acoustic" ! 1 r (/offset_nglob_xy/)
-        call h5_write_dataset_collect_hyperslab(dset_name, rmassz_acoustic, (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, rmassz_acoustic, (/sum(offset_nglob_xy(0:myrank-1))/),H5_COL)
      endif
     endif
   else
     dset_name = "abs_boundary_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),H5_COL)
     dset_name = "abs_boundary_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),H5_COL)
     dset_name = "abs_boundary_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),H5_COL)
     dset_name = "abs_boundary_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),H5_COL)
 
     if (STACEY_ABSORBING_CONDITIONS .and. (.not. PML_CONDITIONS)) then
       ! store mass matrix contributions
       if (ELASTIC_SIMULATION) then
         dset_name = "rmassx" ! 1 r (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),H5_COL)
         dset_name = "rmassy" ! 1 r (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),H5_COL)
         dset_name = "rmassz" ! 1 r (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),H5_COL)
       endif
       if (ACOUSTIC_SIMULATION) then
         dset_name = "rmassz_acoustic" ! 1 r (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),H5_COL)
       endif
     endif
 
   endif
 
   dset_name = "nspec2D_xmin" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_xmin/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_xmin/), (/myrank/),H5_COL)
   dset_name = "nspec2D_xmax" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_xmax/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_xmax/), (/myrank/),H5_COL)
   dset_name = "nspec2D_ymin" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_ymin/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_ymin/), (/myrank/),H5_COL)
   dset_name = "nspec2D_ymax" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_ymax/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_ymax/), (/myrank/),H5_COL)
   dset_name = "NSPEC2D_BOTTOM" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_bottom/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_bottom/), (/myrank/),H5_COL)
   dset_name = "NSPEC2D_TOP" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_top/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_top/), (/myrank/),H5_COL)
 
   if (sum(offset_nspec2D_xmin) > 0) then
     dset_name = "ibelm_xmin" ! 1 i (/offset_nspec2D_xmin/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),H5_COL)
   endif
   if (sum(offset_nspec2D_xmax) > 0) then
     dset_name = "ibelm_xmax" ! 1 i (/offset_nspec2D_xmax/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),H5_COL)
   endif
   if (sum(offset_nspec2D_ymin) > 0) then
     dset_name = "ibelm_ymin" ! 1 i (/offset_nspec2D_ymin/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),H5_COL)
   endif
   if (sum(offset_nspec2D_ymax) > 0) then
     dset_name = "ibelm_ymax" ! 1 i (/offset_nspec2D_ymax/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),H5_COL)
   endif
   if (sum(offset_nspec2D_bottom_ext) > 0) then
     dset_name = "ibelm_bottom" ! 1 i (/offset_nspec2D_bottom_ext/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),H5_COL)
   endif
   if (sum(offset_nspec2D_top_ext) > 0) then
     dset_name = "ibelm_top" ! 1 i (/offset_nspec2D_top_ext/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),H5_COL)
   endif
 
   ! free surface
   dset_name = "num_free_surface_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_free_surface_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_free_surface_faces/), (/myrank/),H5_COL)
 
   if (sum(offset_num_free_surface_faces) > 0) then
     dset_name = "free_surface_ispec" ! 1 i (/offset_num_free_surface_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, free_surface_ispec, &
-            (/sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/sum(offset_num_free_surface_faces(0:myrank-1))/),H5_COL)
     dset_name = "free_surface_ijk" ! 3 i (/0,0,offset_num_free_surface_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, free_surface_ijk, &
-            (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),H5_COL)
     dset_name = "free_surface_jacobian2Dw" ! 2 r (/0,offset_num_free_surface_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, free_surface_jacobian2Dw, &
-            (/0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,sum(offset_num_free_surface_faces(0:myrank-1))/),H5_COL)
     dset_name = "free_surface_normal" ! 3 r (/0,0,offset_num_free_surface_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, free_surface_normal, &
-            (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),H5_COL)
   else
     dset_name = "free_surface_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),H5_COL)
     dset_name = "free_surface_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),H5_COL)
     dset_name = "free_surface_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),H5_COL)
     dset_name = "free_surface_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),H5_COL)
   endif
 
   ! acoustic-elastic coupling surface
   dset_name = "num_coupling_ac_el_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_ac_el_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_ac_el_faces/), (/myrank/),H5_COL)
 
   if (sum(offset_num_coupling_ac_el_faces) > 0) then
     dset_name = "coupling_ac_el_ispec" ! 1 i (/offset_num_coupling_ac_el_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_el_ispec, &
-              (/sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_ac_el_ijk" ! 3 i (/0,0,offset_num_coupling_ac_el_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_el_ijk, &
-              (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_ac_el_jacobian2Dw" ! 2 r (/0,offset_num_coupling_ac_el_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_el_jacobian2Dw, &
-             (/0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+             (/0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_ac_el_normal" ! 3 r (/0,0,offset_num_coupling_ac_el_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_el_normal, &
-             (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+             (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),H5_COL)
   else
     dset_name = "coupling_ac_el_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),H5_COL)
     dset_name = "coupling_ac_el_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),H5_COL)
     dset_name = "coupling_ac_el_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),H5_COL)
     dset_name = "coupling_ac_el_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),H5_COL)
   endif
 
   ! acoustic-poroelastic coupling surface
   dset_name = "num_coupling_ac_po_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_ac_po_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_ac_po_faces/), (/myrank/),H5_COL)
 
   if (sum(offset_num_coupling_ac_po_faces) > 0) then
     dset_name = "coupling_ac_po_ispec" ! 1 i (/offset_num_coupling_ac_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_po_ispec, &
-            (/sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_ac_po_ijk" ! 3 i (/0,0,offset_num_coupling_ac_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_po_ijk, &
-            (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_ac_po_jacobian2Dw" ! 2 r (/0,offset_num_coupling_ac_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_po_jacobian2Dw, &
-            (/0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_ac_po_normal" ! 3 r (/0,0,offset_num_coupling_ac_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_po_normal, &
-            (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_ac_po_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),H5_COL)
     dset_name = "coupling_ac_po_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),H5_COL)
     dset_name = "coupling_ac_po_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),H5_COL)
     dset_name = "coupling_ac_po_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),H5_COL)
   endif
 
   ! elastic-poroelastic coupling surface
   dset_name = "num_coupling_el_po_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_el_po_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_el_po_faces/), (/myrank/),H5_COL)
 
   if (sum(offset_num_coupling_el_po_faces) > 0) then
     dset_name = "coupling_el_po_ispec" ! 1 i (/offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_el_po_ispec, &
-            (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_po_el_ispec" ! 1 i (/offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_po_el_ispec, &
-            (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_el_po_ijk" ! 3 i (/0,0,offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_el_po_ijk, &
-            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_po_el_ijk" ! 3 i (/0,0,offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_po_el_ijk, &
-            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_el_po_jacobian2Dw" ! 2 r (/0,offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_el_po_jacobian2Dw, &
-            (/0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
     dset_name = "coupling_el_po_normal" ! 3 r (/0,0,offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_el_po_normal, &
-            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
   else
     dset_name = "coupling_el_po_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),H5_COL)
     dset_name = "coupling_po_el_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),H5_COL)
     dset_name = "coupling_el_po_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),H5_COL)
     dset_name = "coupling_po_el_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),H5_COL)
     dset_name = "coupling_el_po_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),H5_COL)
     dset_name = "coupling_el_po_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),H5_COL)
   endif
 
   dset_name = "num_interfaces_ext_mesh" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_interfaces_ext_mesh/), (/myrank/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_interfaces_ext_mesh/), (/myrank/),H5_COL)
 
   if (sum(offset_num_interfaces_ext_mesh) > 0) then
     dset_name = "max_nibool_interfaces_ext_mesh" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/max_nibool_interfaces_ext_mesh/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/max_nibool_interfaces_ext_mesh/), (/myrank/),H5_COL)
     dset_name = "my_neighbors_ext_mesh" ! 1 i (/offset_num_interfaces_ext_mesh/)
     call h5_write_dataset_collect_hyperslab(dset_name, my_neighbors_ext_mesh, &
-            (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),H5_COL)
     dset_name = "nibool_interfaces_ext_mesh" ! 1 i (/myrank/)
     call h5_write_dataset_collect_hyperslab(dset_name, nibool_interfaces_ext_mesh, &
-            (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),H5_COL)
     dset_name = "ibool_interfaces_ext_mesh_dummy" ! 2 i (/offset_max_ni_bool_interfaces_ext_mesh/)
     call h5_write_dataset_collect_hyperslab(dset_name, ibool_interfaces_ext_mesh_dummy, &
-            (/0,sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/0,sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),H5_COL)
   else
     dset_name = "max_nibool_interfaces_ext_mesh" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),H5_COL)
     dset_name = "my_neighbors_ext_mesh" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),H5_COL)
     dset_name = "nibool_interfaces_ext_mesh" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),H5_COL)
     dset_name = "ibool_interfaces_ext_mesh_dummy" ! 2 i (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy, (/myrank/),H5_COL)
   endif
 
   ! anisotropy
   if (ELASTIC_SIMULATION .and. ANISOTROPY) then
     dset_name = "c11store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c11store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c11store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c12store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c12store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c12store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c13store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c13store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c13store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c14store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c14store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c14store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c15store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c15store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c15store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c16store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c16store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c16store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c22store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c22store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c22store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c23store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c23store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c23store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c24store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c24store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c24store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c25store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c25store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c25store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c26store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c26store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c26store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c33store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c33store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c33store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c34store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c34store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c34store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c35store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c35store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c35store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c36store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c36store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c36store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c44store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c44store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c44store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c45store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c45store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c45store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c46store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c46store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c46store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c55store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c55store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c55store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c56store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c56store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c56store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     dset_name = "c66store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c66store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, c66store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
   endif
 
   ! inner/outer elements
   dset_name = "ispec_is_inner" ! 1 l (/offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_inner,(/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_inner,(/sum(offset_nspec(0:myrank-1))/),H5_COL)
 
   if (ACOUSTIC_SIMULATION) then
      dset_name = "nspec_inner_acoustic" ! 1 i (/myrank/)
-     call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
+     call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_acoustic/),(/myrank/),H5_COL)
      dset_name = "nspec_outer_acoustic" ! 1 i (/myrank/)
-     call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
+     call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_acoustic/),(/myrank/),H5_COL)
      dset_name = "num_phase_ispec_acoustic" ! 1 i (/myrank/)
-     call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
+     call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_acoustic/),(/myrank/),H5_COL)
     if (sum(offset_num_phase_ispec_acoustic) > 0) then
       dset_name = "phase_ispec_inner_acoustic" ! 2 i (/offset_num_phase_ispec_acoustic, 0/)
       call h5_write_dataset_collect_hyperslab(dset_name, phase_ispec_inner_acoustic, &
-              (/sum(offset_num_phase_ispec_acoustic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_phase_ispec_acoustic(0:myrank-1)),0/),H5_COL)
     else
       dset_name = "phase_ispec_inner_acoustic" ! 2 i (/myrank,0/)
-      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),H5_COL)
     endif
   endif
 
   if (ELASTIC_SIMULATION) then
     dset_name = "nspec_inner_elastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_elastic/),(/myrank/),H5_COL)
     dset_name = "nspec_outer_elastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_elastic/),(/myrank/),H5_COL)
     dset_name = "num_phase_ispec_elastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_elastic/),(/myrank/),H5_COL)
     if (sum(offset_num_phase_ispec_elastic) > 0) then
       dset_name = "phase_ispec_inner_elastic" ! 2 i (/offset_num_phase_ispec_elastic,0/)
       call h5_write_dataset_collect_hyperslab(dset_name, phase_ispec_inner_elastic, &
-              (/sum(offset_num_phase_ispec_elastic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_phase_ispec_elastic(0:myrank-1)),0/),H5_COL)
     else
       dset_name = "phase_ispec_inner_elastic" ! 2 i (/myrank, 0/)
-      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),H5_COL)
     endif
   endif
 
   if (POROELASTIC_SIMULATION) then
     dset_name = "nspec_inner_poroelastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_poroelastic/),(/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_poroelastic/),(/myrank/),H5_COL)
     dset_name = "nspec_outer_poroelastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_poroelastic/),(/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_poroelastic/),(/myrank/),H5_COL)
     dset_name = "num_phase_ispec_poroelastic" ! 1 i (/myrank/)
     call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_poroelastic/), &
-            (/myrank/),HDF5_IO_COLLECTIVE)
+            (/myrank/),H5_COL)
     if (sum(offset_num_phase_ispec_poroelastic) > 0) then
       dset_name = "phase_ispec_inner_poroelastic" ! 2 i (/offset_num_phase_ispec_poroelastic/)
       call h5_write_dataset_collect_hyperslab(dset_name, phase_ispec_inner_poroelastic, &
-            (/sum(offset_num_phase_ispec_poroelastic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
+            (/sum(offset_num_phase_ispec_poroelastic(0:myrank-1)),0/),H5_COL)
       dset_name = "phase_ispec_inner_poroelastic" ! 2 i (/myrank,0/)
-      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),HDF5_IO_COLLECTIVE)
+      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),H5_COL)
     endif
   endif
 
@@ -1411,51 +1411,51 @@
     if (ACOUSTIC_SIMULATION) then
       dset_name = "num_colors_outer_acoustic" ! 1 i (/myrank/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              (/num_colors_outer_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
+              (/num_colors_outer_acoustic/),(/myrank/),H5_COL)
       dset_name = "num_colors_inner_acoustic" ! 1 i (/myrank/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              (/num_colors_inner_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
+              (/num_colors_inner_acoustic/),(/myrank/),H5_COL)
       dset_name = "num_elem_colors_acoustic" ! 1 i (/offset_num_colors_outer_acoustic+num_colors_inner_acoustic/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              num_elem_colors_acoustic,(/sum(offset_num_colors_acoustic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              num_elem_colors_acoustic,(/sum(offset_num_colors_acoustic(0:myrank-1))/),H5_COL)
     endif
     if (ELASTIC_SIMULATION) then
       dset_name = "num_colors_outer_elastic" ! 1 i (/myrank/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              (/num_colors_outer_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
+              (/num_colors_outer_elastic/),(/myrank/),H5_COL)
       dset_name = "num_colors_inner_elastic" ! 1 i (/myrank/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              (/num_colors_inner_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
+              (/num_colors_inner_elastic/),(/myrank/),H5_COL)
       dset_name = "num_elem_colors_elastic" ! 1 i (/offset_num_colors_outer_elastic+num_colors_inner_elastic/)
       call h5_write_dataset_collect_hyperslab(dset_name, num_elem_colors_elastic, &
-              (/sum(offset_num_colors_elastic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_colors_elastic(0:myrank-1))/),H5_COL)
     endif
   endif
 
   ! surface points
   dset_name = "nfaces_surface" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nfaces_surface/), (/myrank/), HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nfaces_surface/), (/myrank/), H5_COL)
   dset_name = "ispec_is_surface_external_mesh" ! 1 l (/offset_nspec_ab/)
   call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_surface_external_mesh, &
-          (/sum(offset_nspec_ab(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+          (/sum(offset_nspec_ab(0:myrank-1))/), H5_COL)
   dset_name = "iglob_is_surface_external_mesh" ! 1 l (/offset_nglob_ab/)
   call h5_write_dataset_collect_hyperslab(dset_name, iglob_is_surface_external_mesh, &
-          (/sum(offset_nglob_ab(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+          (/sum(offset_nglob_ab(0:myrank-1))/), H5_COL)
 
   ! mesh adjacency
   dset_name = "num_neighbors_all" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_neighbors_all/), (/myrank/), HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_neighbors_all/), (/myrank/), H5_COL)
   dset_name = "neighbors_xadj" ! 1 i (/offset_nspec_ab+1/)
   call h5_write_dataset_collect_hyperslab(dset_name, neighbors_xadj, &
-          (/sum(offset_neighbors_xadj(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+          (/sum(offset_neighbors_xadj(0:myrank-1))/), H5_COL)
   dset_name = "neighbors_adjncy" ! 1 i (/offset_num_neighbors_all/)
   call h5_write_dataset_collect_hyperslab(dset_name, neighbors_adjncy, &
-          (/sum(offset_neighbors_adjncy(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+          (/sum(offset_neighbors_adjncy(0:myrank-1))/), H5_COL)
 
   ! arrays for visualization
   dset_name = "spec_elm_conn_xdmf" ! 2 i (/0,offset_nspec*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)/)
   call h5_write_dataset_collect_hyperslab(dset_name, spec_elm_conn_xdmf, &
-          (/0,sum(offset_nspec(0:myrank-1))*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)/), HDF5_IO_COLLECTIVE)
+          (/0,sum(offset_nspec(0:myrank-1))*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)/), H5_COL)
 
   ! stores arrays in binary files
   !if (SAVE_MESH_FILES) then

--- a/src/generate_databases/save_arrays_solver_hdf5.F90
+++ b/src/generate_databases/save_arrays_solver_hdf5.F90
@@ -86,9 +86,6 @@
   ! MPI variables
   integer :: info, comm
 
-  ! if collective write
-  logical :: if_col = .true.
-
   ! hdf5 valiables
   character(len=64) :: dset_name, tempstr
 
@@ -135,9 +132,6 @@
   integer, dimension(0:NPROC-1) :: offset_nglob_ab
   integer, dimension(0:NPROC-1) :: offset_neighbors_xadj
   integer, dimension(0:NPROC-1) :: offset_neighbors_adjncy
-
-  ! use global setting for io mode
-  if_col = HDF5_IO_COLLECTIVE
 
   ! saves mesh file external_mesh.h5
   tempstr = "/external_mesh.h5"
@@ -898,149 +892,149 @@
     call flush_IMAIN()
   endif
 
-  ! set dwrite flagif_colto pre_define the dataset on file before write.
+  ! set dwrite flagHDF5_IO_COLLECTIVEto pre_define the dataset on file before write.
 
   dset_name = "nspec" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/nspec_ab/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/nspec_ab/), (/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "nglob" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/nglob_ab/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/nglob_ab/), (/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "nspec_irregular" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/nspec_irregular/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/nspec_irregular/), (/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "ibool" ! 4 i (/0,0,0, offset_nglobs/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ibool, (/0,0,0,sum(offset_nglob(0:myrank-1))/), if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, ibool, (/0,0,0,sum(offset_nglob(0:myrank-1))/), HDF5_IO_COLLECTIVE)
   dset_name = "xstore_unique" ! 1 r (/offset_nglobs/)
-  call h5_write_dataset_collect_hyperslab(dset_name,xstore_unique,(/sum(offset_nglob(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,xstore_unique,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "ystore_unique" ! 1 r (/offset_nglobs/)
-  call h5_write_dataset_collect_hyperslab(dset_name,ystore_unique,(/sum(offset_nglob(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,ystore_unique,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "zstore_unique" ! 1 r (/offset_nglobs/)
-  call h5_write_dataset_collect_hyperslab(dset_name,zstore_unique,(/sum(offset_nglob(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,zstore_unique,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "irregular_element_number" ! 1 i (/offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,irregular_element_number,(/sum(offset_nspec(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,irregular_element_number,(/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "xix_regular" ! 1 r (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/xix_regular/),(/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/xix_regular/),(/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "jacobian_regular" ! 1 r (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name,(/jacobian_regular/),(/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,(/jacobian_regular/),(/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "xixstore" ! 4 r  (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,xixstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,xixstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "xiystore" ! 4 r  (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,xiystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,xiystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "xizstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,xizstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,xizstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "etaxstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,etaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,etaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "etaystore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,etaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,etaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "etazstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,etazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,etazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "gammaxstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,gammaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,gammaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "gammaystore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,gammaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,gammaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "gammazstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,gammazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,gammazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "jacobianstore" ! 4 r (/0,0,0,offset_nspec_irregular = offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,jacobianstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,jacobianstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "kappastore" ! 4 r (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,kappastore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,kappastore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "mustore" ! 4 r (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name,mustore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name,mustore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "ispec_is_acoustic" ! 1 l (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_acoustic, (/sum(offset_nspec(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_acoustic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "ispec_is_elastic" ! 1 l (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_elastic, (/sum(offset_nspec(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_elastic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   dset_name = "ispec_is_poroelastic" ! 1 l (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_poroelastic, (/sum(offset_nspec(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_poroelastic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
 
   ! acoustic
   if (ACOUSTIC_SIMULATION) then
     dset_name = "rmass_acoustic" ! 1 r (/offset_nglob/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rmass_acoustic,(/sum(offset_nglob(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rmass_acoustic,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
 
   ! this array is needed for acoustic simulations but also for elastic simulations with CPML,
   ! thus we allocate it and read it in all cases (whether the simulation is acoustic, elastic, or acoustic/elastic)
   dset_name = "rhostore" ! 4 r (/0,0,0,offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, rhostore, (/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, rhostore, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
 
   ! elastic
   if (ELASTIC_SIMULATION) then
     dset_name = "rmass" ! 1 r (/offset_nglob/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rmass, (/sum(offset_nglob(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rmass, (/sum(offset_nglob(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     if (APPROXIMATE_OCEAN_LOAD) then
       dset_name = "rmass_ocean_load" ! 1 r (/offset_nglob_ocean/)
-      call h5_write_dataset_collect_hyperslab(dset_name, rmass_ocean_load, (/sum(offset_nglob_ocean(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, rmass_ocean_load, (/sum(offset_nglob_ocean(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     !pll Stacey
     dset_name = "rho_vp" ! 4 r (/0,0,0,offset_nspec/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vp, (/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vp, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "rho_vs" ! 4 r (/0,0,0,offset_nspec/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vs, (/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vs, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
 
   ! poroelastic
   if (POROELASTIC_SIMULATION) then
     dset_name = "rmass_solid_poroelastic" ! 1 r (/offset_nglob/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rmass_solid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rmass_solid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "rmass_fluid_poroelastic" ! 1 r (/offset_nglob/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rmass_fluid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rmass_fluid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "rhoarraystore" ! 5 r (/0,0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rhoarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rhoarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "kappaarraystore" ! 5 r (/0,0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, kappaarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, kappaarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "etastore" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, etastore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, etastore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "tortstore" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, tortstore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, tortstore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "permstore" ! 5 r (/0,0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, permstore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, permstore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "phistore" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, phistore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, phistore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "rho_vpI" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vpI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vpI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "rho_vpII" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vpII, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vpII, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "rho_vsI" ! 4 r (/0,0,0,offset_nspecporo/)
-    call h5_write_dataset_collect_hyperslab(dset_name, rho_vsI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, rho_vsI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
 
   ! C-PML absorbing boundary conditions
   if (PML_CONDITIONS) then
     dset_name = "nspec_cpml" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_cpml/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_cpml/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "CPML_width_x" ! 1 r (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_x/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_x/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "CPML_width_y" ! 1 r (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_y/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_y/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "CPML_width_z" ! 1 r (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_z/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/CPML_width_z/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "min_distance_between_CPML_parameter" ! 1 r (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/min_distance_between_CPML_parameter/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/min_distance_between_CPML_parameter/), (/myrank/),HDF5_IO_COLLECTIVE)
 
     if (sum(offset_nspeccpml) > 0) then
       dset_name = "CPML_regions" ! 1 i (/offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, CPML_regions, (/sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, CPML_regions, (/sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "CPML_to_spec" ! 1 i (/offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, CPML_to_spec, (/sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, CPML_to_spec, (/sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "is_CPML" ! 1 l (/offset_nspecab/)
-      call h5_write_dataset_collect_hyperslab(dset_name, is_CPML, (/sum(offset_nspec_ab(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, is_CPML, (/sum(offset_nspec_ab(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "d_store_x" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, d_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, d_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "d_store_y" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, d_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, d_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "d_store_z" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, d_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, d_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "k_store_x" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, k_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, k_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "k_store_y" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, k_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, k_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "k_store_z" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, k_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, k_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "alpha_store_x" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "alpha_store_y" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dset_name = "alpha_store_z" ! 4 r (/0,0,0,offset_nspeccpml/)
-      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, alpha_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
 
       ! --------------------------------------------------------------------------------------------
       ! for adjoint tomography
@@ -1048,18 +1042,18 @@
       ! --------------------------------------------------------------------------------------------
       if ((SIMULATION_TYPE == 1 .and. SAVE_FORWARD) .or. SIMULATION_TYPE == 3) then
         dset_name = "nglob_interface_PML_acoustic" ! 1 i (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/nglob_interface_PML_acoustic/), (/myrank/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/nglob_interface_PML_acoustic/), (/myrank/),HDF5_IO_COLLECTIVE)
         dset_name = "nglob_interface_PML_elastic" ! 1 i (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/nglob_interface_PML_elastic/), (/myrank/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/nglob_interface_PML_elastic/), (/myrank/),HDF5_IO_COLLECTIVE)
         if (sum(offset_nglob_interface_PML_acoustic) > 0) then
           dset_name = "points_interface_PML_acoustic" ! 1 i (/offset_nglob_interface_PML_acoustic/)
           call h5_write_dataset_collect_hyperslab(dset_name, &
-              points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_acoustic(0:myrank-1))/),if_col)
+              points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_acoustic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         endif
         if (sum(offset_nglob_interface_PML_elastic) > 0) then
           dset_name = "points_interface_PML_elastic" ! 1 i (/offset_nglob_interface_PML_elastic/)
           call h5_write_dataset_collect_hyperslab(dset_name, &
-              points_interface_PML_elastic, (/sum(offset_nglob_interface_PML_elastic(0:myrank-1))/),if_col)
+              points_interface_PML_elastic, (/sum(offset_nglob_interface_PML_elastic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         endif
       endif
     endif
@@ -1067,348 +1061,348 @@
 
   ! absorbing boundary surface
   dset_name = "num_abs_boundary_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_abs_boundary_faces/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_abs_boundary_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
 
   if (sum(offset_num_abs_boundary_faces) > 0) then
     dset_name = "abs_boundary_ispec" ! 1 i (/offset_num_abs_boundary_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, abs_boundary_ispec, &
-            (/sum(offset_num_abs_boundary_faces(0:myrank-1))/),if_col)
+            (/sum(offset_num_abs_boundary_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "abs_boundary_ijk" ! 3 i (/0,0,offset_num_abs_boundary_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, abs_boundary_ijk, &
-            (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), if_col)
+            (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "abs_boundary_jacobian2Dw" ! 2 r (/0,offset_num_abs_boundary_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, abs_boundary_jacobian2Dw, &
-            (/0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), if_col)
+            (/0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "abs_boundary_normal" ! 3 r (/0,0,offset_num_abs_boundary_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, abs_boundary_normal, &
-            (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), if_col)
+            (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
 
     if (STACEY_ABSORBING_CONDITIONS .and. (.not. PML_CONDITIONS)) then
       ! store mass matrix contributions
       if (ELASTIC_SIMULATION) then
         dset_name = "rmassx" ! 1 r (/offset_nglob_xy/)
-        call h5_write_dataset_collect_hyperslab(dset_name, rmassx, (/sum(offset_nglob_xy(0:myrank-1))/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, rmassx, (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dset_name = "rmassy" ! 1 r (/offset_nglob_xy/)
-        call h5_write_dataset_collect_hyperslab(dset_name, rmassy, (/sum(offset_nglob_xy(0:myrank-1))/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, rmassy, (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dset_name = "rmassz" ! 1 r (/offset_nglob_xy/)
-        call h5_write_dataset_collect_hyperslab(dset_name, rmassz, (/sum(offset_nglob_xy(0:myrank-1))/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, rmassz, (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
      endif
       if (ACOUSTIC_SIMULATION) then
         dset_name = "rmassz_acoustic" ! 1 r (/offset_nglob_xy/)
-        call h5_write_dataset_collect_hyperslab(dset_name, rmassz_acoustic, (/sum(offset_nglob_xy(0:myrank-1))/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, rmassz_acoustic, (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
      endif
     endif
   else
     dset_name = "abs_boundary_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "abs_boundary_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "abs_boundary_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "abs_boundary_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
 
     if (STACEY_ABSORBING_CONDITIONS .and. (.not. PML_CONDITIONS)) then
       ! store mass matrix contributions
       if (ELASTIC_SIMULATION) then
         dset_name = "rmassx" ! 1 r (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),HDF5_IO_COLLECTIVE)
         dset_name = "rmassy" ! 1 r (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),HDF5_IO_COLLECTIVE)
         dset_name = "rmassz" ! 1 r (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),HDF5_IO_COLLECTIVE)
       endif
       if (ACOUSTIC_SIMULATION) then
         dset_name = "rmassz_acoustic" ! 1 r (/myrank/)
-        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),if_col)
+        call h5_write_dataset_collect_hyperslab(dset_name, (/0.0/), (/myrank/),HDF5_IO_COLLECTIVE)
       endif
     endif
 
   endif
 
   dset_name = "nspec2D_xmin" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_xmin/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_xmin/), (/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "nspec2D_xmax" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_xmax/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_xmax/), (/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "nspec2D_ymin" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_ymin/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_ymin/), (/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "nspec2D_ymax" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_ymax/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_ymax/), (/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "NSPEC2D_BOTTOM" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_bottom/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_bottom/), (/myrank/),HDF5_IO_COLLECTIVE)
   dset_name = "NSPEC2D_TOP" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_top/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nspec2D_top/), (/myrank/),HDF5_IO_COLLECTIVE)
 
   if (sum(offset_nspec2D_xmin) > 0) then
     dset_name = "ibelm_xmin" ! 1 i (/offset_nspec2D_xmin/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
   if (sum(offset_nspec2D_xmax) > 0) then
     dset_name = "ibelm_xmax" ! 1 i (/offset_nspec2D_xmax/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
   if (sum(offset_nspec2D_ymin) > 0) then
     dset_name = "ibelm_ymin" ! 1 i (/offset_nspec2D_ymin/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
   if (sum(offset_nspec2D_ymax) > 0) then
     dset_name = "ibelm_ymax" ! 1 i (/offset_nspec2D_ymax/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
   if (sum(offset_nspec2D_bottom_ext) > 0) then
     dset_name = "ibelm_bottom" ! 1 i (/offset_nspec2D_bottom_ext/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
   if (sum(offset_nspec2D_top_ext) > 0) then
     dset_name = "ibelm_top" ! 1 i (/offset_nspec2D_top_ext/)
-    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
 
   ! free surface
   dset_name = "num_free_surface_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_free_surface_faces/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_free_surface_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
 
   if (sum(offset_num_free_surface_faces) > 0) then
     dset_name = "free_surface_ispec" ! 1 i (/offset_num_free_surface_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, free_surface_ispec, &
-            (/sum(offset_num_free_surface_faces(0:myrank-1))/),if_col)
+            (/sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "free_surface_ijk" ! 3 i (/0,0,offset_num_free_surface_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, free_surface_ijk, &
-            (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),if_col)
+            (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "free_surface_jacobian2Dw" ! 2 r (/0,offset_num_free_surface_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, free_surface_jacobian2Dw, &
-            (/0,sum(offset_num_free_surface_faces(0:myrank-1))/),if_col)
+            (/0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "free_surface_normal" ! 3 r (/0,0,offset_num_free_surface_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, free_surface_normal, &
-            (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),if_col)
+            (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   else
     dset_name = "free_surface_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "free_surface_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "free_surface_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "free_surface_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
   endif
 
   ! acoustic-elastic coupling surface
   dset_name = "num_coupling_ac_el_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_ac_el_faces/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_ac_el_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
 
   if (sum(offset_num_coupling_ac_el_faces) > 0) then
     dset_name = "coupling_ac_el_ispec" ! 1 i (/offset_num_coupling_ac_el_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_el_ispec, &
-              (/sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),if_col)
+              (/sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_el_ijk" ! 3 i (/0,0,offset_num_coupling_ac_el_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_el_ijk, &
-              (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),if_col)
+              (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_el_jacobian2Dw" ! 2 r (/0,offset_num_coupling_ac_el_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_el_jacobian2Dw, &
-             (/0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),if_col)
+             (/0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_el_normal" ! 3 r (/0,0,offset_num_coupling_ac_el_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_el_normal, &
-             (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),if_col)
+             (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   else
     dset_name = "coupling_ac_el_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_el_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_el_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_el_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
   endif
 
   ! acoustic-poroelastic coupling surface
   dset_name = "num_coupling_ac_po_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_ac_po_faces/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_ac_po_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
 
   if (sum(offset_num_coupling_ac_po_faces) > 0) then
     dset_name = "coupling_ac_po_ispec" ! 1 i (/offset_num_coupling_ac_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_po_ispec, &
-            (/sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),if_col)
+            (/sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_po_ijk" ! 3 i (/0,0,offset_num_coupling_ac_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_po_ijk, &
-            (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),if_col)
+            (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_po_jacobian2Dw" ! 2 r (/0,offset_num_coupling_ac_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_po_jacobian2Dw, &
-            (/0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),if_col)
+            (/0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_po_normal" ! 3 r (/0,0,offset_num_coupling_ac_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_ac_po_normal, &
-            (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),if_col)
+            (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_po_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_po_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_po_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_ac_po_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
   endif
 
   ! elastic-poroelastic coupling surface
   dset_name = "num_coupling_el_po_faces" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_el_po_faces/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_coupling_el_po_faces/), (/myrank/),HDF5_IO_COLLECTIVE)
 
   if (sum(offset_num_coupling_el_po_faces) > 0) then
     dset_name = "coupling_el_po_ispec" ! 1 i (/offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_el_po_ispec, &
-            (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+            (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_po_el_ispec" ! 1 i (/offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_po_el_ispec, &
-            (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+            (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_el_po_ijk" ! 3 i (/0,0,offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_el_po_ijk, &
-            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_po_el_ijk" ! 3 i (/0,0,offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_po_el_ijk, &
-            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_el_po_jacobian2Dw" ! 2 r (/0,offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_el_po_jacobian2Dw, &
-            (/0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+            (/0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_el_po_normal" ! 3 r (/0,0,offset_num_coupling_el_po_faces/)
     call h5_write_dataset_collect_hyperslab(dset_name, coupling_el_po_normal, &
-            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+            (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   else
     dset_name = "coupling_el_po_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_po_el_ispec" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_el_po_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_po_el_ijk" ! 3 i (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, i3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_el_po_jacobian2Dw" ! 2 r (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r2d_dummy, (/0,myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "coupling_el_po_normal" ! 3 r (/0,0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, r3d_dummy, (/0,0,myrank/),HDF5_IO_COLLECTIVE)
   endif
 
   dset_name = "num_interfaces_ext_mesh" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_interfaces_ext_mesh/), (/myrank/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_interfaces_ext_mesh/), (/myrank/),HDF5_IO_COLLECTIVE)
 
   if (sum(offset_num_interfaces_ext_mesh) > 0) then
     dset_name = "max_nibool_interfaces_ext_mesh" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/max_nibool_interfaces_ext_mesh/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/max_nibool_interfaces_ext_mesh/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "my_neighbors_ext_mesh" ! 1 i (/offset_num_interfaces_ext_mesh/)
     call h5_write_dataset_collect_hyperslab(dset_name, my_neighbors_ext_mesh, &
-            (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),if_col)
+            (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "nibool_interfaces_ext_mesh" ! 1 i (/myrank/)
     call h5_write_dataset_collect_hyperslab(dset_name, nibool_interfaces_ext_mesh, &
-            (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),if_col)
+            (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dset_name = "ibool_interfaces_ext_mesh_dummy" ! 2 i (/offset_max_ni_bool_interfaces_ext_mesh/)
     call h5_write_dataset_collect_hyperslab(dset_name, ibool_interfaces_ext_mesh_dummy, &
-            (/0,sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),if_col)
+            (/0,sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   else
     dset_name = "max_nibool_interfaces_ext_mesh" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "my_neighbors_ext_mesh" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "nibool_interfaces_ext_mesh" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/0/), (/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "ibool_interfaces_ext_mesh_dummy" ! 2 i (/0,myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy, (/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy, (/myrank/),HDF5_IO_COLLECTIVE)
   endif
 
   ! anisotropy
   if (ELASTIC_SIMULATION .and. ANISOTROPY) then
     dset_name = "c11store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c11store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c11store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c12store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c12store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c12store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c13store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c13store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c13store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c14store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c14store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c14store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c15store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c15store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c15store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c16store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c16store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c16store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c22store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c22store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c22store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c23store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c23store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c23store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c24store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c24store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c24store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c25store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c25store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c25store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c26store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c26store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c26store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c33store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c33store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c33store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c34store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c34store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c34store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c35store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c35store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c35store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c36store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c36store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c36store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c44store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c44store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c44store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c45store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c45store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c45store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c46store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c46store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c46store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c55store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c55store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c55store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c56store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c56store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c56store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dset_name = "c66store" ! 4 r (/0,0,0,offset_nspec_aniso/)
-    call h5_write_dataset_collect_hyperslab(dset_name, c66store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, c66store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
   endif
 
   ! inner/outer elements
   dset_name = "ispec_is_inner" ! 1 l (/offset_nspec/)
-  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_inner,(/sum(offset_nspec(0:myrank-1))/),if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_inner,(/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
 
   if (ACOUSTIC_SIMULATION) then
      dset_name = "nspec_inner_acoustic" ! 1 i (/myrank/)
-     call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_acoustic/),(/myrank/),if_col)
+     call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
      dset_name = "nspec_outer_acoustic" ! 1 i (/myrank/)
-     call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_acoustic/),(/myrank/),if_col)
+     call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
      dset_name = "num_phase_ispec_acoustic" ! 1 i (/myrank/)
-     call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_acoustic/),(/myrank/),if_col)
+     call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
     if (sum(offset_num_phase_ispec_acoustic) > 0) then
       dset_name = "phase_ispec_inner_acoustic" ! 2 i (/offset_num_phase_ispec_acoustic, 0/)
       call h5_write_dataset_collect_hyperslab(dset_name, phase_ispec_inner_acoustic, &
-              (/sum(offset_num_phase_ispec_acoustic(0:myrank-1)),0/),if_col)
+              (/sum(offset_num_phase_ispec_acoustic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
     else
       dset_name = "phase_ispec_inner_acoustic" ! 2 i (/myrank,0/)
-      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),HDF5_IO_COLLECTIVE)
     endif
   endif
 
   if (ELASTIC_SIMULATION) then
     dset_name = "nspec_inner_elastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_elastic/),(/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "nspec_outer_elastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_elastic/),(/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "num_phase_ispec_elastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_elastic/),(/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
     if (sum(offset_num_phase_ispec_elastic) > 0) then
       dset_name = "phase_ispec_inner_elastic" ! 2 i (/offset_num_phase_ispec_elastic,0/)
       call h5_write_dataset_collect_hyperslab(dset_name, phase_ispec_inner_elastic, &
-              (/sum(offset_num_phase_ispec_elastic(0:myrank-1)),0/),if_col)
+              (/sum(offset_num_phase_ispec_elastic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
     else
       dset_name = "phase_ispec_inner_elastic" ! 2 i (/myrank, 0/)
-      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),HDF5_IO_COLLECTIVE)
     endif
   endif
 
   if (POROELASTIC_SIMULATION) then
     dset_name = "nspec_inner_poroelastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_poroelastic/),(/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_inner_poroelastic/),(/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "nspec_outer_poroelastic" ! 1 i (/myrank/)
-    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_poroelastic/),(/myrank/),if_col)
+    call h5_write_dataset_collect_hyperslab(dset_name, (/nspec_outer_poroelastic/),(/myrank/),HDF5_IO_COLLECTIVE)
     dset_name = "num_phase_ispec_poroelastic" ! 1 i (/myrank/)
     call h5_write_dataset_collect_hyperslab(dset_name, (/num_phase_ispec_poroelastic/), &
-            (/myrank/),if_col)
+            (/myrank/),HDF5_IO_COLLECTIVE)
     if (sum(offset_num_phase_ispec_poroelastic) > 0) then
       dset_name = "phase_ispec_inner_poroelastic" ! 2 i (/offset_num_phase_ispec_poroelastic/)
       call h5_write_dataset_collect_hyperslab(dset_name, phase_ispec_inner_poroelastic, &
-            (/sum(offset_num_phase_ispec_poroelastic(0:myrank-1)),0/),if_col)
+            (/sum(offset_num_phase_ispec_poroelastic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
       dset_name = "phase_ispec_inner_poroelastic" ! 2 i (/myrank,0/)
-      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),if_col)
+      call h5_write_dataset_collect_hyperslab(dset_name, i2d_dummy,(/myrank,0/),HDF5_IO_COLLECTIVE)
     endif
   endif
 
@@ -1417,51 +1411,51 @@
     if (ACOUSTIC_SIMULATION) then
       dset_name = "num_colors_outer_acoustic" ! 1 i (/myrank/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              (/num_colors_outer_acoustic/),(/myrank/),if_col)
+              (/num_colors_outer_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
       dset_name = "num_colors_inner_acoustic" ! 1 i (/myrank/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              (/num_colors_inner_acoustic/),(/myrank/),if_col)
+              (/num_colors_inner_acoustic/),(/myrank/),HDF5_IO_COLLECTIVE)
       dset_name = "num_elem_colors_acoustic" ! 1 i (/offset_num_colors_outer_acoustic+num_colors_inner_acoustic/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              num_elem_colors_acoustic,(/sum(offset_num_colors_acoustic(0:myrank-1))/),if_col)
+              num_elem_colors_acoustic,(/sum(offset_num_colors_acoustic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (ELASTIC_SIMULATION) then
       dset_name = "num_colors_outer_elastic" ! 1 i (/myrank/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              (/num_colors_outer_elastic/),(/myrank/),if_col)
+              (/num_colors_outer_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
       dset_name = "num_colors_inner_elastic" ! 1 i (/myrank/)
       call h5_write_dataset_collect_hyperslab(dset_name, &
-              (/num_colors_inner_elastic/),(/myrank/),if_col)
+              (/num_colors_inner_elastic/),(/myrank/),HDF5_IO_COLLECTIVE)
       dset_name = "num_elem_colors_elastic" ! 1 i (/offset_num_colors_outer_elastic+num_colors_inner_elastic/)
       call h5_write_dataset_collect_hyperslab(dset_name, num_elem_colors_elastic, &
-              (/sum(offset_num_colors_elastic(0:myrank-1))/),if_col)
+              (/sum(offset_num_colors_elastic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
   endif
 
   ! surface points
   dset_name = "nfaces_surface" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/nfaces_surface/), (/myrank/), if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/nfaces_surface/), (/myrank/), HDF5_IO_COLLECTIVE)
   dset_name = "ispec_is_surface_external_mesh" ! 1 l (/offset_nspec_ab/)
   call h5_write_dataset_collect_hyperslab(dset_name, ispec_is_surface_external_mesh, &
-          (/sum(offset_nspec_ab(0:myrank-1))/), if_col)
+          (/sum(offset_nspec_ab(0:myrank-1))/), HDF5_IO_COLLECTIVE)
   dset_name = "iglob_is_surface_external_mesh" ! 1 l (/offset_nglob_ab/)
   call h5_write_dataset_collect_hyperslab(dset_name, iglob_is_surface_external_mesh, &
-          (/sum(offset_nglob_ab(0:myrank-1))/), if_col)
+          (/sum(offset_nglob_ab(0:myrank-1))/), HDF5_IO_COLLECTIVE)
 
   ! mesh adjacency
   dset_name = "num_neighbors_all" ! 1 i (/myrank/)
-  call h5_write_dataset_collect_hyperslab(dset_name, (/num_neighbors_all/), (/myrank/), if_col)
+  call h5_write_dataset_collect_hyperslab(dset_name, (/num_neighbors_all/), (/myrank/), HDF5_IO_COLLECTIVE)
   dset_name = "neighbors_xadj" ! 1 i (/offset_nspec_ab+1/)
   call h5_write_dataset_collect_hyperslab(dset_name, neighbors_xadj, &
-          (/sum(offset_neighbors_xadj(0:myrank-1))/), if_col)
+          (/sum(offset_neighbors_xadj(0:myrank-1))/), HDF5_IO_COLLECTIVE)
   dset_name = "neighbors_adjncy" ! 1 i (/offset_num_neighbors_all/)
   call h5_write_dataset_collect_hyperslab(dset_name, neighbors_adjncy, &
-          (/sum(offset_neighbors_adjncy(0:myrank-1))/), if_col)
+          (/sum(offset_neighbors_adjncy(0:myrank-1))/), HDF5_IO_COLLECTIVE)
 
   ! arrays for visualization
   dset_name = "spec_elm_conn_xdmf" ! 2 i (/0,offset_nspec*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)/)
   call h5_write_dataset_collect_hyperslab(dset_name, spec_elm_conn_xdmf, &
-          (/0,sum(offset_nspec(0:myrank-1))*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)/), if_col)
+          (/0,sum(offset_nspec(0:myrank-1))*(NGLLX-1)*(NGLLY-1)*(NGLLZ-1)/), HDF5_IO_COLLECTIVE)
 
   ! stores arrays in binary files
   !if (SAVE_MESH_FILES) then

--- a/src/generate_databases/save_arrays_solver_hdf5.F90
+++ b/src/generate_databases/save_arrays_solver_hdf5.F90
@@ -135,6 +135,8 @@
 
   ! avoid integer overflow
   integer(kind=8) :: sum_neighbors_adjncy, offset_neighbors_adjncy_this_proc
+  integer(kind=8), dimension(0:NPROC-1) :: offset_neighbors_adjncy_i8
+
 
   ! saves mesh file external_mesh.h5
   tempstr = "/external_mesh.h5"
@@ -249,6 +251,8 @@
   ! mesh adjacency
   call gather_all_all_singlei(nspec_ab+1,offset_neighbors_xadj,NPROC)
   call gather_all_all_singlei(num_neighbors_all,offset_neighbors_adjncy,NPROC)
+  offset_neighbors_adjncy_i8 = offset_neighbors_adjncy
+  sum_neighbors_adjncy = sum(offset_neighbors_adjncy_i8)
 
   !
   ! make datasets by main
@@ -874,7 +878,6 @@
     dset_name = "neighbors_xadj" ! 1 i (/offset_neighbors_xadj/)   ! actual array size: nspec_ab + 1
     call h5_create_dataset_gen(dset_name,(/sum(offset_neighbors_xadj(:))/), 1, 0)
     dset_name = "neighbors_adjncy" ! 1 i (/offset_neighbors_adjncy/)
-    sum_neighbors_adjncy = sum(offset_neighbors_adjncy(:)) ! to avoid integer overflow
     call h5_create_dataset_gen(dset_name,(/sum_neighbors_adjncy/), 1, 1) ! 64bit integer
 
     ! arrays for visualization
@@ -1453,7 +1456,7 @@
   call h5_write_dataset_collect_hyperslab(dset_name, neighbors_xadj, &
           (/sum(offset_neighbors_xadj(0:myrank-1))/), H5_COL)
   dset_name = "neighbors_adjncy" ! 1 i (/offset_num_neighbors_all/)
-  offset_neighbors_adjncy_this_proc = sum(offset_neighbors_adjncy(0:myrank-1))
+  offset_neighbors_adjncy_this_proc = sum(offset_neighbors_adjncy_i8(0:myrank-1))
   call h5_write_dataset_collect_hyperslab(dset_name, neighbors_adjncy, &
           (/offset_neighbors_adjncy_this_proc/), H5_COL)
 

--- a/src/generate_databases/save_arrays_solver_hdf5.F90
+++ b/src/generate_databases/save_arrays_solver_hdf5.F90
@@ -35,7 +35,8 @@
 
   use shared_parameters, only: ACOUSTIC_SIMULATION, ELASTIC_SIMULATION, POROELASTIC_SIMULATION, &
     APPROXIMATE_OCEAN_LOAD, ANISOTROPY, &
-    COUPLE_WITH_INJECTION_TECHNIQUE, MESH_A_CHUNK_OF_THE_EARTH,NPROC
+    COUPLE_WITH_INJECTION_TECHNIQUE, MESH_A_CHUNK_OF_THE_EARTH,NPROC, &
+    HDF5_IO_COLLECTIVE
 
   ! global indices
   use generate_databases_par, only: NSPEC_AB, ibool, NGLOB_AB
@@ -86,7 +87,7 @@
   integer :: info, comm
 
   ! if collective write
-  logical, parameter :: if_col = .true.
+  logical :: if_col = .true.
 
   ! hdf5 valiables
   character(len=64) :: dset_name, tempstr
@@ -134,6 +135,9 @@
   integer, dimension(0:NPROC-1) :: offset_nglob_ab
   integer, dimension(0:NPROC-1) :: offset_neighbors_xadj
   integer, dimension(0:NPROC-1) :: offset_neighbors_adjncy
+
+  ! use global setting for io mode
+  if_col = HDF5_IO_COLLECTIVE
 
   ! saves mesh file external_mesh.h5
   tempstr = "/external_mesh.h5"

--- a/src/generate_databases/save_arrays_solver_hdf5.F90
+++ b/src/generate_databases/save_arrays_solver_hdf5.F90
@@ -137,7 +137,6 @@
   integer(kind=8) :: sum_neighbors_adjncy, offset_neighbors_adjncy_this_proc
   integer(kind=8), dimension(0:NPROC-1) :: offset_neighbors_adjncy_i8
 
-
   ! saves mesh file external_mesh.h5
   tempstr = "/external_mesh.h5"
   filename = LOCAL_PATH(1:len_trim(LOCAL_PATH))//trim(tempstr)

--- a/src/shared/check_mesh_resolution.f90
+++ b/src/shared/check_mesh_resolution.f90
@@ -524,12 +524,12 @@
       if (DT_PRESENT) then
         filename = 'res_Courant_number'
         call write_checkmesh_data_hdf5(filename,tmp1)
-      else
-        ! minimum period estimate
-        filename = 'res_minimum_period'
-        call write_checkmesh_data_hdf5(filename,tmp2)
-        call write_checkmesh_xdmf_hdf5(NSPEC_AB)
       endif
+
+      ! minimum period estimate
+      filename = 'res_minimum_period'
+      call write_checkmesh_data_hdf5(filename,tmp2)
+      call write_checkmesh_xdmf_hdf5(NSPEC_AB)
     else
       ! default output
       call create_name_database(prname,myrank,LOCAL_PATH)

--- a/src/shared/hdf5_manager.F90
+++ b/src/shared/hdf5_manager.F90
@@ -194,6 +194,7 @@ module manager_hdf5
   interface h5_read_dataset_collect_hyperslab
     module procedure h5_read_dataset_1d_l_collect_hyperslab ! logical
     module procedure h5_read_dataset_1d_i_collect_hyperslab ! integer
+    module procedure h5_read_dataset_1d_i64_collect_hyperslab ! integer 64-bit
     module procedure h5_read_dataset_2d_i_collect_hyperslab
     module procedure h5_read_dataset_3d_i_collect_hyperslab
     module procedure h5_read_dataset_4d_i_collect_hyperslab
@@ -2605,7 +2606,60 @@ contains
     call h5_close_dataset()
   end subroutine h5_read_dataset_1d_i_collect_hyperslab
 
+  !
+!-------------------------------------------------------------------------------
 !
+
+  subroutine h5_read_dataset_1d_i64_collect_hyperslab(dataset_name, data, offset_in, if_collective)
+    implicit none
+    character(len=*), intent(in)                                :: dataset_name
+    integer, dimension(:), intent(inout), target                :: data
+    integer(kind=8), dimension(:), intent(in)                           :: offset_in
+    logical, intent(in)                                         :: if_collective
+    ! local parameters
+    integer                                                     :: rank = 1
+    integer(HSIZE_T), dimension(1)                              :: dim
+    integer(HSIZE_T), dimension(1)                              :: count ! size of hyperslab
+    integer(HSSIZE_T), dimension(1)                             :: offset ! the position where the datablock is inserted
+
+    dim = shape(data)
+    offset = offset_in ! convert data type
+
+    ! open dataset
+    call h5_open_dataset2(trim(dataset_name))
+
+    ! select a place where data is inserted.
+    count(1)  = dim(1)
+
+    ! select hyperslab in the file
+    call h5screate_simple_f(rank,count, mem_dspace_id, error)
+    call check_error()
+    call h5dget_space_f(dataset_id, file_dspace_id, error)
+    call check_error()
+    call h5sselect_hyperslab_f(file_dspace_id, H5S_SELECT_SET_F, offset, count, error)
+    call check_error()
+    call h5_create_dataset_prop_list(if_collective)
+
+    call h5_check_arr_dim(dim)
+
+    ! write array using Fortran pointer
+    !call h5dread_f(dataset_id, H5T_NATIVE_INTEGER, data, dim, error, &
+    !                file_space_id=file_dspace_id, mem_space_id=mem_dspace_id, xfer_prp=plist_id)
+    ! use F2003 API
+    f_ptr = c_loc(data(1))
+    call h5dread_f(dataset_id, H5T_NATIVE_INTEGER, f_ptr, error, &
+                    file_space_id=file_dspace_id, mem_space_id=mem_dspace_id, xfer_prp=plist_id)
+    if (error /= 0) write(*,*) 'hdf5 dataset write failed for ', dataset_name
+    call check_error()
+    call h5_close_prop_list(dataset_name)
+    call h5sclose_f(mem_dspace_id, error)
+    call check_error()
+    call h5sclose_f(file_dspace_id, error)
+    call check_error()
+    call h5_close_dataset()
+  end subroutine h5_read_dataset_1d_i64_collect_hyperslab
+
+
 !-------------------------------------------------------------------------------
 !
 

--- a/src/shared/hdf5_manager.F90
+++ b/src/shared/hdf5_manager.F90
@@ -410,7 +410,7 @@ contains
   subroutine write_attenuation_file_hdf5(factor_common, scale_factor, factor_common_kappa, scale_factor_kappa)
 
 #if defined(USE_HDF5)
-    use shared_parameters, only: NPROC, LOCAL_PATH
+    use shared_parameters, only: NPROC, LOCAL_PATH,H5_COL
     use constants, only: myrank,N_SLS,NGLLX,NGLLY,NGLLZ
 #endif
 
@@ -463,16 +463,16 @@ contains
     call h5_open_file_p_collect(filename)
     dset_name = "scale_factor"
     call h5_write_dataset_4d_r_collect_hyperslab(dset_name, &
-                                                 scale_factor,(/0,0,0,sum(offset_nspec(0:myrank-1))/),.true.)
+                                                 scale_factor,(/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
     dset_name = "scale_factor_kappa"
     call h5_write_dataset_4d_r_collect_hyperslab(dset_name, &
-                                                 scale_factor_kappa,(/0,0,0,sum(offset_nspec(0:myrank-1))/),.true.)
+                                                 scale_factor_kappa,(/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
     dset_name = "factor_common"
     call h5_write_dataset_5d_r_collect_hyperslab(dset_name, &
-                                                 factor_common,(/0,0,0,0,sum(offset_nspec(0:myrank-1))/),.true.)
+                                                 factor_common,(/0,0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
     dset_name = "factor_common_kappa"
     call h5_write_dataset_5d_r_collect_hyperslab(dset_name, &
-                                                 factor_common_kappa,(/0,0,0,0,sum(offset_nspec(0:myrank-1))/),.true.)
+                                                 factor_common_kappa,(/0,0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
 
     call h5_close_file_p()
     call h5_finalize()
@@ -499,7 +499,7 @@ contains
   subroutine read_attenuation_file_hdf5(factor_common, scale_factor, factor_common_kappa, scale_factor_kappa)
 
 #if defined(USE_HDF5)
-    use shared_parameters, only: NPROC, LOCAL_PATH
+    use shared_parameters, only: NPROC, LOCAL_PATH, H5_COL
     use constants, only: myrank
 #endif
 
@@ -526,16 +526,16 @@ contains
     ! open file
     call h5_open_file_p_collect(fname)
     ! read offset array
-    call h5_read_dataset_1d_i_collect_hyperslab("offset_nspec",offset_nspec, (/0/), .true.)
+    call h5_read_dataset_1d_i_collect_hyperslab("offset_nspec",offset_nspec, (/0/), H5_COL)
 
     call h5_read_dataset_4d_r_collect_hyperslab("scale_factor", scale_factor, &
-                                                (/0,0,0,sum(offset_nspec(0:myrank-1))/), .true.)
+                                                (/0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
     call h5_read_dataset_4d_r_collect_hyperslab("scale_factor_kappa", scale_factor_kappa, &
-                                                (/0,0,0,sum(offset_nspec(0:myrank-1))/), .true.)
+                                                (/0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
     call h5_read_dataset_5d_r_collect_hyperslab("factor_common", factor_common, &
-                                                (/0,0,0,0,sum(offset_nspec(0:myrank-1))/), .true.)
+                                                (/0,0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
     call h5_read_dataset_5d_r_collect_hyperslab("factor_common_kappa", factor_common_kappa, &
-                                                (/0,0,0,0,sum(offset_nspec(0:myrank-1))/), .true.)
+                                                (/0,0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
 
     call h5_close_file_p()
     call h5_finalize()
@@ -562,7 +562,7 @@ contains
   subroutine write_checkmesh_data_hdf5(dset_name,dump_array)
 
 #if defined(USE_HDF5)
-    use shared_parameters, only: LOCAL_PATH, NPROC, HDF5_IO_COLLECTIVE
+    use shared_parameters, only: LOCAL_PATH, NPROC, H5_COL
     use constants, only: myrank
 #endif
 
@@ -614,7 +614,7 @@ contains
 
     ! open file
     call h5_open_file_p_collect(filename)
-    call h5_write_dataset_1d_r_collect_hyperslab(dset_name, dump_array, (/sum(offset(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_write_dataset_1d_r_collect_hyperslab(dset_name, dump_array, (/sum(offset(0:myrank-1))/), H5_COL)
     call h5_close_file_p()
 
     call h5_finalize()

--- a/src/shared/hdf5_manager.F90
+++ b/src/shared/hdf5_manager.F90
@@ -584,12 +584,6 @@ contains
     ! flag if dataset exists
     logical           :: exists = .false.
 
-    ! io mode
-    logical           :: if_collective = .true.
-
-    ! use global settings for collective IO
-    if_collective = HDF5_IO_COLLECTIVE
-
     ! saves mesh file external_mesh.h5
     tempstr = "/external_mesh.h5"
     filename = LOCAL_PATH(1:len_trim(LOCAL_PATH))//trim(tempstr)
@@ -620,7 +614,7 @@ contains
 
     ! open file
     call h5_open_file_p_collect(filename)
-    call h5_write_dataset_1d_r_collect_hyperslab(dset_name, dump_array, (/sum(offset(0:myrank-1))/), if_collective)
+    call h5_write_dataset_1d_r_collect_hyperslab(dset_name, dump_array, (/sum(offset(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     call h5_close_file_p()
 
     call h5_finalize()

--- a/src/shared/hdf5_manager.F90
+++ b/src/shared/hdf5_manager.F90
@@ -612,8 +612,13 @@ contains
     endif
     call synchronize_all()
 
-    ! open file
-    call h5_open_file_p_collect(filename)
+    ! open file (usually *_collect can be used with H5_COL = .false.)
+    ! but I got a strange error on some systems, so I use if statement here
+    if (H5_COL) then
+      call h5_open_file_p_collect(filename)
+    else
+      call h5_open_file_p(filename)
+    endif
     call h5_write_dataset_collect_hyperslab(dset_name, dump_array, (/sum(offset(0:myrank-1))/), H5_COL)
     call h5_close_file_p()
 

--- a/src/shared/hdf5_manager.F90
+++ b/src/shared/hdf5_manager.F90
@@ -526,16 +526,16 @@ contains
     ! open file
     call h5_open_file_p_collect(fname)
     ! read offset array
-    call h5_read_dataset_1d_i_collect_hyperslab("offset_nspec",offset_nspec, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_nspec",offset_nspec, (/0/), H5_COL)
 
-    call h5_read_dataset_4d_r_collect_hyperslab("scale_factor", scale_factor, &
-                                                (/0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
-    call h5_read_dataset_4d_r_collect_hyperslab("scale_factor_kappa", scale_factor_kappa, &
-                                                (/0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
-    call h5_read_dataset_5d_r_collect_hyperslab("factor_common", factor_common, &
-                                                (/0,0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
-    call h5_read_dataset_5d_r_collect_hyperslab("factor_common_kappa", factor_common_kappa, &
-                                                (/0,0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("scale_factor", scale_factor, &
+                                          (/0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("scale_factor_kappa", scale_factor_kappa, &
+                                          (/0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("factor_common", factor_common, &
+                                          (/0,0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("factor_common_kappa", factor_common_kappa, &
+                                          (/0,0,0,0,sum(offset_nspec(0:myrank-1))/), H5_COL)
 
     call h5_close_file_p()
     call h5_finalize()
@@ -614,7 +614,7 @@ contains
 
     ! open file
     call h5_open_file_p_collect(filename)
-    call h5_write_dataset_1d_r_collect_hyperslab(dset_name, dump_array, (/sum(offset(0:myrank-1))/), H5_COL)
+    call h5_write_dataset_collect_hyperslab(dset_name, dump_array, (/sum(offset(0:myrank-1))/), H5_COL)
     call h5_close_file_p()
 
     call h5_finalize()

--- a/src/shared/hdf5_manager.F90
+++ b/src/shared/hdf5_manager.F90
@@ -562,7 +562,7 @@ contains
   subroutine write_checkmesh_data_hdf5(dset_name,dump_array)
 
 #if defined(USE_HDF5)
-    use shared_parameters, only: LOCAL_PATH, NPROC
+    use shared_parameters, only: LOCAL_PATH, NPROC, HDF5_IO_COLLECTIVE
     use constants, only: myrank
 #endif
 
@@ -583,6 +583,12 @@ contains
 
     ! flag if dataset exists
     logical           :: exists = .false.
+
+    ! io mode
+    logical           :: if_collective = .true.
+
+    ! use global settings for collective IO
+    if_collective = HDF5_IO_COLLECTIVE
 
     ! saves mesh file external_mesh.h5
     tempstr = "/external_mesh.h5"
@@ -614,7 +620,7 @@ contains
 
     ! open file
     call h5_open_file_p_collect(filename)
-    call h5_write_dataset_1d_r_collect_hyperslab(dset_name, dump_array, (/sum(offset(0:myrank-1))/),.true.)
+    call h5_write_dataset_1d_r_collect_hyperslab(dset_name, dump_array, (/sum(offset(0:myrank-1))/), if_collective)
     call h5_close_file_p()
 
     call h5_finalize()

--- a/src/shared/hdf5_manager.F90
+++ b/src/shared/hdf5_manager.F90
@@ -254,6 +254,7 @@ module manager_hdf5
   interface h5_write_dataset_collect_hyperslab
     module procedure h5_write_dataset_1d_l_collect_hyperslab ! logical
     module procedure h5_write_dataset_1d_i_collect_hyperslab ! integer
+    module procedure h5_write_dataset_1d_i64_collect_hyperslab ! integer 64-bit
     module procedure h5_write_dataset_2d_i_collect_hyperslab
     module procedure h5_write_dataset_3d_i_collect_hyperslab
     module procedure h5_write_dataset_4d_i_collect_hyperslab
@@ -264,6 +265,13 @@ module manager_hdf5
     module procedure h5_write_dataset_5d_r_collect_hyperslab
     module procedure h5_write_dataset_2d_d_collect_hyperslab ! double
   end interface h5_write_dataset_collect_hyperslab
+
+! generic interface to create dataset
+interface h5_create_dataset_gen
+  module procedure h5_create_dataset_gen_int
+  module procedure h5_create_dataset_gen_int64
+end interface h5_create_dataset_gen
+
 
   ! object-oriented interface
   ! (Fortran 2003 standard style)
@@ -1756,7 +1764,7 @@ contains
 !-------------------------------------------------------------------------------
 !
 
-  subroutine h5_create_dataset_gen(dataset_name, dim_in, rank, dtype_id)
+  subroutine h5_create_dataset_gen_int(dataset_name, dim_in, rank, dtype_id)
     implicit none
     character(len=*), intent(in) :: dataset_name
     integer, dimension(:), intent(in)  :: dim_in
@@ -1817,7 +1825,75 @@ contains
     if (error /= 0) write(*,*) 'hdf5 dataspace close failed for ', dataset_name
     call check_error()
 
-  end subroutine h5_create_dataset_gen
+  end subroutine h5_create_dataset_gen_int
+
+!
+!-------------------------------------------------------------------------------
+!
+
+  subroutine h5_create_dataset_gen_int64(dataset_name, dim_in, rank, dtype_id)
+    implicit none
+    character(len=*), intent(in) :: dataset_name
+    integer(kind=8), dimension(:), intent(in)  :: dim_in
+
+    integer(HSIZE_T), dimension(size(dim_in)) :: dim
+    integer, intent(in)                :: dtype_id ! 1:int, 4:real4, 8:real8,
+    integer, intent(in)                :: rank
+
+    integer(HID_T)                     :: dspace_id
+    !logical :: if_chunk = .true.
+    !integer :: i
+
+    dim = dim_in ! convert data type
+
+    call h5screate_simple_f(rank, dim, dspace_id, error)
+    if (error /= 0) write(*,*) 'hdf5 dataspace create failed for ', dataset_name
+    call check_error()
+    call h5pcreate_f(H5P_DATASET_CREATE_F, plist_id, error)
+    call check_error()
+
+    ! chunk size setting
+    !do i = 1, rank
+    !    if (dim(i) <= 0) then
+    !        if_chunk = .false.
+    !        print *, "dataset not chunk set: ", dataset_name
+    !    endif
+    !enddo
+    !if (if_chunk) call h5pset_chunk_f(plist_id,rank,dim,error)
+
+    if (dtype_id == 0) then ! bool uses integer
+      call h5dcreate_f(file_id, trim(dataset_name), H5T_NATIVE_INTEGER, dspace_id, dataset_id, error, &
+                       dcpl_id=plist_id)
+    else if (dtype_id == 1) then ! integer
+      call h5dcreate_f(file_id, trim(dataset_name), H5T_NATIVE_INTEGER, dspace_id, dataset_id, error, &
+                       dcpl_id=plist_id)
+    else if (dtype_id == 2) then ! character
+      call h5dcreate_f(file_id, trim(dataset_name), str_type, dspace_id, dataset_id, error, &
+                       dcpl_id=plist_id)
+    else if (dtype_id == 4) then  !  real
+      call h5dcreate_f(file_id, trim(dataset_name), H5T_NATIVE_REAL, dspace_id, dataset_id, error, &
+                       dcpl_id=plist_id)
+    else if (dtype_id == 8) then ! double
+      call h5dcreate_f(file_id, trim(dataset_name), H5T_NATIVE_DOUBLE, dspace_id, dataset_id, error, &
+                       dcpl_id=plist_id)
+    else
+      print *, "specified dtype_id is not implemented yet for hdf5 io. aborting..."
+      stop 'Invalid dtype_id, not implemented yet in h5_create_dataset_gen() routine'
+    endif
+    if (error /= 0) write(*,*) 'hdf5 dataset create failed for ', dataset_name
+    call check_error()
+
+    call h5_close_prop_list_nocheck(dataset_name)
+
+    call h5dclose_f(dataset_id,error)
+    if (error /= 0) write(*,*) 'hdf5 dataset close failed for ', dataset_name
+    call check_error()
+    call h5sclose_f(dspace_id, error)
+    if (error /= 0) write(*,*) 'hdf5 dataspace close failed for ', dataset_name
+    call check_error()
+
+  end subroutine h5_create_dataset_gen_int64
+
 
 !
 !-------------------------------------------------------------------------------
@@ -3980,6 +4056,59 @@ contains
 !
 !-------------------------------------------------------------------------------
 !
+
+! store local 1d array to global 1d array
+  subroutine h5_write_dataset_1d_i64_collect_hyperslab(dataset_name, data, offset_in, if_collective)
+    implicit none
+    character(len=*), intent(in)                                :: dataset_name
+    integer, dimension(:), intent(in), target                   :: data
+    integer(kind=8), dimension(:), intent(in)                   :: offset_in
+    logical, intent(in)                                         :: if_collective
+    ! local parameters
+    integer                                                     :: rank = 1
+    integer(HSIZE_T), dimension(1)                              :: dim
+    integer(HSIZE_T), dimension(1)                              :: count ! size of hyperslab
+    integer(HSSIZE_T), dimension(1)                             :: offset ! the position where the datablock is inserted
+
+    dim = shape(data)
+    offset = offset_in ! convert data type
+
+    ! open dataset
+    call h5_open_dataset2(trim(dataset_name))
+
+    ! select a place where data is inserted.
+    count(1) = dim(1)
+
+    ! select hyperslab in the file
+    call h5screate_simple_f(rank,count, mem_dspace_id, error)
+    call check_error()
+    call h5dget_space_f(dataset_id, file_dspace_id, error)
+    call check_error()
+    call h5sselect_hyperslab_f(file_dspace_id, H5S_SELECT_SET_F, offset, count, error)
+    call check_error()
+    call h5_create_dataset_prop_list(if_collective)
+
+    call h5_check_arr_dim(dim)
+    ! write array using Fortran pointer
+    !call h5dwrite_f(dataset_id, H5T_NATIVE_INTEGER, data, dim, error, &
+    !                file_space_id=file_dspace_id, mem_space_id=mem_dspace_id, xfer_prp=plist_id)
+    ! use F2003 API
+    call h5dwrite_f(dataset_id, H5T_NATIVE_INTEGER, c_loc(data(1)), error, &
+                    file_space_id=file_dspace_id, mem_space_id=mem_dspace_id, xfer_prp=plist_id)
+    if (error /= 0) write(*,*) 'hdf5 dataset write failed for ', dataset_name
+    call check_error()
+    call h5_close_prop_list(dataset_name)
+    call h5sclose_f(mem_dspace_id, error)
+    call check_error()
+    call h5sclose_f(file_dspace_id, error)
+    call check_error()
+    call h5_close_dataset()
+  end subroutine h5_write_dataset_1d_i64_collect_hyperslab
+
+!
+!-------------------------------------------------------------------------------
+!
+
 
   subroutine h5_write_dataset_1d_r_collect_hyperslab(dataset_name, data, offset_in, if_collective)
     implicit none

--- a/src/shared/shared_par.F90
+++ b/src/shared/shared_par.F90
@@ -192,6 +192,9 @@ end module constants
   ! number of io dedicated nodes
   integer :: HDF5_IO_NODES = 0
 
+  ! HDF5 IO writing mode (collective or independent)
+  logical :: HDF5_IO_COLLECTIVE = .true.
+
   ! flag for io-dedicated/compute node.
   logical :: IO_storage_task = .false.
   logical :: IO_compute_task = .true.

--- a/src/shared/shared_par.F90
+++ b/src/shared/shared_par.F90
@@ -193,7 +193,7 @@ end module constants
   integer :: HDF5_IO_NODES = 0
 
   ! HDF5 IO writing mode (collective or independent)
-  logical :: HDF5_IO_COLLECTIVE = .true.
+  logical :: H5_COL = .true.
 
   ! flag for io-dedicated/compute node.
   logical :: IO_storage_task = .false.

--- a/src/specfem3D/read_mesh_databases_hdf5.F90
+++ b/src/specfem3D/read_mesh_databases_hdf5.F90
@@ -45,12 +45,6 @@
   ! MPI variables
   integer :: info, comm
 
-  ! if collective read
-  logical :: if_col = .true.
-
-  ! overwrite the io mode by global variable
-  if_col = HDF5_IO_COLLECTIVE
-
   if (I_should_read_the_database) then
     ! set file name
     tempstr = "/external_mesh.h5"
@@ -69,13 +63,13 @@
     ! read datasets
     dsetname = "nspec"
     !call h5_read_dataset_p_scalar(dsetname, NSPEC_AB)
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_AB, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_AB, (/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "nglob"
     !call h5_read_dataset_p_scalar(dsetname, NGLOB_AB)
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NGLOB_AB, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NGLOB_AB, (/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "nspec_irregular"
     !call h5_read_dataset_p_scalar(dsetname, NSPEC_IRREGULAR)
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_IRREGULAR, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_IRREGULAR, (/myrank/),HDF5_IO_COLLECTIVE)
 
     ! close hdf5
     call h5_close_file()
@@ -130,9 +124,6 @@
   ! MPI variables
   integer :: info, comm
 
-  ! if collective read
-  logical :: if_col
-
   ! offset arrays
   integer, dimension(0:NPROC-1) :: offset_nglob
   integer, dimension(0:NPROC-1) :: offset_nspec
@@ -167,8 +158,6 @@
   integer, dimension(0:NPROC-1) :: offset_neighbors_xadj
   integer, dimension(0:NPROC-1) :: offset_neighbors_adjncy
 
-  ! overwrite the io mode by global variable
-  if_col = HDF5_IO_COLLECTIVE
 
   ! user output
   if (myrank == 0) then
@@ -197,80 +186,80 @@
     call h5_open_file_p_collect(database_hdf5)
 
     ! gets offsets
-    call h5_read_dataset_collect_hyperslab("offset_nglob",offset_nglob, (/0/), if_col)
-    call h5_read_dataset_collect_hyperslab("offset_nspec",offset_nspec, (/0/), if_col)
-    call h5_read_dataset_collect_hyperslab("offset_nspec_irregular",offset_nspec_irregular, (/0/), if_col)
+    call h5_read_dataset_collect_hyperslab("offset_nglob",offset_nglob, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nspec",offset_nspec, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nspec_irregular",offset_nspec_irregular, (/0/), HDF5_IO_COLLECTIVE)
 
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_xmin",offset_nspec2D_xmin, (/0/), if_col)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_xmax",offset_nspec2D_xmax, (/0/), if_col)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_ymin",offset_nspec2D_ymin, (/0/), if_col)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_ymax",offset_nspec2D_ymax, (/0/), if_col)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_bottom_ext",offset_nspec2D_bottom_ext, (/0/), if_col)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_top_ext",offset_nspec2D_top_ext, (/0/), if_col)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_xmin",offset_nspec2D_xmin, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_xmax",offset_nspec2D_xmax, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_ymin",offset_nspec2D_ymin, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_ymax",offset_nspec2D_ymax, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_bottom_ext",offset_nspec2D_bottom_ext, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_top_ext",offset_nspec2D_top_ext, (/0/), HDF5_IO_COLLECTIVE)
 
-    call h5_read_dataset_collect_hyperslab("offset_nspec_ab",offset_nspec_ab, (/0/), if_col)
-    call h5_read_dataset_collect_hyperslab("offset_nglob_ab",offset_nglob_ab, (/0/), if_col)
+    call h5_read_dataset_collect_hyperslab("offset_nspec_ab",offset_nspec_ab, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nglob_ab",offset_nglob_ab, (/0/), HDF5_IO_COLLECTIVE)
 
     ! mesh adjacency
-    call h5_read_dataset_collect_hyperslab("offset_neighbors_xadj",offset_neighbors_xadj, (/0/), if_col)
-    call h5_read_dataset_collect_hyperslab("offset_neighbors_adjncy",offset_neighbors_adjncy, (/0/), if_col)
+    call h5_read_dataset_collect_hyperslab("offset_neighbors_xadj",offset_neighbors_xadj, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_neighbors_adjncy",offset_neighbors_adjncy, (/0/), HDF5_IO_COLLECTIVE)
 
     ! info about external mesh simulation
     dsetname = "nspec"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_AB, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_AB, (/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "nglob"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NGLOB_AB, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NGLOB_AB, (/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "nspec_irregular"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_IRREGULAR, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_IRREGULAR, (/myrank/),HDF5_IO_COLLECTIVE)
 
     dsetname = "ibool"
-    call h5_read_dataset_collect_hyperslab(dsetname, ibool, (/0,0,0,sum(offset_nglob(0:myrank-1))/), if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname, ibool, (/0,0,0,sum(offset_nglob(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dsetname = "xstore_unique"
-    call h5_read_dataset_collect_hyperslab(dsetname,xstore,(/sum(offset_nglob(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,xstore,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "ystore_unique"
-    call h5_read_dataset_collect_hyperslab(dsetname,ystore,(/sum(offset_nglob(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,ystore,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "zstore_unique"
-    call h5_read_dataset_collect_hyperslab(dsetname,zstore,(/sum(offset_nglob(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,zstore,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
 
     dsetname = "irregular_element_number"
-    call h5_read_dataset_collect_hyperslab(dsetname,irregular_element_number,(/sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,irregular_element_number,(/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "xix_regular"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname,xix_regular,(/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname,xix_regular,(/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "jacobian_regular"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname,jacobian_regular,(/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname,jacobian_regular,(/myrank/),HDF5_IO_COLLECTIVE)
 
     dsetname = "xixstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,xixstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,xixstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "xiystore"
-    call h5_read_dataset_collect_hyperslab(dsetname,xiystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,xiystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "xizstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,xizstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,xizstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "etaxstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,etaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,etaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "etaystore"
-    call h5_read_dataset_collect_hyperslab(dsetname,etaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,etaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "etazstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,etazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,etazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "gammaxstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,gammaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,gammaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "gammaystore"
-    call h5_read_dataset_collect_hyperslab(dsetname,gammaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,gammaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "gammazstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,gammazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,gammazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "jacobianstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,jacobianstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,jacobianstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
 
     dsetname = "ispec_is_acoustic"
-    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_acoustic, (/sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_acoustic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "ispec_is_elastic"
-    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_elastic, (/sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_elastic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "ispec_is_poroelastic"
-    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_poroelastic, (/sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_poroelastic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
 
     dsetname = "kappastore"
-    call h5_read_dataset_collect_hyperslab(dsetname,kappastore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,kappastore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     dsetname = "mustore"
-    call h5_read_dataset_collect_hyperslab(dsetname,mustore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname,mustore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
 
   call bcast_all_i_for_database(NSPEC_AB, 1)
@@ -361,7 +350,7 @@
 
     if (I_should_read_the_database) then
       dsetname = "rmass_acoustic"
-      call h5_read_dataset_collect_hyperslab(dsetname, rmass_acoustic,(/sum(offset_nglob(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rmass_acoustic,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (size(rmass_acoustic) > 0) call bcast_all_cr_for_database(rmass_acoustic(1), size(rmass_acoustic))
 
@@ -377,7 +366,7 @@
   if (I_should_read_the_database) then
     dsetname = "rhostore"
     !call h5_read_dataset_p(dsetname, rhostore)
-    call h5_read_dataset_collect_hyperslab(dsetname, rhostore, (/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname, rhostore, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_cr_for_database(rhostore(1,1,1,1), size(rhostore))
 
@@ -541,7 +530,7 @@
     ! reads mass matrices
     if (I_should_read_the_database) then
       dsetname = "rmass"
-      call h5_read_dataset_collect_hyperslab(dsetname, rmass, (/sum(offset_nglob(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rmass, (/sum(offset_nglob(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     endif
     call bcast_all_cr_for_database(rmass(1), size(rmass))
     if (ier /= 0) stop 'Error reading in array rmass'
@@ -554,9 +543,9 @@
       rmass_ocean_load(:) = 0.0_CUSTOM_REAL
 
       if (I_should_read_the_database) then
-        call h5_read_dataset_collect_hyperslab("offset_nglob_ocean",offset_nglob_ocean, (/0/), if_col)
+        call h5_read_dataset_collect_hyperslab("offset_nglob_ocean",offset_nglob_ocean, (/0/), HDF5_IO_COLLECTIVE)
         dsetname = "rmass_ocean_load"
-        call h5_read_dataset_collect_hyperslab(dsetname, rmass_ocean_load, (/sum(offset_nglob_ocean(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, rmass_ocean_load, (/sum(offset_nglob_ocean(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       endif
       if (size(rmass_ocean_load) > 0) call bcast_all_cr_for_database(rmass_ocean_load(1), size(rmass_ocean_load))
     else
@@ -569,12 +558,12 @@
     !pll material parameters for stacey conditions
     if (I_should_read_the_database) then
       dsetname = "rho_vp"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vp, (/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vp, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (size(rho_vp) > 0) call bcast_all_cr_for_database(rho_vp(1,1,1,1), size(rho_vp))
     if (I_should_read_the_database) then
       dsetname = "rho_vs"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vs, (/0,0,0,sum(offset_nspec(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vs, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (size(rho_vs) > 0) call bcast_all_cr_for_database(rho_vs(1,1,1,1), size(rho_vs))
 
@@ -686,30 +675,30 @@
     epsilons_trace_over_3(:,:,:,:) = 0.0_CUSTOM_REAL; epsilonw_trace_over_3(:,:,:,:) = 0.0_CUSTOM_REAL
 
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_nspecporo",offset_nspecporo, (/0/), if_col)
+      call h5_read_dataset_collect_hyperslab("offset_nspecporo",offset_nspecporo, (/0/), HDF5_IO_COLLECTIVE)
       dsetname = "rmass_solid_poroelastic"
-      call h5_read_dataset_collect_hyperslab(dsetname, rmass_solid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rmass_solid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "rmass_fluid_poroelastic"
-      call h5_read_dataset_collect_hyperslab(dsetname, rmass_fluid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rmass_fluid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "rhoarraystore"
-      call h5_read_dataset_collect_hyperslab(dsetname, rhoarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rhoarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "kappaarraystore"
       call h5_read_dataset_collect_hyperslab(dsetname, kappaarraystore, &
-                                                  (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+                                                  (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "etastore"
-      call h5_read_dataset_collect_hyperslab(dsetname, etastore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, etastore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "tortstore"
-      call h5_read_dataset_collect_hyperslab(dsetname, tortstore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, tortstore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "permstore"
-      call h5_read_dataset_collect_hyperslab(dsetname, permstore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, permstore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "phistore"
-      call h5_read_dataset_collect_hyperslab(dsetname, phistore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, phistore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "rho_vpI"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vpI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vpI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "rho_vpII"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vpII, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vpII, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "rho_vsI"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vsI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vsI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (size(rmass_solid_poroelastic) > 0) &
       call bcast_all_cr_for_database(rmass_solid_poroelastic(1), size(rmass_solid_poroelastic))
@@ -765,17 +754,17 @@
 
   if (PML_CONDITIONS) then
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_nspeccpml",offset_nspeccpml, (/0/), if_col)
+      call h5_read_dataset_collect_hyperslab("offset_nspeccpml",offset_nspeccpml, (/0/), HDF5_IO_COLLECTIVE)
       dsetname = "nspec_cpml"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_CPML, (/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_CPML, (/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "CPML_width_x"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_x, (/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_x, (/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "CPML_width_y"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_y, (/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_y, (/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "CPML_width_z"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_z, (/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_z, (/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "min_distance_between_CPML_parameter"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, min_distance_between_CPML_parameter, (/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, min_distance_between_CPML_parameter, (/myrank/),HDF5_IO_COLLECTIVE)
     endif
     call bcast_all_i_for_database(NSPEC_CPML, 1)
     call bcast_all_cr_for_database(CPML_width_x, 1)
@@ -827,29 +816,29 @@
 
       if (I_should_read_the_database) then
         dsetname = "CPML_regions"
-        call h5_read_dataset_collect_hyperslab(dsetname, CPML_regions, (/sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, CPML_regions, (/sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "CPML_to_spec"
-        call h5_read_dataset_collect_hyperslab(dsetname, CPML_to_spec, (/sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, CPML_to_spec, (/sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "is_CPML"
-        call h5_read_dataset_collect_hyperslab(dsetname, is_CPML, (/sum(offset_nspec_ab(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, is_CPML, (/sum(offset_nspec_ab(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "d_store_x"
-        call h5_read_dataset_collect_hyperslab(dsetname, d_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, d_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "d_store_y"
-        call h5_read_dataset_collect_hyperslab(dsetname, d_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, d_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "d_store_z"
-        call h5_read_dataset_collect_hyperslab(dsetname, d_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, d_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "k_store_x"
-        call h5_read_dataset_collect_hyperslab(dsetname, k_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, k_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "k_store_y"
-        call h5_read_dataset_collect_hyperslab(dsetname, k_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, k_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "k_store_z"
-        call h5_read_dataset_collect_hyperslab(dsetname, k_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, k_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "alpha_store_x"
-        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "alpha_store_y"
-        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         dsetname = "alpha_store_z"
-        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),if_col)
+        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       endif
 
       if (size(CPML_regions) > 0) call bcast_all_i_for_database(CPML_regions(1), size(CPML_regions))
@@ -869,17 +858,17 @@
         ! acoustic
         if (I_should_read_the_database) then
           call h5_read_dataset_collect_hyperslab( &
-                           "offset_nglob_interface_PML_acoustic",offset_nglob_interface_PML_acoustic, (/0/), if_col)
+                           "offset_nglob_interface_PML_acoustic",offset_nglob_interface_PML_acoustic, (/0/), HDF5_IO_COLLECTIVE)
           dsetname = "nglob_interface_PML_acoustic"
-          call h5_read_dataset_scalar_collect_hyperslab(dsetname, nglob_interface_PML_acoustic, (/myrank/),if_col)
+          call h5_read_dataset_scalar_collect_hyperslab(dsetname, nglob_interface_PML_acoustic, (/myrank/),HDF5_IO_COLLECTIVE)
         endif
         call bcast_all_i_for_database(nglob_interface_PML_acoustic, 1)
         ! elastic
         if (I_should_read_the_database) then
           call h5_read_dataset_collect_hyperslab( &
-                            "offset_nglob_interface_PML_elastic",offset_nglob_interface_PML_elastic, (/0/), if_col)
+                            "offset_nglob_interface_PML_elastic",offset_nglob_interface_PML_elastic, (/0/), HDF5_IO_COLLECTIVE)
           dsetname = "nglob_interface_PML_elastic"
-          call h5_read_dataset_scalar_collect_hyperslab(dsetname, nglob_interface_PML_elastic, (/myrank/),if_col)
+          call h5_read_dataset_scalar_collect_hyperslab(dsetname, nglob_interface_PML_elastic, (/myrank/),HDF5_IO_COLLECTIVE)
         endif
         call bcast_all_i_for_database(nglob_interface_PML_elastic, 1)
         ! acoustic allocation
@@ -892,7 +881,7 @@
           if (I_should_read_the_database) then
             dsetname = "points_interface_PML_acoustic"
             call h5_read_dataset_collect_hyperslab(dsetname, &
-                points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_acoustic(0:myrank-1))/),if_col)
+                points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_acoustic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
           endif
           if (size(points_interface_PML_acoustic) > 0) &
             call bcast_all_i_for_database(points_interface_PML_acoustic(1), size(points_interface_PML_acoustic))
@@ -907,7 +896,7 @@
           if (I_should_read_the_database) then
             dsetname = "points_interface_PML_elastic"
             call h5_read_dataset_collect_hyperslab(dsetname, &
-                points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_elastic(0:myrank-1))/),if_col)
+                points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_elastic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
           endif
           if (size(points_interface_PML_elastic) > 0) &
             call bcast_all_i_for_database(points_interface_PML_elastic(1), size(points_interface_PML_elastic))
@@ -919,7 +908,7 @@
   ! absorbing boundary surface
   if (I_should_read_the_database) then
     dsetname = "num_abs_boundary_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_abs_boundary_faces, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_abs_boundary_faces, (/myrank/),HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(num_abs_boundary_faces, 1)
 
@@ -941,29 +930,29 @@
   abs_boundary_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL; abs_boundary_normal(:,:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_abs_boundary_faces",offset_num_abs_boundary_faces, (/0/), if_col)
+    call h5_read_dataset_collect_hyperslab("offset_num_abs_boundary_faces",offset_num_abs_boundary_faces, (/0/), HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_array_for_database(offset_num_abs_boundary_faces, size(offset_num_abs_boundary_faces))
 
   if (sum(offset_num_abs_boundary_faces) > 0) then
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_nglob_xy",offset_nglob_xy, (/0/), if_col)
+      call h5_read_dataset_collect_hyperslab("offset_nglob_xy",offset_nglob_xy, (/0/), HDF5_IO_COLLECTIVE)
     endif
     call bcast_all_i_array_for_database(offset_nglob_xy, size(offset_nglob_xy))
 
     if (I_should_read_the_database) then
       dsetname = "abs_boundary_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, abs_boundary_ispec, &
-              (/sum(offset_num_abs_boundary_faces(0:myrank-1))/),if_col)
+              (/sum(offset_num_abs_boundary_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "abs_boundary_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, abs_boundary_ijk, &
-              (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), if_col)
+              (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "abs_boundary_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, abs_boundary_jacobian2Dw, &
-              (/0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), if_col)
+              (/0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "abs_boundary_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, abs_boundary_normal, &
-              (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), if_col)
+              (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     endif
     if (size(abs_boundary_ispec) > 0) &
       call bcast_all_i_for_database(abs_boundary_ispec(1), size(abs_boundary_ispec))
@@ -980,13 +969,13 @@
         if (I_should_read_the_database) then
           dsetname = "rmassx"
           call h5_read_dataset_collect_hyperslab(dsetname, rmassx(1:offset_nglob_xy(myrank)), &
-                                                          (/sum(offset_nglob_xy(0:myrank-1))/),if_col)
+                                                          (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
           dsetname = "rmassy"
           call h5_read_dataset_collect_hyperslab(dsetname, rmassy(1:offset_nglob_xy(myrank)), &
-                                                          (/sum(offset_nglob_xy(0:myrank-1))/),if_col)
+                                                          (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
           dsetname = "rmassz"
           call h5_read_dataset_collect_hyperslab(dsetname, rmassz(1:offset_nglob_xy(myrank)), &
-                                                          (/sum(offset_nglob_xy(0:myrank-1))/),if_col)
+                                                          (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         endif
         if (size(rmassx) > 0) call bcast_all_cr_for_database(rmassx(1), size(rmassx))
         if (size(rmassy) > 0) call bcast_all_cr_for_database(rmassy(1), size(rmassy))
@@ -996,7 +985,7 @@
         if (I_should_read_the_database) then
           dsetname = "rmassz_acoustic"
           call h5_read_dataset_collect_hyperslab(dsetname, rmassz_acoustic(1:offset_nglob_xy(myrank)), &
-                                                          (/sum(offset_nglob_xy(0:myrank-1))/),if_col)
+                                                          (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
         endif
         if (size(rmassz_acoustic) > 0) call bcast_all_cr_for_database(rmassz_acoustic(1), size(rmassz_acoustic))
       endif
@@ -1006,17 +995,17 @@
   ! boundaries
   if (I_should_read_the_database) then
     dsetname = "nspec2D_xmin"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_xmin, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_xmin, (/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "nspec2D_xmax"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_xmax, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_xmax, (/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "nspec2D_ymin"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_ymin, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_ymin, (/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "nspec2D_ymax"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_ymax, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_ymax, (/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "NSPEC2D_BOTTOM"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_bottom, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_bottom, (/myrank/),HDF5_IO_COLLECTIVE)
     dsetname = "NSPEC2D_TOP"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_top, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_top, (/myrank/),HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(nspec2D_xmin, 1)
   call bcast_all_i_for_database(nspec2D_xmax, 1)
@@ -1045,27 +1034,27 @@
   if (I_should_read_the_database) then
     if (sum(offset_nspec2D_xmin) > 0) then
       dsetname = "ibelm_xmin"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (sum(offset_nspec2D_xmax) > 0) then
       dsetname = "ibelm_xmax"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (sum(offset_nspec2D_ymin) > 0) then
       dsetname = "ibelm_ymin"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (sum(offset_nspec2D_ymax) > 0) then
       dsetname = "ibelm_ymax"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (sum(offset_nspec2D_bottom_ext) > 0) then
       dsetname = "ibelm_bottom"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (sum(offset_nspec2D_top_ext) > 0) then
       dsetname = "ibelm_top"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
   endif
   if (size(ibelm_xmin) > 0) call bcast_all_i_for_database(ibelm_xmin(1), size(ibelm_xmin))
@@ -1078,7 +1067,7 @@
   ! free surface
   if (I_should_read_the_database) then
     dsetname = "num_free_surface_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_free_surface_faces, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_free_surface_faces, (/myrank/),HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(num_free_surface_faces, 1)
 
@@ -1095,7 +1084,7 @@
   free_surface_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL; free_surface_normal(:,:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_free_surface_faces",offset_num_free_surface_faces, (/0/), if_col)
+    call h5_read_dataset_collect_hyperslab("offset_num_free_surface_faces",offset_num_free_surface_faces, (/0/), HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_array_for_database(offset_num_free_surface_faces, size(offset_num_free_surface_faces))
 
@@ -1103,16 +1092,16 @@
     if (I_should_read_the_database) then
       dsetname = "free_surface_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, free_surface_ispec, &
-              (/sum(offset_num_free_surface_faces(0:myrank-1))/),if_col)
+              (/sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "free_surface_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, free_surface_ijk, &
-              (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),if_col)
+              (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "free_surface_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, free_surface_jacobian2Dw, &
-              (/0,sum(offset_num_free_surface_faces(0:myrank-1))/),if_col)
+              (/0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "free_surface_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, free_surface_normal, &
-              (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),if_col)
+              (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (size(free_surface_ispec) > 0) &
       call bcast_all_i_for_database(free_surface_ispec(1), size(free_surface_ispec))
@@ -1127,7 +1116,7 @@
   ! acoustic-elastic coupling surface
   if (I_should_read_the_database) then
     dsetname = "num_coupling_ac_el_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_ac_el_faces, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_ac_el_faces, (/myrank/),HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(num_coupling_ac_el_faces, 1)
 
@@ -1144,7 +1133,7 @@
   coupling_ac_el_normal(:,:,:) = 0.0_CUSTOM_REAL; coupling_ac_el_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_coupling_ac_el_faces",offset_num_coupling_ac_el_faces,(/0/),if_col)
+    call h5_read_dataset_collect_hyperslab("offset_num_coupling_ac_el_faces",offset_num_coupling_ac_el_faces,(/0/),HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_array_for_database(offset_num_coupling_ac_el_faces, size(offset_num_coupling_ac_el_faces))
 
@@ -1152,16 +1141,16 @@
     if (I_should_read_the_database) then
       dsetname = "coupling_ac_el_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_el_ispec, &
-            (/sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),if_col)
+            (/sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_ac_el_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_el_ijk, &
-                (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),if_col)
+                (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_ac_el_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_el_jacobian2Dw, &
-               (/0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),if_col)
+               (/0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_ac_el_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_el_normal, &
-               (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),if_col)
+               (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (size(coupling_ac_el_ispec) > 0) &
       call bcast_all_i_for_database(coupling_ac_el_ispec(1), size(coupling_ac_el_ispec))
@@ -1176,7 +1165,7 @@
   ! acoustic-poroelastic coupling surface
   if (I_should_read_the_database) then
     dsetname = "num_coupling_ac_po_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_ac_po_faces, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_ac_po_faces, (/myrank/),HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(num_coupling_ac_po_faces, 1)
 
@@ -1193,7 +1182,7 @@
   coupling_ac_po_normal(:,:,:) = 0.0_CUSTOM_REAL; coupling_ac_po_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_coupling_ac_po_faces",offset_num_coupling_ac_po_faces, (/0/), if_col)
+    call h5_read_dataset_collect_hyperslab("offset_num_coupling_ac_po_faces",offset_num_coupling_ac_po_faces, (/0/), HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_array_for_database(offset_num_coupling_ac_po_faces,size(offset_num_coupling_ac_po_faces))
 
@@ -1201,16 +1190,16 @@
     if (I_should_read_the_database) then
       dsetname = "coupling_ac_po_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_po_ispec, &
-              (/sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),if_col)
+              (/sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_ac_po_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_po_ijk, &
-              (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),if_col)
+              (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_ac_po_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_po_jacobian2Dw, &
-              (/0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),if_col)
+              (/0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_ac_po_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_po_normal, &
-              (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),if_col)
+              (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (size(coupling_ac_po_ispec) > 0) &
       call bcast_all_i_for_database(coupling_ac_po_ispec(1), size(coupling_ac_po_ispec))
@@ -1225,7 +1214,7 @@
   ! elastic-poroelastic coupling surface
   if (I_should_read_the_database) then
     dsetname = "num_coupling_el_po_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_el_po_faces, (/myrank/),if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_el_po_faces, (/myrank/),HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(num_coupling_el_po_faces, 1)
 
@@ -1247,7 +1236,7 @@
   coupling_el_po_normal(:,:,:) = 0.0_CUSTOM_REAL; coupling_el_po_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_coupling_el_po_faces",offset_num_coupling_el_po_faces, (/0/), if_col)
+    call h5_read_dataset_collect_hyperslab("offset_num_coupling_el_po_faces",offset_num_coupling_el_po_faces, (/0/), HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_array_for_database(offset_num_coupling_el_po_faces,size(offset_num_coupling_el_po_faces))
 
@@ -1255,22 +1244,22 @@
     if (I_should_read_the_database) then
       dsetname = "coupling_el_po_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_el_po_ispec, &
-              (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+              (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_po_el_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_po_el_ispec, &
-              (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+              (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_el_po_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_el_po_ijk, &
-              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_po_el_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_po_el_ijk, &
-              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_el_po_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_el_po_jacobian2Dw, &
-              (/0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+              (/0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "coupling_el_po_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_el_po_normal, &
-              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),if_col)
+              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (size(coupling_el_po_ispec) > 0) &
       call bcast_all_i_for_database(coupling_el_po_ispec(1), size(coupling_el_po_ispec))
@@ -1289,7 +1278,7 @@
   ! MPI interfaces
   if (I_should_read_the_database) then
      dsetname = "num_interfaces_ext_mesh"
-     call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_interfaces_ext_mesh, (/myrank/),if_col)
+     call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_interfaces_ext_mesh, (/myrank/),HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(num_interfaces_ext_mesh, 1)
 
@@ -1301,14 +1290,14 @@
   my_neighbors_ext_mesh(:) = -1; nibool_interfaces_ext_mesh(:) = 0
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_interfaces_ext_mesh",offset_num_interfaces_ext_mesh, (/0/), if_col)
+    call h5_read_dataset_collect_hyperslab("offset_num_interfaces_ext_mesh",offset_num_interfaces_ext_mesh, (/0/), HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_array_for_database(offset_num_interfaces_ext_mesh,size(offset_num_interfaces_ext_mesh))
 
   if (sum(offset_num_interfaces_ext_mesh) > 0) then
     if (I_should_read_the_database) then
       dsetname = "max_nibool_interfaces_ext_mesh"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, max_nibool_interfaces_ext_mesh, (/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, max_nibool_interfaces_ext_mesh, (/myrank/),HDF5_IO_COLLECTIVE)
     endif
     call bcast_all_i_for_database(max_nibool_interfaces_ext_mesh, 1)
     allocate(ibool_interfaces_ext_mesh(max_nibool_interfaces_ext_mesh,num_interfaces_ext_mesh),stat=ier)
@@ -1319,13 +1308,13 @@
     if (I_should_read_the_database) then
       dsetname = "my_neighbors_ext_mesh"
       call h5_read_dataset_collect_hyperslab(dsetname, my_neighbors_ext_mesh, &
-              (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),if_col)
+              (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "nibool_interfaces_ext_mesh"
       call h5_read_dataset_collect_hyperslab(dsetname, nibool_interfaces_ext_mesh, &
-              (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),if_col)
+              (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       dsetname = "ibool_interfaces_ext_mesh_dummy"
       call h5_read_dataset_collect_hyperslab(dsetname, ibool_interfaces_ext_mesh, &
-              (/0,sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),if_col)
+              (/0,sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
     endif
     if (size(my_neighbors_ext_mesh) > 0) &
       call bcast_all_i_for_database(my_neighbors_ext_mesh(1), size(my_neighbors_ext_mesh))
@@ -1344,49 +1333,49 @@
   ! material properties
   if (ELASTIC_SIMULATION .and. ANISOTROPY) then
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_nspec_aniso",offset_nspec_aniso, (/0/), if_col)
+      call h5_read_dataset_collect_hyperslab("offset_nspec_aniso",offset_nspec_aniso, (/0/), HDF5_IO_COLLECTIVE)
       dsetname = "c11store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c11store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c11store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c12store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c12store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c12store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c13store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c13store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c13store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c14store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c14store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c14store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c15store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c15store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c15store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c16store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c16store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c16store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c22store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c22store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c22store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c23store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c23store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c23store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c24store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c24store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c24store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c25store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c25store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c25store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c26store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c26store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c26store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c33store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c33store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c33store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c34store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c34store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c34store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c35store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c35store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c35store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c36store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c36store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c36store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c44store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c44store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c44store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c45store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c45store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c45store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c46store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c46store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c46store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c55store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c55store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c55store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c56store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c56store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c56store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
       dsetname = "c66store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c66store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), if_col)
+      call h5_read_dataset_collect_hyperslab(dsetname, c66store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     endif
     if (size(c11store) > 0) call bcast_all_cr_for_database(c11store(1,1,1,1), size(c11store))
     if (size(c12store) > 0) call bcast_all_cr_for_database(c12store(1,1,1,1), size(c12store))
@@ -1419,18 +1408,18 @@
 
   if (I_should_read_the_database) then
     dsetname = "ispec_is_inner"
-    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_inner,(/sum(offset_nspec(0:myrank-1))/),if_col)
+    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_inner,(/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
   endif
   if (size(ispec_is_inner) > 0) call bcast_all_l_for_database(ispec_is_inner(1), size(ispec_is_inner))
 
   if (ACOUSTIC_SIMULATION) then
     if (I_should_read_the_database) then
       dsetname = "nspec_inner_acoustic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_acoustic,(/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "nspec_outer_acoustic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_acoustic,(/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "num_phase_ispec_acoustic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_acoustic,(/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
     endif
     call bcast_all_i_for_database(nspec_inner_acoustic, 1)
     call bcast_all_i_for_database(nspec_outer_acoustic, 1)
@@ -1443,12 +1432,12 @@
     phase_ispec_inner_acoustic(:,:) = 0
 
     call h5_read_dataset_collect_hyperslab("offset_num_phase_ispec_acoustic", &
-            offset_num_phase_ispec_acoustic, (/0/), if_col)
+            offset_num_phase_ispec_acoustic, (/0/), HDF5_IO_COLLECTIVE)
     if (sum(offset_num_phase_ispec_acoustic) > 0) then
      if (I_should_read_the_database) then
         dsetname = "phase_ispec_inner_acoustic"
         call h5_read_dataset_collect_hyperslab(dsetname, phase_ispec_inner_acoustic, &
-                (/sum(offset_num_phase_ispec_acoustic(0:myrank-1)),0/),if_col)
+                (/sum(offset_num_phase_ispec_acoustic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
       endif
       if (size(phase_ispec_inner_acoustic) > 0) &
             call bcast_all_i_for_database(phase_ispec_inner_acoustic(1,1), size(phase_ispec_inner_acoustic))
@@ -1458,11 +1447,11 @@
   if (ELASTIC_SIMULATION) then
     if (I_should_read_the_database) then
       dsetname = "nspec_inner_elastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_elastic,(/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "nspec_outer_elastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_elastic,(/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "num_phase_ispec_elastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_elastic,(/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
     endif
     call bcast_all_i_for_database(nspec_inner_elastic, 1)
     call bcast_all_i_for_database(nspec_outer_elastic, 1)
@@ -1475,7 +1464,7 @@
     phase_ispec_inner_elastic(:,:) = 0
 
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_num_phase_ispec_elastic",offset_num_phase_ispec_elastic, (/0/), if_col)
+      call h5_read_dataset_collect_hyperslab("offset_num_phase_ispec_elastic",offset_num_phase_ispec_elastic, (/0/), HDF5_IO_COLLECTIVE)
     endif
     call bcast_all_i_array_for_database(offset_num_phase_ispec_elastic,size(offset_num_phase_ispec_elastic))
 
@@ -1483,7 +1472,7 @@
       if (I_should_read_the_database) then
          dsetname = "phase_ispec_inner_elastic"
         call h5_read_dataset_collect_hyperslab(dsetname, phase_ispec_inner_elastic, &
-                (/sum(offset_num_phase_ispec_elastic(0:myrank-1)),0/),if_col)
+                (/sum(offset_num_phase_ispec_elastic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
       endif
       if (size(phase_ispec_inner_elastic) > 0) &
         call bcast_all_i_for_database(phase_ispec_inner_elastic(1,1), size(phase_ispec_inner_elastic))
@@ -1493,11 +1482,11 @@
   if (POROELASTIC_SIMULATION) then
     if (I_should_read_the_database) then
       dsetname = "nspec_inner_poroelastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_poroelastic,(/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_poroelastic,(/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "nspec_outer_poroelastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_poroelastic,(/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_poroelastic,(/myrank/),HDF5_IO_COLLECTIVE)
       dsetname = "num_phase_ispec_poroelastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_poroelastic, (/myrank/),if_col)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_poroelastic, (/myrank/),HDF5_IO_COLLECTIVE)
     endif
     call bcast_all_i_for_database(nspec_inner_poroelastic, 1)
     call bcast_all_i_for_database(nspec_outer_poroelastic, 1)
@@ -1511,14 +1500,14 @@
 
     if (I_should_read_the_database) then
       call h5_read_dataset_collect_hyperslab("offset_num_phase_ispec_poroelastic", &
-            offset_num_phase_ispec_poroelastic, (/0/), if_col)
+            offset_num_phase_ispec_poroelastic, (/0/), HDF5_IO_COLLECTIVE)
     endif
     call bcast_all_i_array_for_database(offset_num_phase_ispec_poroelastic,size(offset_num_phase_ispec_poroelastic))
     if (sum(offset_num_phase_ispec_poroelastic) > 0) then
       if (I_should_read_the_database) then
         dsetname = "phase_ispec_inner_poroelastic"
         call h5_read_dataset_collect_hyperslab(dsetname, phase_ispec_inner_poroelastic, &
-              (/sum(offset_num_phase_ispec_poroelastic(0:myrank-1)),0/),if_col)
+              (/sum(offset_num_phase_ispec_poroelastic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
       endif
       if (size(phase_ispec_inner_poroelastic) > 0) &
         call bcast_all_i_for_database(phase_ispec_inner_poroelastic(1,1), size(phase_ispec_inner_poroelastic))
@@ -1531,9 +1520,9 @@
     if (ACOUSTIC_SIMULATION) then
       if (I_should_read_the_database) then
         dsetname = "num_colors_outer_acoustic"
-        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_outer_acoustic,(/myrank/),if_col)
+        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_outer_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
         dsetname = "num_colors_inner_acoustic"
-        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_inner_acoustic,(/myrank/),if_col)
+        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_inner_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
       endif
       call bcast_all_i_for_database(num_colors_outer_acoustic, 1)
       call bcast_all_i_for_database(num_colors_inner_acoustic, 1)
@@ -1545,10 +1534,10 @@
 
       if (I_should_read_the_database) then
         call h5_read_dataset_collect_hyperslab( &
-                         "offset_num_colors_acoustic",offset_num_colors_acoustic, (/0/), if_col)
+                         "offset_num_colors_acoustic",offset_num_colors_acoustic, (/0/), HDF5_IO_COLLECTIVE)
         dsetname = "num_elem_colors_acoustic"
         call h5_read_dataset_collect_hyperslab(dsetname, &
-                num_elem_colors_acoustic,(/sum(offset_num_colors_acoustic(0:myrank-1))/),if_col)
+                num_elem_colors_acoustic,(/sum(offset_num_colors_acoustic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       endif
       if (size(num_elem_colors_acoustic) > 0) &
         call bcast_all_i_for_database(num_elem_colors_acoustic(1), size(num_elem_colors_acoustic))
@@ -1557,9 +1546,9 @@
     if (ELASTIC_SIMULATION) then
       if (I_should_read_the_database) then
         dsetname = "num_colors_outer_elastic"
-        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_outer_elastic,(/myrank/),if_col)
+        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_outer_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
         dsetname = "num_colors_inner_elastic"
-        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_inner_elastic,(/myrank/),if_col)
+        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_inner_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
       endif
       call bcast_all_i_for_database(num_colors_outer_elastic, 1)
       call bcast_all_i_for_database(num_colors_inner_elastic, 1)
@@ -1571,10 +1560,10 @@
 
       if (I_should_read_the_database) then
         call h5_read_dataset_collect_hyperslab( &
-                  "offset_num_colors_elastic",offset_num_colors_elastic, (/0/), if_col)
+                  "offset_num_colors_elastic",offset_num_colors_elastic, (/0/), HDF5_IO_COLLECTIVE)
         dsetname = "num_elem_colors_elastic"
         call h5_read_dataset_collect_hyperslab(dsetname, num_elem_colors_elastic, &
-                (/sum(offset_num_colors_elastic(0:myrank-1))/),if_col)
+                (/sum(offset_num_colors_elastic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
       endif
       if (size(num_elem_colors_elastic) > 0) &
         call bcast_all_i_for_database(num_elem_colors_elastic(1), size(num_elem_colors_elastic))
@@ -1611,13 +1600,13 @@
   ! used for receiver detection, movie files and shakemaps
   if (I_should_read_the_database) then
     dsetname = "nfaces_surface"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nfaces_surface, (/myrank/), if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nfaces_surface, (/myrank/), HDF5_IO_COLLECTIVE)
     dsetname = "ispec_is_surface_external_mesh"
     call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_surface_external_mesh, &
-            (/sum(offset_nspec_ab(0:myrank-1))/), if_col)
+            (/sum(offset_nspec_ab(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dsetname = "iglob_is_surface_external_mesh"
     call h5_read_dataset_collect_hyperslab(dsetname, iglob_is_surface_external_mesh, &
-            (/sum(offset_nglob_ab(0:myrank-1))/), if_col)
+            (/sum(offset_nglob_ab(0:myrank-1))/), HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(nfaces_surface, 1)
   call bcast_all_l_for_database(ispec_is_surface_external_mesh(1), size(ispec_is_surface_external_mesh))
@@ -1626,7 +1615,7 @@
   ! for mesh adjacency
   if (I_should_read_the_database) then
     dsetname = "num_neighbors_all"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_neighbors_all, (/myrank/), if_col)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_neighbors_all, (/myrank/), HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(num_neighbors_all, 1)
 
@@ -1640,10 +1629,10 @@
   if (I_should_read_the_database) then
     dsetname = "neighbors_xadj"
     call h5_read_dataset_collect_hyperslab(dsetname, neighbors_xadj, &
-            (/sum(offset_neighbors_xadj(0:myrank-1))/), if_col)
+            (/sum(offset_neighbors_xadj(0:myrank-1))/), HDF5_IO_COLLECTIVE)
     dsetname = "neighbors_adjncy"
     call h5_read_dataset_collect_hyperslab(dsetname, neighbors_adjncy, &
-            (/sum(offset_neighbors_adjncy(0:myrank-1))/), if_col)
+            (/sum(offset_neighbors_adjncy(0:myrank-1))/), HDF5_IO_COLLECTIVE)
   endif
   call bcast_all_i_for_database(neighbors_xadj(1), size(neighbors_xadj))
   call bcast_all_i_for_database(neighbors_adjncy(1), size(neighbors_adjncy))

--- a/src/specfem3D/read_mesh_databases_hdf5.F90
+++ b/src/specfem3D/read_mesh_databases_hdf5.F90
@@ -34,6 +34,7 @@
 #ifdef USE_HDF5
   use specfem_par
   use manager_hdf5
+  use shared_parameters, only: HDF5_IO_COLLECTIVE
 
   implicit none
   ! Local variables
@@ -46,6 +47,9 @@
 
   ! if collective read
   logical :: if_col = .true.
+
+  ! overwrite the io mode by global variable
+  if_col = HDF5_IO_COLLECTIVE
 
   if (I_should_read_the_database) then
     ! set file name
@@ -127,7 +131,7 @@
   integer :: info, comm
 
   ! if collective read
-  logical :: if_col = .true.
+  logical :: if_col
 
   ! offset arrays
   integer, dimension(0:NPROC-1) :: offset_nglob
@@ -162,6 +166,9 @@
   integer, dimension(0:NPROC-1) :: offset_nglob_ab
   integer, dimension(0:NPROC-1) :: offset_neighbors_xadj
   integer, dimension(0:NPROC-1) :: offset_neighbors_adjncy
+
+  ! overwrite the io mode by global variable
+  if_col = HDF5_IO_COLLECTIVE
 
   ! user output
   if (myrank == 0) then

--- a/src/specfem3D/read_mesh_databases_hdf5.F90
+++ b/src/specfem3D/read_mesh_databases_hdf5.F90
@@ -34,7 +34,7 @@
 #ifdef USE_HDF5
   use specfem_par
   use manager_hdf5
-  use shared_parameters, only: HDF5_IO_COLLECTIVE
+  use shared_parameters, only: H5_COL
 
   implicit none
   ! Local variables
@@ -63,13 +63,13 @@
     ! read datasets
     dsetname = "nspec"
     !call h5_read_dataset_p_scalar(dsetname, NSPEC_AB)
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_AB, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_AB, (/myrank/),H5_COL)
     dsetname = "nglob"
     !call h5_read_dataset_p_scalar(dsetname, NGLOB_AB)
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NGLOB_AB, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NGLOB_AB, (/myrank/),H5_COL)
     dsetname = "nspec_irregular"
     !call h5_read_dataset_p_scalar(dsetname, NSPEC_IRREGULAR)
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_IRREGULAR, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_IRREGULAR, (/myrank/),H5_COL)
 
     ! close hdf5
     call h5_close_file()
@@ -186,80 +186,80 @@
     call h5_open_file_p_collect(database_hdf5)
 
     ! gets offsets
-    call h5_read_dataset_collect_hyperslab("offset_nglob",offset_nglob, (/0/), HDF5_IO_COLLECTIVE)
-    call h5_read_dataset_collect_hyperslab("offset_nspec",offset_nspec, (/0/), HDF5_IO_COLLECTIVE)
-    call h5_read_dataset_collect_hyperslab("offset_nspec_irregular",offset_nspec_irregular, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nglob",offset_nglob, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_nspec",offset_nspec, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_nspec_irregular",offset_nspec_irregular, (/0/), H5_COL)
 
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_xmin",offset_nspec2D_xmin, (/0/), HDF5_IO_COLLECTIVE)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_xmax",offset_nspec2D_xmax, (/0/), HDF5_IO_COLLECTIVE)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_ymin",offset_nspec2D_ymin, (/0/), HDF5_IO_COLLECTIVE)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_ymax",offset_nspec2D_ymax, (/0/), HDF5_IO_COLLECTIVE)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_bottom_ext",offset_nspec2D_bottom_ext, (/0/), HDF5_IO_COLLECTIVE)
-    call h5_read_dataset_collect_hyperslab("offset_nspec2D_top_ext",offset_nspec2D_top_ext, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_xmin",offset_nspec2D_xmin, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_xmax",offset_nspec2D_xmax, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_ymin",offset_nspec2D_ymin, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_ymax",offset_nspec2D_ymax, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_bottom_ext",offset_nspec2D_bottom_ext, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_nspec2D_top_ext",offset_nspec2D_top_ext, (/0/), H5_COL)
 
-    call h5_read_dataset_collect_hyperslab("offset_nspec_ab",offset_nspec_ab, (/0/), HDF5_IO_COLLECTIVE)
-    call h5_read_dataset_collect_hyperslab("offset_nglob_ab",offset_nglob_ab, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_nspec_ab",offset_nspec_ab, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_nglob_ab",offset_nglob_ab, (/0/), H5_COL)
 
     ! mesh adjacency
-    call h5_read_dataset_collect_hyperslab("offset_neighbors_xadj",offset_neighbors_xadj, (/0/), HDF5_IO_COLLECTIVE)
-    call h5_read_dataset_collect_hyperslab("offset_neighbors_adjncy",offset_neighbors_adjncy, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_neighbors_xadj",offset_neighbors_xadj, (/0/), H5_COL)
+    call h5_read_dataset_collect_hyperslab("offset_neighbors_adjncy",offset_neighbors_adjncy, (/0/), H5_COL)
 
     ! info about external mesh simulation
     dsetname = "nspec"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_AB, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_AB, (/myrank/),H5_COL)
     dsetname = "nglob"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NGLOB_AB, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NGLOB_AB, (/myrank/),H5_COL)
     dsetname = "nspec_irregular"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_IRREGULAR, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_IRREGULAR, (/myrank/),H5_COL)
 
     dsetname = "ibool"
-    call h5_read_dataset_collect_hyperslab(dsetname, ibool, (/0,0,0,sum(offset_nglob(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname, ibool, (/0,0,0,sum(offset_nglob(0:myrank-1))/), H5_COL)
     dsetname = "xstore_unique"
-    call h5_read_dataset_collect_hyperslab(dsetname,xstore,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,xstore,(/sum(offset_nglob(0:myrank-1))/),H5_COL)
     dsetname = "ystore_unique"
-    call h5_read_dataset_collect_hyperslab(dsetname,ystore,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,ystore,(/sum(offset_nglob(0:myrank-1))/),H5_COL)
     dsetname = "zstore_unique"
-    call h5_read_dataset_collect_hyperslab(dsetname,zstore,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,zstore,(/sum(offset_nglob(0:myrank-1))/),H5_COL)
 
     dsetname = "irregular_element_number"
-    call h5_read_dataset_collect_hyperslab(dsetname,irregular_element_number,(/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,irregular_element_number,(/sum(offset_nspec(0:myrank-1))/),H5_COL)
     dsetname = "xix_regular"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname,xix_regular,(/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname,xix_regular,(/myrank/),H5_COL)
     dsetname = "jacobian_regular"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname,jacobian_regular,(/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname,jacobian_regular,(/myrank/),H5_COL)
 
     dsetname = "xixstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,xixstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,xixstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
     dsetname = "xiystore"
-    call h5_read_dataset_collect_hyperslab(dsetname,xiystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,xiystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
     dsetname = "xizstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,xizstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,xizstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
     dsetname = "etaxstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,etaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,etaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
     dsetname = "etaystore"
-    call h5_read_dataset_collect_hyperslab(dsetname,etaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,etaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
     dsetname = "etazstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,etazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,etazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
     dsetname = "gammaxstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,gammaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,gammaxstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
     dsetname = "gammaystore"
-    call h5_read_dataset_collect_hyperslab(dsetname,gammaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,gammaystore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
     dsetname = "gammazstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,gammazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,gammazstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
     dsetname = "jacobianstore"
-    call h5_read_dataset_collect_hyperslab(dsetname,jacobianstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,jacobianstore,(/0,0,0,sum(offset_nspec_irregular(0:myrank-1))/),H5_COL)
 
     dsetname = "ispec_is_acoustic"
-    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_acoustic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_acoustic, (/sum(offset_nspec(0:myrank-1))/),H5_COL)
     dsetname = "ispec_is_elastic"
-    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_elastic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_elastic, (/sum(offset_nspec(0:myrank-1))/),H5_COL)
     dsetname = "ispec_is_poroelastic"
-    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_poroelastic, (/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_poroelastic, (/sum(offset_nspec(0:myrank-1))/),H5_COL)
 
     dsetname = "kappastore"
-    call h5_read_dataset_collect_hyperslab(dsetname,kappastore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,kappastore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
     dsetname = "mustore"
-    call h5_read_dataset_collect_hyperslab(dsetname,mustore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname,mustore,(/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
   endif
 
   call bcast_all_i_for_database(NSPEC_AB, 1)
@@ -350,7 +350,7 @@
 
     if (I_should_read_the_database) then
       dsetname = "rmass_acoustic"
-      call h5_read_dataset_collect_hyperslab(dsetname, rmass_acoustic,(/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rmass_acoustic,(/sum(offset_nglob(0:myrank-1))/),H5_COL)
     endif
     if (size(rmass_acoustic) > 0) call bcast_all_cr_for_database(rmass_acoustic(1), size(rmass_acoustic))
 
@@ -366,7 +366,7 @@
   if (I_should_read_the_database) then
     dsetname = "rhostore"
     !call h5_read_dataset_p(dsetname, rhostore)
-    call h5_read_dataset_collect_hyperslab(dsetname, rhostore, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname, rhostore, (/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
   endif
   call bcast_all_cr_for_database(rhostore(1,1,1,1), size(rhostore))
 
@@ -530,7 +530,7 @@
     ! reads mass matrices
     if (I_should_read_the_database) then
       dsetname = "rmass"
-      call h5_read_dataset_collect_hyperslab(dsetname, rmass, (/sum(offset_nglob(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rmass, (/sum(offset_nglob(0:myrank-1))/), H5_COL)
     endif
     call bcast_all_cr_for_database(rmass(1), size(rmass))
     if (ier /= 0) stop 'Error reading in array rmass'
@@ -543,9 +543,9 @@
       rmass_ocean_load(:) = 0.0_CUSTOM_REAL
 
       if (I_should_read_the_database) then
-        call h5_read_dataset_collect_hyperslab("offset_nglob_ocean",offset_nglob_ocean, (/0/), HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab("offset_nglob_ocean",offset_nglob_ocean, (/0/), H5_COL)
         dsetname = "rmass_ocean_load"
-        call h5_read_dataset_collect_hyperslab(dsetname, rmass_ocean_load, (/sum(offset_nglob_ocean(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, rmass_ocean_load, (/sum(offset_nglob_ocean(0:myrank-1))/),H5_COL)
       endif
       if (size(rmass_ocean_load) > 0) call bcast_all_cr_for_database(rmass_ocean_load(1), size(rmass_ocean_load))
     else
@@ -558,12 +558,12 @@
     !pll material parameters for stacey conditions
     if (I_should_read_the_database) then
       dsetname = "rho_vp"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vp, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vp, (/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
     endif
     if (size(rho_vp) > 0) call bcast_all_cr_for_database(rho_vp(1,1,1,1), size(rho_vp))
     if (I_should_read_the_database) then
       dsetname = "rho_vs"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vs, (/0,0,0,sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vs, (/0,0,0,sum(offset_nspec(0:myrank-1))/),H5_COL)
     endif
     if (size(rho_vs) > 0) call bcast_all_cr_for_database(rho_vs(1,1,1,1), size(rho_vs))
 
@@ -675,30 +675,30 @@
     epsilons_trace_over_3(:,:,:,:) = 0.0_CUSTOM_REAL; epsilonw_trace_over_3(:,:,:,:) = 0.0_CUSTOM_REAL
 
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_nspecporo",offset_nspecporo, (/0/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab("offset_nspecporo",offset_nspecporo, (/0/), H5_COL)
       dsetname = "rmass_solid_poroelastic"
-      call h5_read_dataset_collect_hyperslab(dsetname, rmass_solid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rmass_solid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),H5_COL)
       dsetname = "rmass_fluid_poroelastic"
-      call h5_read_dataset_collect_hyperslab(dsetname, rmass_fluid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rmass_fluid_poroelastic, (/sum(offset_nglob(0:myrank-1))/),H5_COL)
       dsetname = "rhoarraystore"
-      call h5_read_dataset_collect_hyperslab(dsetname, rhoarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rhoarraystore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
       dsetname = "kappaarraystore"
       call h5_read_dataset_collect_hyperslab(dsetname, kappaarraystore, &
-                                                  (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                                                  (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
       dsetname = "etastore"
-      call h5_read_dataset_collect_hyperslab(dsetname, etastore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, etastore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
       dsetname = "tortstore"
-      call h5_read_dataset_collect_hyperslab(dsetname, tortstore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, tortstore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
       dsetname = "permstore"
-      call h5_read_dataset_collect_hyperslab(dsetname, permstore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, permstore, (/0,0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
       dsetname = "phistore"
-      call h5_read_dataset_collect_hyperslab(dsetname, phistore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, phistore, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
       dsetname = "rho_vpI"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vpI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vpI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
       dsetname = "rho_vpII"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vpII, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vpII, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
       dsetname = "rho_vsI"
-      call h5_read_dataset_collect_hyperslab(dsetname, rho_vsI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, rho_vsI, (/0,0,0,sum(offset_nspecporo(0:myrank-1))/),H5_COL)
     endif
     if (size(rmass_solid_poroelastic) > 0) &
       call bcast_all_cr_for_database(rmass_solid_poroelastic(1), size(rmass_solid_poroelastic))
@@ -754,17 +754,17 @@
 
   if (PML_CONDITIONS) then
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_nspeccpml",offset_nspeccpml, (/0/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab("offset_nspeccpml",offset_nspeccpml, (/0/), H5_COL)
       dsetname = "nspec_cpml"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_CPML, (/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, NSPEC_CPML, (/myrank/),H5_COL)
       dsetname = "CPML_width_x"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_x, (/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_x, (/myrank/),H5_COL)
       dsetname = "CPML_width_y"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_y, (/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_y, (/myrank/),H5_COL)
       dsetname = "CPML_width_z"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_z, (/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, CPML_width_z, (/myrank/),H5_COL)
       dsetname = "min_distance_between_CPML_parameter"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, min_distance_between_CPML_parameter, (/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, min_distance_between_CPML_parameter, (/myrank/),H5_COL)
     endif
     call bcast_all_i_for_database(NSPEC_CPML, 1)
     call bcast_all_cr_for_database(CPML_width_x, 1)
@@ -816,29 +816,29 @@
 
       if (I_should_read_the_database) then
         dsetname = "CPML_regions"
-        call h5_read_dataset_collect_hyperslab(dsetname, CPML_regions, (/sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, CPML_regions, (/sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "CPML_to_spec"
-        call h5_read_dataset_collect_hyperslab(dsetname, CPML_to_spec, (/sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, CPML_to_spec, (/sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "is_CPML"
-        call h5_read_dataset_collect_hyperslab(dsetname, is_CPML, (/sum(offset_nspec_ab(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, is_CPML, (/sum(offset_nspec_ab(0:myrank-1))/),H5_COL)
         dsetname = "d_store_x"
-        call h5_read_dataset_collect_hyperslab(dsetname, d_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, d_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "d_store_y"
-        call h5_read_dataset_collect_hyperslab(dsetname, d_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, d_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "d_store_z"
-        call h5_read_dataset_collect_hyperslab(dsetname, d_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, d_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "k_store_x"
-        call h5_read_dataset_collect_hyperslab(dsetname, k_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, k_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "k_store_y"
-        call h5_read_dataset_collect_hyperslab(dsetname, k_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, k_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "k_store_z"
-        call h5_read_dataset_collect_hyperslab(dsetname, k_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, k_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "alpha_store_x"
-        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_x, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "alpha_store_y"
-        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_y, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
         dsetname = "alpha_store_z"
-        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_collect_hyperslab(dsetname, alpha_store_z, (/0,0,0,sum(offset_nspeccpml(0:myrank-1))/),H5_COL)
       endif
 
       if (size(CPML_regions) > 0) call bcast_all_i_for_database(CPML_regions(1), size(CPML_regions))
@@ -858,17 +858,17 @@
         ! acoustic
         if (I_should_read_the_database) then
           call h5_read_dataset_collect_hyperslab( &
-                           "offset_nglob_interface_PML_acoustic",offset_nglob_interface_PML_acoustic, (/0/), HDF5_IO_COLLECTIVE)
+                           "offset_nglob_interface_PML_acoustic",offset_nglob_interface_PML_acoustic, (/0/), H5_COL)
           dsetname = "nglob_interface_PML_acoustic"
-          call h5_read_dataset_scalar_collect_hyperslab(dsetname, nglob_interface_PML_acoustic, (/myrank/),HDF5_IO_COLLECTIVE)
+          call h5_read_dataset_scalar_collect_hyperslab(dsetname, nglob_interface_PML_acoustic, (/myrank/),H5_COL)
         endif
         call bcast_all_i_for_database(nglob_interface_PML_acoustic, 1)
         ! elastic
         if (I_should_read_the_database) then
           call h5_read_dataset_collect_hyperslab( &
-                            "offset_nglob_interface_PML_elastic",offset_nglob_interface_PML_elastic, (/0/), HDF5_IO_COLLECTIVE)
+                            "offset_nglob_interface_PML_elastic",offset_nglob_interface_PML_elastic, (/0/), H5_COL)
           dsetname = "nglob_interface_PML_elastic"
-          call h5_read_dataset_scalar_collect_hyperslab(dsetname, nglob_interface_PML_elastic, (/myrank/),HDF5_IO_COLLECTIVE)
+          call h5_read_dataset_scalar_collect_hyperslab(dsetname, nglob_interface_PML_elastic, (/myrank/),H5_COL)
         endif
         call bcast_all_i_for_database(nglob_interface_PML_elastic, 1)
         ! acoustic allocation
@@ -881,7 +881,7 @@
           if (I_should_read_the_database) then
             dsetname = "points_interface_PML_acoustic"
             call h5_read_dataset_collect_hyperslab(dsetname, &
-                points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_acoustic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_acoustic(0:myrank-1))/),H5_COL)
           endif
           if (size(points_interface_PML_acoustic) > 0) &
             call bcast_all_i_for_database(points_interface_PML_acoustic(1), size(points_interface_PML_acoustic))
@@ -896,7 +896,7 @@
           if (I_should_read_the_database) then
             dsetname = "points_interface_PML_elastic"
             call h5_read_dataset_collect_hyperslab(dsetname, &
-                points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_elastic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                points_interface_PML_acoustic, (/sum(offset_nglob_interface_PML_elastic(0:myrank-1))/),H5_COL)
           endif
           if (size(points_interface_PML_elastic) > 0) &
             call bcast_all_i_for_database(points_interface_PML_elastic(1), size(points_interface_PML_elastic))
@@ -908,7 +908,7 @@
   ! absorbing boundary surface
   if (I_should_read_the_database) then
     dsetname = "num_abs_boundary_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_abs_boundary_faces, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_abs_boundary_faces, (/myrank/),H5_COL)
   endif
   call bcast_all_i_for_database(num_abs_boundary_faces, 1)
 
@@ -930,29 +930,29 @@
   abs_boundary_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL; abs_boundary_normal(:,:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_abs_boundary_faces",offset_num_abs_boundary_faces, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_num_abs_boundary_faces",offset_num_abs_boundary_faces, (/0/), H5_COL)
   endif
   call bcast_all_i_array_for_database(offset_num_abs_boundary_faces, size(offset_num_abs_boundary_faces))
 
   if (sum(offset_num_abs_boundary_faces) > 0) then
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_nglob_xy",offset_nglob_xy, (/0/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab("offset_nglob_xy",offset_nglob_xy, (/0/), H5_COL)
     endif
     call bcast_all_i_array_for_database(offset_nglob_xy, size(offset_nglob_xy))
 
     if (I_should_read_the_database) then
       dsetname = "abs_boundary_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, abs_boundary_ispec, &
-              (/sum(offset_num_abs_boundary_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_abs_boundary_faces(0:myrank-1))/),H5_COL)
       dsetname = "abs_boundary_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, abs_boundary_ijk, &
-              (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), H5_COL)
       dsetname = "abs_boundary_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, abs_boundary_jacobian2Dw, &
-              (/0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+              (/0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), H5_COL)
       dsetname = "abs_boundary_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, abs_boundary_normal, &
-              (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_abs_boundary_faces(0:myrank-1))/), H5_COL)
     endif
     if (size(abs_boundary_ispec) > 0) &
       call bcast_all_i_for_database(abs_boundary_ispec(1), size(abs_boundary_ispec))
@@ -969,13 +969,13 @@
         if (I_should_read_the_database) then
           dsetname = "rmassx"
           call h5_read_dataset_collect_hyperslab(dsetname, rmassx(1:offset_nglob_xy(myrank)), &
-                                                          (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                                                          (/sum(offset_nglob_xy(0:myrank-1))/),H5_COL)
           dsetname = "rmassy"
           call h5_read_dataset_collect_hyperslab(dsetname, rmassy(1:offset_nglob_xy(myrank)), &
-                                                          (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                                                          (/sum(offset_nglob_xy(0:myrank-1))/),H5_COL)
           dsetname = "rmassz"
           call h5_read_dataset_collect_hyperslab(dsetname, rmassz(1:offset_nglob_xy(myrank)), &
-                                                          (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                                                          (/sum(offset_nglob_xy(0:myrank-1))/),H5_COL)
         endif
         if (size(rmassx) > 0) call bcast_all_cr_for_database(rmassx(1), size(rmassx))
         if (size(rmassy) > 0) call bcast_all_cr_for_database(rmassy(1), size(rmassy))
@@ -985,7 +985,7 @@
         if (I_should_read_the_database) then
           dsetname = "rmassz_acoustic"
           call h5_read_dataset_collect_hyperslab(dsetname, rmassz_acoustic(1:offset_nglob_xy(myrank)), &
-                                                          (/sum(offset_nglob_xy(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                                                          (/sum(offset_nglob_xy(0:myrank-1))/),H5_COL)
         endif
         if (size(rmassz_acoustic) > 0) call bcast_all_cr_for_database(rmassz_acoustic(1), size(rmassz_acoustic))
       endif
@@ -995,17 +995,17 @@
   ! boundaries
   if (I_should_read_the_database) then
     dsetname = "nspec2D_xmin"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_xmin, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_xmin, (/myrank/),H5_COL)
     dsetname = "nspec2D_xmax"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_xmax, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_xmax, (/myrank/),H5_COL)
     dsetname = "nspec2D_ymin"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_ymin, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_ymin, (/myrank/),H5_COL)
     dsetname = "nspec2D_ymax"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_ymax, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_ymax, (/myrank/),H5_COL)
     dsetname = "NSPEC2D_BOTTOM"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_bottom, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_bottom, (/myrank/),H5_COL)
     dsetname = "NSPEC2D_TOP"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_top, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec2D_top, (/myrank/),H5_COL)
   endif
   call bcast_all_i_for_database(nspec2D_xmin, 1)
   call bcast_all_i_for_database(nspec2D_xmax, 1)
@@ -1034,27 +1034,27 @@
   if (I_should_read_the_database) then
     if (sum(offset_nspec2D_xmin) > 0) then
       dsetname = "ibelm_xmin"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_xmin, (/sum(offset_nspec2D_xmin(0:myrank-1))/),H5_COL)
     endif
     if (sum(offset_nspec2D_xmax) > 0) then
       dsetname = "ibelm_xmax"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_xmax, (/sum(offset_nspec2D_xmax(0:myrank-1))/),H5_COL)
     endif
     if (sum(offset_nspec2D_ymin) > 0) then
       dsetname = "ibelm_ymin"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_ymin, (/sum(offset_nspec2D_ymin(0:myrank-1))/),H5_COL)
     endif
     if (sum(offset_nspec2D_ymax) > 0) then
       dsetname = "ibelm_ymax"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_ymax, (/sum(offset_nspec2D_ymax(0:myrank-1))/),H5_COL)
     endif
     if (sum(offset_nspec2D_bottom_ext) > 0) then
       dsetname = "ibelm_bottom"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_bottom, (/sum(offset_nspec2D_bottom_ext(0:myrank-1))/),H5_COL)
     endif
     if (sum(offset_nspec2D_top_ext) > 0) then
       dsetname = "ibelm_top"
-      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, ibelm_top, (/sum(offset_nspec2D_top_ext(0:myrank-1))/),H5_COL)
     endif
   endif
   if (size(ibelm_xmin) > 0) call bcast_all_i_for_database(ibelm_xmin(1), size(ibelm_xmin))
@@ -1067,7 +1067,7 @@
   ! free surface
   if (I_should_read_the_database) then
     dsetname = "num_free_surface_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_free_surface_faces, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_free_surface_faces, (/myrank/),H5_COL)
   endif
   call bcast_all_i_for_database(num_free_surface_faces, 1)
 
@@ -1084,7 +1084,7 @@
   free_surface_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL; free_surface_normal(:,:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_free_surface_faces",offset_num_free_surface_faces, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_num_free_surface_faces",offset_num_free_surface_faces, (/0/), H5_COL)
   endif
   call bcast_all_i_array_for_database(offset_num_free_surface_faces, size(offset_num_free_surface_faces))
 
@@ -1092,16 +1092,16 @@
     if (I_should_read_the_database) then
       dsetname = "free_surface_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, free_surface_ispec, &
-              (/sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_free_surface_faces(0:myrank-1))/),H5_COL)
       dsetname = "free_surface_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, free_surface_ijk, &
-              (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),H5_COL)
       dsetname = "free_surface_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, free_surface_jacobian2Dw, &
-              (/0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,sum(offset_num_free_surface_faces(0:myrank-1))/),H5_COL)
       dsetname = "free_surface_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, free_surface_normal, &
-              (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_free_surface_faces(0:myrank-1))/),H5_COL)
     endif
     if (size(free_surface_ispec) > 0) &
       call bcast_all_i_for_database(free_surface_ispec(1), size(free_surface_ispec))
@@ -1116,7 +1116,7 @@
   ! acoustic-elastic coupling surface
   if (I_should_read_the_database) then
     dsetname = "num_coupling_ac_el_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_ac_el_faces, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_ac_el_faces, (/myrank/),H5_COL)
   endif
   call bcast_all_i_for_database(num_coupling_ac_el_faces, 1)
 
@@ -1133,7 +1133,7 @@
   coupling_ac_el_normal(:,:,:) = 0.0_CUSTOM_REAL; coupling_ac_el_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_coupling_ac_el_faces",offset_num_coupling_ac_el_faces,(/0/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_num_coupling_ac_el_faces",offset_num_coupling_ac_el_faces,(/0/),H5_COL)
   endif
   call bcast_all_i_array_for_database(offset_num_coupling_ac_el_faces, size(offset_num_coupling_ac_el_faces))
 
@@ -1141,16 +1141,16 @@
     if (I_should_read_the_database) then
       dsetname = "coupling_ac_el_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_el_ispec, &
-            (/sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+            (/sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_ac_el_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_el_ijk, &
-                (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_ac_el_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_el_jacobian2Dw, &
-               (/0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+               (/0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_ac_el_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_el_normal, &
-               (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+               (/0,0,sum(offset_num_coupling_ac_el_faces(0:myrank-1))/),H5_COL)
     endif
     if (size(coupling_ac_el_ispec) > 0) &
       call bcast_all_i_for_database(coupling_ac_el_ispec(1), size(coupling_ac_el_ispec))
@@ -1165,7 +1165,7 @@
   ! acoustic-poroelastic coupling surface
   if (I_should_read_the_database) then
     dsetname = "num_coupling_ac_po_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_ac_po_faces, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_ac_po_faces, (/myrank/),H5_COL)
   endif
   call bcast_all_i_for_database(num_coupling_ac_po_faces, 1)
 
@@ -1182,7 +1182,7 @@
   coupling_ac_po_normal(:,:,:) = 0.0_CUSTOM_REAL; coupling_ac_po_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_coupling_ac_po_faces",offset_num_coupling_ac_po_faces, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_num_coupling_ac_po_faces",offset_num_coupling_ac_po_faces, (/0/), H5_COL)
   endif
   call bcast_all_i_array_for_database(offset_num_coupling_ac_po_faces,size(offset_num_coupling_ac_po_faces))
 
@@ -1190,16 +1190,16 @@
     if (I_should_read_the_database) then
       dsetname = "coupling_ac_po_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_po_ispec, &
-              (/sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_ac_po_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_po_ijk, &
-              (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_ac_po_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_po_jacobian2Dw, &
-              (/0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_ac_po_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_ac_po_normal, &
-              (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_coupling_ac_po_faces(0:myrank-1))/),H5_COL)
     endif
     if (size(coupling_ac_po_ispec) > 0) &
       call bcast_all_i_for_database(coupling_ac_po_ispec(1), size(coupling_ac_po_ispec))
@@ -1214,7 +1214,7 @@
   ! elastic-poroelastic coupling surface
   if (I_should_read_the_database) then
     dsetname = "num_coupling_el_po_faces"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_el_po_faces, (/myrank/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_coupling_el_po_faces, (/myrank/),H5_COL)
   endif
   call bcast_all_i_for_database(num_coupling_el_po_faces, 1)
 
@@ -1236,7 +1236,7 @@
   coupling_el_po_normal(:,:,:) = 0.0_CUSTOM_REAL; coupling_el_po_jacobian2Dw(:,:) = 0.0_CUSTOM_REAL
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_coupling_el_po_faces",offset_num_coupling_el_po_faces, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_num_coupling_el_po_faces",offset_num_coupling_el_po_faces, (/0/), H5_COL)
   endif
   call bcast_all_i_array_for_database(offset_num_coupling_el_po_faces,size(offset_num_coupling_el_po_faces))
 
@@ -1244,22 +1244,22 @@
     if (I_should_read_the_database) then
       dsetname = "coupling_el_po_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_el_po_ispec, &
-              (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_po_el_ispec"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_po_el_ispec, &
-              (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_el_po_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_el_po_ijk, &
-              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_po_el_ijk"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_po_el_ijk, &
-              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_el_po_jacobian2Dw"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_el_po_jacobian2Dw, &
-              (/0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
       dsetname = "coupling_el_po_normal"
       call h5_read_dataset_collect_hyperslab(dsetname, coupling_el_po_normal, &
-              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,0,sum(offset_num_coupling_el_po_faces(0:myrank-1))/),H5_COL)
     endif
     if (size(coupling_el_po_ispec) > 0) &
       call bcast_all_i_for_database(coupling_el_po_ispec(1), size(coupling_el_po_ispec))
@@ -1278,7 +1278,7 @@
   ! MPI interfaces
   if (I_should_read_the_database) then
      dsetname = "num_interfaces_ext_mesh"
-     call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_interfaces_ext_mesh, (/myrank/),HDF5_IO_COLLECTIVE)
+     call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_interfaces_ext_mesh, (/myrank/),H5_COL)
   endif
   call bcast_all_i_for_database(num_interfaces_ext_mesh, 1)
 
@@ -1290,14 +1290,14 @@
   my_neighbors_ext_mesh(:) = -1; nibool_interfaces_ext_mesh(:) = 0
 
   if (I_should_read_the_database) then
-    call h5_read_dataset_collect_hyperslab("offset_num_interfaces_ext_mesh",offset_num_interfaces_ext_mesh, (/0/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab("offset_num_interfaces_ext_mesh",offset_num_interfaces_ext_mesh, (/0/), H5_COL)
   endif
   call bcast_all_i_array_for_database(offset_num_interfaces_ext_mesh,size(offset_num_interfaces_ext_mesh))
 
   if (sum(offset_num_interfaces_ext_mesh) > 0) then
     if (I_should_read_the_database) then
       dsetname = "max_nibool_interfaces_ext_mesh"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, max_nibool_interfaces_ext_mesh, (/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, max_nibool_interfaces_ext_mesh, (/myrank/),H5_COL)
     endif
     call bcast_all_i_for_database(max_nibool_interfaces_ext_mesh, 1)
     allocate(ibool_interfaces_ext_mesh(max_nibool_interfaces_ext_mesh,num_interfaces_ext_mesh),stat=ier)
@@ -1308,13 +1308,13 @@
     if (I_should_read_the_database) then
       dsetname = "my_neighbors_ext_mesh"
       call h5_read_dataset_collect_hyperslab(dsetname, my_neighbors_ext_mesh, &
-              (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),H5_COL)
       dsetname = "nibool_interfaces_ext_mesh"
       call h5_read_dataset_collect_hyperslab(dsetname, nibool_interfaces_ext_mesh, &
-              (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),H5_COL)
       dsetname = "ibool_interfaces_ext_mesh_dummy"
       call h5_read_dataset_collect_hyperslab(dsetname, ibool_interfaces_ext_mesh, &
-              (/0,sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+              (/0,sum(offset_num_interfaces_ext_mesh(0:myrank-1))/),H5_COL)
     endif
     if (size(my_neighbors_ext_mesh) > 0) &
       call bcast_all_i_for_database(my_neighbors_ext_mesh(1), size(my_neighbors_ext_mesh))
@@ -1333,49 +1333,49 @@
   ! material properties
   if (ELASTIC_SIMULATION .and. ANISOTROPY) then
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_nspec_aniso",offset_nspec_aniso, (/0/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab("offset_nspec_aniso",offset_nspec_aniso, (/0/), H5_COL)
       dsetname = "c11store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c11store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c11store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c12store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c12store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c12store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c13store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c13store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c13store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c14store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c14store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c14store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c15store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c15store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c15store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c16store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c16store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c16store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c22store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c22store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c22store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c23store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c23store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c23store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c24store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c24store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c24store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c25store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c25store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c25store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c26store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c26store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c26store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c33store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c33store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c33store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c34store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c34store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c34store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c35store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c35store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c35store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c36store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c36store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c36store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c44store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c44store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c44store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c45store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c45store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c45store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c46store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c46store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c46store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c55store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c55store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c55store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c56store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c56store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c56store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
       dsetname = "c66store"
-      call h5_read_dataset_collect_hyperslab(dsetname, c66store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab(dsetname, c66store, (/0,0,0,sum(offset_nspec_aniso(0:myrank-1))/), H5_COL)
     endif
     if (size(c11store) > 0) call bcast_all_cr_for_database(c11store(1,1,1,1), size(c11store))
     if (size(c12store) > 0) call bcast_all_cr_for_database(c12store(1,1,1,1), size(c12store))
@@ -1408,18 +1408,18 @@
 
   if (I_should_read_the_database) then
     dsetname = "ispec_is_inner"
-    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_inner,(/sum(offset_nspec(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_inner,(/sum(offset_nspec(0:myrank-1))/),H5_COL)
   endif
   if (size(ispec_is_inner) > 0) call bcast_all_l_for_database(ispec_is_inner(1), size(ispec_is_inner))
 
   if (ACOUSTIC_SIMULATION) then
     if (I_should_read_the_database) then
       dsetname = "nspec_inner_acoustic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_acoustic,(/myrank/),H5_COL)
       dsetname = "nspec_outer_acoustic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_acoustic,(/myrank/),H5_COL)
       dsetname = "num_phase_ispec_acoustic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_acoustic,(/myrank/),H5_COL)
     endif
     call bcast_all_i_for_database(nspec_inner_acoustic, 1)
     call bcast_all_i_for_database(nspec_outer_acoustic, 1)
@@ -1432,12 +1432,12 @@
     phase_ispec_inner_acoustic(:,:) = 0
 
     call h5_read_dataset_collect_hyperslab("offset_num_phase_ispec_acoustic", &
-            offset_num_phase_ispec_acoustic, (/0/), HDF5_IO_COLLECTIVE)
+            offset_num_phase_ispec_acoustic, (/0/), H5_COL)
     if (sum(offset_num_phase_ispec_acoustic) > 0) then
      if (I_should_read_the_database) then
         dsetname = "phase_ispec_inner_acoustic"
         call h5_read_dataset_collect_hyperslab(dsetname, phase_ispec_inner_acoustic, &
-                (/sum(offset_num_phase_ispec_acoustic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
+                (/sum(offset_num_phase_ispec_acoustic(0:myrank-1)),0/),H5_COL)
       endif
       if (size(phase_ispec_inner_acoustic) > 0) &
             call bcast_all_i_for_database(phase_ispec_inner_acoustic(1,1), size(phase_ispec_inner_acoustic))
@@ -1447,11 +1447,11 @@
   if (ELASTIC_SIMULATION) then
     if (I_should_read_the_database) then
       dsetname = "nspec_inner_elastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_elastic,(/myrank/),H5_COL)
       dsetname = "nspec_outer_elastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_elastic,(/myrank/),H5_COL)
       dsetname = "num_phase_ispec_elastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_elastic,(/myrank/),H5_COL)
     endif
     call bcast_all_i_for_database(nspec_inner_elastic, 1)
     call bcast_all_i_for_database(nspec_outer_elastic, 1)
@@ -1464,7 +1464,7 @@
     phase_ispec_inner_elastic(:,:) = 0
 
     if (I_should_read_the_database) then
-      call h5_read_dataset_collect_hyperslab("offset_num_phase_ispec_elastic",offset_num_phase_ispec_elastic, (/0/), HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_collect_hyperslab("offset_num_phase_ispec_elastic",offset_num_phase_ispec_elastic, (/0/), H5_COL)
     endif
     call bcast_all_i_array_for_database(offset_num_phase_ispec_elastic,size(offset_num_phase_ispec_elastic))
 
@@ -1472,7 +1472,7 @@
       if (I_should_read_the_database) then
          dsetname = "phase_ispec_inner_elastic"
         call h5_read_dataset_collect_hyperslab(dsetname, phase_ispec_inner_elastic, &
-                (/sum(offset_num_phase_ispec_elastic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
+                (/sum(offset_num_phase_ispec_elastic(0:myrank-1)),0/),H5_COL)
       endif
       if (size(phase_ispec_inner_elastic) > 0) &
         call bcast_all_i_for_database(phase_ispec_inner_elastic(1,1), size(phase_ispec_inner_elastic))
@@ -1482,11 +1482,11 @@
   if (POROELASTIC_SIMULATION) then
     if (I_should_read_the_database) then
       dsetname = "nspec_inner_poroelastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_poroelastic,(/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_inner_poroelastic,(/myrank/),H5_COL)
       dsetname = "nspec_outer_poroelastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_poroelastic,(/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, nspec_outer_poroelastic,(/myrank/),H5_COL)
       dsetname = "num_phase_ispec_poroelastic"
-      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_poroelastic, (/myrank/),HDF5_IO_COLLECTIVE)
+      call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_phase_ispec_poroelastic, (/myrank/),H5_COL)
     endif
     call bcast_all_i_for_database(nspec_inner_poroelastic, 1)
     call bcast_all_i_for_database(nspec_outer_poroelastic, 1)
@@ -1500,14 +1500,14 @@
 
     if (I_should_read_the_database) then
       call h5_read_dataset_collect_hyperslab("offset_num_phase_ispec_poroelastic", &
-            offset_num_phase_ispec_poroelastic, (/0/), HDF5_IO_COLLECTIVE)
+            offset_num_phase_ispec_poroelastic, (/0/), H5_COL)
     endif
     call bcast_all_i_array_for_database(offset_num_phase_ispec_poroelastic,size(offset_num_phase_ispec_poroelastic))
     if (sum(offset_num_phase_ispec_poroelastic) > 0) then
       if (I_should_read_the_database) then
         dsetname = "phase_ispec_inner_poroelastic"
         call h5_read_dataset_collect_hyperslab(dsetname, phase_ispec_inner_poroelastic, &
-              (/sum(offset_num_phase_ispec_poroelastic(0:myrank-1)),0/),HDF5_IO_COLLECTIVE)
+              (/sum(offset_num_phase_ispec_poroelastic(0:myrank-1)),0/),H5_COL)
       endif
       if (size(phase_ispec_inner_poroelastic) > 0) &
         call bcast_all_i_for_database(phase_ispec_inner_poroelastic(1,1), size(phase_ispec_inner_poroelastic))
@@ -1520,9 +1520,9 @@
     if (ACOUSTIC_SIMULATION) then
       if (I_should_read_the_database) then
         dsetname = "num_colors_outer_acoustic"
-        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_outer_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_outer_acoustic,(/myrank/),H5_COL)
         dsetname = "num_colors_inner_acoustic"
-        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_inner_acoustic,(/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_inner_acoustic,(/myrank/),H5_COL)
       endif
       call bcast_all_i_for_database(num_colors_outer_acoustic, 1)
       call bcast_all_i_for_database(num_colors_inner_acoustic, 1)
@@ -1534,10 +1534,10 @@
 
       if (I_should_read_the_database) then
         call h5_read_dataset_collect_hyperslab( &
-                         "offset_num_colors_acoustic",offset_num_colors_acoustic, (/0/), HDF5_IO_COLLECTIVE)
+                         "offset_num_colors_acoustic",offset_num_colors_acoustic, (/0/), H5_COL)
         dsetname = "num_elem_colors_acoustic"
         call h5_read_dataset_collect_hyperslab(dsetname, &
-                num_elem_colors_acoustic,(/sum(offset_num_colors_acoustic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                num_elem_colors_acoustic,(/sum(offset_num_colors_acoustic(0:myrank-1))/),H5_COL)
       endif
       if (size(num_elem_colors_acoustic) > 0) &
         call bcast_all_i_for_database(num_elem_colors_acoustic(1), size(num_elem_colors_acoustic))
@@ -1546,9 +1546,9 @@
     if (ELASTIC_SIMULATION) then
       if (I_should_read_the_database) then
         dsetname = "num_colors_outer_elastic"
-        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_outer_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_outer_elastic,(/myrank/),H5_COL)
         dsetname = "num_colors_inner_elastic"
-        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_inner_elastic,(/myrank/),HDF5_IO_COLLECTIVE)
+        call h5_read_dataset_scalar_collect_hyperslab(dsetname,num_colors_inner_elastic,(/myrank/),H5_COL)
       endif
       call bcast_all_i_for_database(num_colors_outer_elastic, 1)
       call bcast_all_i_for_database(num_colors_inner_elastic, 1)
@@ -1560,10 +1560,10 @@
 
       if (I_should_read_the_database) then
         call h5_read_dataset_collect_hyperslab( &
-                  "offset_num_colors_elastic",offset_num_colors_elastic, (/0/), HDF5_IO_COLLECTIVE)
+                  "offset_num_colors_elastic",offset_num_colors_elastic, (/0/), H5_COL)
         dsetname = "num_elem_colors_elastic"
         call h5_read_dataset_collect_hyperslab(dsetname, num_elem_colors_elastic, &
-                (/sum(offset_num_colors_elastic(0:myrank-1))/),HDF5_IO_COLLECTIVE)
+                (/sum(offset_num_colors_elastic(0:myrank-1))/),H5_COL)
       endif
       if (size(num_elem_colors_elastic) > 0) &
         call bcast_all_i_for_database(num_elem_colors_elastic(1), size(num_elem_colors_elastic))
@@ -1600,13 +1600,13 @@
   ! used for receiver detection, movie files and shakemaps
   if (I_should_read_the_database) then
     dsetname = "nfaces_surface"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nfaces_surface, (/myrank/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, nfaces_surface, (/myrank/), H5_COL)
     dsetname = "ispec_is_surface_external_mesh"
     call h5_read_dataset_collect_hyperslab(dsetname, ispec_is_surface_external_mesh, &
-            (/sum(offset_nspec_ab(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+            (/sum(offset_nspec_ab(0:myrank-1))/), H5_COL)
     dsetname = "iglob_is_surface_external_mesh"
     call h5_read_dataset_collect_hyperslab(dsetname, iglob_is_surface_external_mesh, &
-            (/sum(offset_nglob_ab(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+            (/sum(offset_nglob_ab(0:myrank-1))/), H5_COL)
   endif
   call bcast_all_i_for_database(nfaces_surface, 1)
   call bcast_all_l_for_database(ispec_is_surface_external_mesh(1), size(ispec_is_surface_external_mesh))
@@ -1615,7 +1615,7 @@
   ! for mesh adjacency
   if (I_should_read_the_database) then
     dsetname = "num_neighbors_all"
-    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_neighbors_all, (/myrank/), HDF5_IO_COLLECTIVE)
+    call h5_read_dataset_scalar_collect_hyperslab(dsetname, num_neighbors_all, (/myrank/), H5_COL)
   endif
   call bcast_all_i_for_database(num_neighbors_all, 1)
 
@@ -1629,10 +1629,10 @@
   if (I_should_read_the_database) then
     dsetname = "neighbors_xadj"
     call h5_read_dataset_collect_hyperslab(dsetname, neighbors_xadj, &
-            (/sum(offset_neighbors_xadj(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+            (/sum(offset_neighbors_xadj(0:myrank-1))/), H5_COL)
     dsetname = "neighbors_adjncy"
     call h5_read_dataset_collect_hyperslab(dsetname, neighbors_adjncy, &
-            (/sum(offset_neighbors_adjncy(0:myrank-1))/), HDF5_IO_COLLECTIVE)
+            (/sum(offset_neighbors_adjncy(0:myrank-1))/), H5_COL)
   endif
   call bcast_all_i_for_database(neighbors_xadj(1), size(neighbors_xadj))
   call bcast_all_i_for_database(neighbors_adjncy(1), size(neighbors_adjncy))

--- a/src/specfem3D/write_movie_output_HDF5.F90
+++ b/src/specfem3D/write_movie_output_HDF5.F90
@@ -1033,7 +1033,7 @@ contains
   subroutine prepare_vol_movie_hdf5()
 
   use specfem_par_movie_hdf5
-  use shared_parameters, only: HDF5_IO_COLLECTIVE
+  use shared_parameters, only: H5_COL
 
   implicit none
 
@@ -1120,13 +1120,13 @@ contains
   call h5_open_group(group_name)
 
   dset_name = "elm_conn"
-  call h5_write_dataset_collect_hyperslab_in_group(dset_name,elm_conn_loc,(/0,nelm_offset(myrank)/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab_in_group(dset_name,elm_conn_loc,(/0,nelm_offset(myrank)/),H5_COL)
   dset_name = "x"
-  call h5_write_dataset_collect_hyperslab_in_group(dset_name,xstore,(/nglob_offset(myrank)/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab_in_group(dset_name,xstore,(/nglob_offset(myrank)/),H5_COL)
   dset_name = "y"
-  call h5_write_dataset_collect_hyperslab_in_group(dset_name,ystore,(/nglob_offset(myrank)/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab_in_group(dset_name,ystore,(/nglob_offset(myrank)/),H5_COL)
   dset_name = "z"
-  call h5_write_dataset_collect_hyperslab_in_group(dset_name,zstore,(/nglob_offset(myrank)/),HDF5_IO_COLLECTIVE)
+  call h5_write_dataset_collect_hyperslab_in_group(dset_name,zstore,(/nglob_offset(myrank)/),H5_COL)
 
   call h5_close_group()
   call h5_close_file()
@@ -1143,7 +1143,7 @@ contains
   subroutine write_vol_data_hdf5(darr, dset_name)
 
   use specfem_par_movie_hdf5
-  use shared_parameters, only: HDF5_IO_COLLECTIVE
+  use shared_parameters, only: H5_COL
 
   implicit none
 
@@ -1187,7 +1187,7 @@ contains
   call h5_open_file_p(fname_h5_data_vol)
   call h5_open_group(group_name)
   call h5_write_dataset_collect_hyperslab_in_group(dset_name, &
-                                darr, (/nglob_offset(myrank)/), HDF5_IO_COLLECTIVE)
+                                darr, (/nglob_offset(myrank)/), H5_COL)
 
   call h5_close_group()
   call h5_close_file()

--- a/src/specfem3D/write_movie_output_HDF5.F90
+++ b/src/specfem3D/write_movie_output_HDF5.F90
@@ -1033,6 +1033,7 @@ contains
   subroutine prepare_vol_movie_hdf5()
 
   use specfem_par_movie_hdf5
+  use shared_parameters, only: HDF5_IO_COLLECTIVE
 
   implicit none
 
@@ -1042,7 +1043,10 @@ contains
   integer           :: iproc, ier, nglob_all, nspec_all
   character(len=MAX_STRING_LEN) :: fname_h5_data_vol
 
-  logical,parameter :: if_collective = .true.
+  logical :: if_collective = .true.
+
+  ! overwrite with global values
+  if_collective = HDF5_IO_COLLECTIVE
 
   allocate(nglob_par_proc_nio(0:NPROC-1), stat=ier)
   if (ier /= 0) call exit_MPI_without_rank('error allocating array nglob_par_proc')
@@ -1144,6 +1148,7 @@ contains
   subroutine write_vol_data_hdf5(darr, dset_name)
 
   use specfem_par_movie_hdf5
+  use shared_parameters, only: HDF5_IO_COLLECTIVE
 
   implicit none
 
@@ -1156,7 +1161,10 @@ contains
   character(len=MAX_STRING_LEN) :: fname_h5_data_vol
 
   integer, parameter :: rank = 1
-  logical, parameter :: if_collective = .true.
+  logical :: if_collective = .true.
+
+  ! overwrite with global values
+  if_collective = HDF5_IO_COLLECTIVE
 
   fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume.h5"
 

--- a/src/specfem3D/write_movie_output_HDF5.F90
+++ b/src/specfem3D/write_movie_output_HDF5.F90
@@ -1043,11 +1043,6 @@ contains
   integer           :: iproc, ier, nglob_all, nspec_all
   character(len=MAX_STRING_LEN) :: fname_h5_data_vol
 
-  logical :: if_collective = .true.
-
-  ! overwrite with global values
-  if_collective = HDF5_IO_COLLECTIVE
-
   allocate(nglob_par_proc_nio(0:NPROC-1), stat=ier)
   if (ier /= 0) call exit_MPI_without_rank('error allocating array nglob_par_proc')
   if (ier /= 0) stop 'error allocating arrays for nglob_par_proc'
@@ -1125,13 +1120,13 @@ contains
   call h5_open_group(group_name)
 
   dset_name = "elm_conn"
-  call h5_write_dataset_collect_hyperslab_in_group(dset_name,elm_conn_loc,(/0,nelm_offset(myrank)/),if_collective)
+  call h5_write_dataset_collect_hyperslab_in_group(dset_name,elm_conn_loc,(/0,nelm_offset(myrank)/),HDF5_IO_COLLECTIVE)
   dset_name = "x"
-  call h5_write_dataset_collect_hyperslab_in_group(dset_name,xstore,(/nglob_offset(myrank)/),if_collective)
+  call h5_write_dataset_collect_hyperslab_in_group(dset_name,xstore,(/nglob_offset(myrank)/),HDF5_IO_COLLECTIVE)
   dset_name = "y"
-  call h5_write_dataset_collect_hyperslab_in_group(dset_name,ystore,(/nglob_offset(myrank)/),if_collective)
+  call h5_write_dataset_collect_hyperslab_in_group(dset_name,ystore,(/nglob_offset(myrank)/),HDF5_IO_COLLECTIVE)
   dset_name = "z"
-  call h5_write_dataset_collect_hyperslab_in_group(dset_name,zstore,(/nglob_offset(myrank)/),if_collective)
+  call h5_write_dataset_collect_hyperslab_in_group(dset_name,zstore,(/nglob_offset(myrank)/),HDF5_IO_COLLECTIVE)
 
   call h5_close_group()
   call h5_close_file()
@@ -1161,10 +1156,6 @@ contains
   character(len=MAX_STRING_LEN) :: fname_h5_data_vol
 
   integer, parameter :: rank = 1
-  logical :: if_collective = .true.
-
-  ! overwrite with global values
-  if_collective = HDF5_IO_COLLECTIVE
 
   fname_h5_data_vol = trim(OUTPUT_FILES) // "/movie_volume.h5"
 
@@ -1196,7 +1187,7 @@ contains
   call h5_open_file_p(fname_h5_data_vol)
   call h5_open_group(group_name)
   call h5_write_dataset_collect_hyperslab_in_group(dset_name, &
-                                darr, (/nglob_offset(myrank)/), if_collective)
+                                darr, (/nglob_offset(myrank)/), HDF5_IO_COLLECTIVE)
 
   call h5_close_group()
   call h5_close_file()


### PR DESCRIPTION
I created `logical H5_COL` flag in shared_param to control the IO mode of HDF5 easily (collective or independent). This is useful for the case that the machine does not like collective I/O (TACC Frontera).
I also modified the file write process of `neighbors_adjncy` in `generate_databases` to use 64-bit integer so that the code allows to count the number of the array elements which is larger than the maximum of 32 bit integer.