### PR TITLE
Fixed incorrect dimensionality in data variables in combine_vol_data

### DIFF
--- a/src/auxiliaries/combine_vol_data.F90
+++ b/src/auxiliaries/combine_vol_data.F90
@@ -631,7 +631,7 @@
   integer,intent(in) :: NSPEC_AB,NGLOB_AB
   integer,dimension(NGLLX,NGLLY,NGLLZ,NSPEC_AB),intent(in) :: ibool
   real(kind=CUSTOM_REAL),dimension(NGLOB_AB),intent(in) :: xstore, ystore, zstore
-  real(kind=CUSTOM_REAL),dimension(NGLLY,NGLLY,NGLLZ,NSPEC_AB),intent(in) :: data
+  real(kind=CUSTOM_REAL),dimension(NGLLX,NGLLY,NGLLZ,NSPEC_AB),intent(in) :: data
 
   integer, intent(inout) :: numpoin,np
 
@@ -860,7 +860,7 @@
   integer,intent(in) :: NSPEC_AB,NGLOB_AB
   integer,dimension(NGLLX,NGLLY,NGLLZ,NSPEC_AB),intent(in) :: ibool
   real(kind=CUSTOM_REAL),dimension(NGLOB_AB),intent(in) :: xstore, ystore, zstore
-  real(kind=CUSTOM_REAL),dimension(NGLLY,NGLLY,NGLLZ,NSPEC_AB),intent(in) :: data
+  real(kind=CUSTOM_REAL),dimension(NGLLX,NGLLY,NGLLZ,NSPEC_AB),intent(in) :: data
 
   integer,intent(inout) :: numpoin,np
 


### PR DESCRIPTION
Changed the dimensions of two data variables in combine_vol_data from NGLLY,NGLLY,NGLLZ,NSPEC_AB to NGLLX,NGLLY,NGLLZ,NSPEC_AB