### PR TITLE
Correct num_device value in initialize_GPU

### DIFF
--- a/src/specfem3D/initialize_simulation.F90
+++ b/src/specfem3D/initialize_simulation.F90
@@ -583,6 +583,8 @@
 
   if (NPROC == 1 .and. NUMBER_OF_SIMULTANEOUS_RUNS > 1 ) then
     num_device = mygroup
+  else if (NPROC > 1 .and. NUMBER_OF_SIMULTANEOUS_RUNS > 1 ) then
+    num_device = myrank + mygroup * NPROC
   else
     num_device = myrank
   endif


### PR DESCRIPTION
Change the assignment of num_device in cases where NPROC > 1 and NUMBER_OF_SIMULTANEOUS_RUNS > 1 to prevent assignment of multiple processes to the same GPU