### PR TITLE
Inconsistent source time function for Newmark format during forward simulation, i.e. SIMULATION_TYPE == 1.

### DIFF
--- a/src/specfem3D/compute_add_sources_acoustic.f90
+++ b/src/specfem3D/compute_add_sources_acoustic.f90
@@ -94,11 +94,25 @@
           time_source_dble = time_t - tshift_src(isource)
 
           ! determines source time function value
-          stf = get_stf_acoustic(time_source_dble,isource)
+          if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+            ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+             stf = get_stf_acoustic(time_source_dble+DT,isource)
+          else
+             stf = get_stf_acoustic(time_source_dble,isource)
+          end if
 
           !! VM VM add external source time function
           if (USE_EXTERNAL_SOURCE_FILE) then
-            stf = user_source_time_function(it, isource)
+             if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+                ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+                if (it < NSTEP) then
+                   stf = user_source_time_function(it+1, isource)
+                else
+                   stf = 0.d0
+                end if
+             else
+               stf = user_source_time_function(it, isource)
+             end if
           endif
 
           ! distinguishes between single and double precision for reals

--- a/src/specfem3D/compute_add_sources_acoustic.f90
+++ b/src/specfem3D/compute_add_sources_acoustic.f90
@@ -458,11 +458,25 @@
         time_source_dble = time_t - tshift_src(isource)
 
         ! determines source time function value
-        stf = get_stf_acoustic(time_source_dble,isource)
+        if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+           ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+           stf = get_stf_acoustic(time_source_dble+DT,isource)
+        else
+           stf = get_stf_acoustic(time_source_dble,isource)
+        end if
 
         !! VM VM add external source time function
         if (USE_EXTERNAL_SOURCE_FILE) then
-           stf = user_source_time_function(it, isource)
+           if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+             ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+             if (it < NSTEP) then
+                stf = user_source_time_function(it+1, isource)
+             else
+                stf = 0.d0
+             end if
+           else
+              stf = user_source_time_function(it, isource)
+           end if
         endif
 
         ! stores precomputed source time function factor

--- a/src/specfem3D/compute_add_sources_poroelastic.f90
+++ b/src/specfem3D/compute_add_sources_poroelastic.f90
@@ -96,11 +96,25 @@
           endif
 
           ! determines source time function value
-          stf = get_stf_poroelastic(time_source_dble,isource)
+          if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+             ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+             stf = get_stf_poroelastic(time_source_dble+DT,isource)
+          else
+             stf = get_stf_poroelastic(time_source_dble,isource)
+          end if
 
           !! VM VM add external source time function
           if (USE_EXTERNAL_SOURCE_FILE) then
-            stf = user_source_time_function(it, isource)
+             if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+                ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+                if (it < NSTEP) then
+                   stf = user_source_time_function(it+1, isource)
+                else
+                   stf = 0.d0
+                 end if
+             else
+                stf = user_source_time_function(it, isource)
+             end if
           endif
 
           ! distinguishes between single and double precision for reals

--- a/src/specfem3D/compute_add_sources_viscoelastic.F90
+++ b/src/specfem3D/compute_add_sources_viscoelastic.F90
@@ -537,10 +537,23 @@
 
         !! add external source time function
         if (USE_EXTERNAL_SOURCE_FILE) then
-           stf = user_source_time_function(it, isource)
+           if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+             ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+             if (it < NSTEP) then
+                stf = user_source_time_function(it+1, isource)
+             else
+                stf = 0.d0
+             end if
+           else
+              stf = user_source_time_function(it, isource)
+           end if
         else
            ! determines source time function value
-           stf = get_stf_viscoelastic(time_source_dble,isource)
+           if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+              stf = get_stf_viscoelastic(time_source_dble+DT,isource)
+           else
+              stf = get_stf_viscoelastic(time_source_dble,isource)
+           end if
         endif
 
         ! stores precomputed source time function factor

--- a/src/specfem3D/compute_add_sources_viscoelastic.F90
+++ b/src/specfem3D/compute_add_sources_viscoelastic.F90
@@ -107,10 +107,24 @@
 
           !! add external source time function
           if (USE_EXTERNAL_SOURCE_FILE) then
-             stf = user_source_time_function(it, isource)
+             if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+                ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+                if (it < NSTEP) then
+                   stf = user_source_time_function(it+1, isource)
+                else
+                   stf = 0.d0
+                end if
+             else
+                stf = user_source_time_function(it, isource)
+             end if
           else
              ! determines source time function value
-             stf = get_stf_viscoelastic(time_source_dble,isource)
+             if ((1 == SIMULATION_TYPE) .and. (1 == time_stepping_scheme)) then
+                ! For forward simulation using Newmark format, the source wavelet function at t+deltat time instant should be used in correction phase because a^(n+1) should be used.
+                stf = get_stf_viscoelastic(time_source_dble+DT,isource)
+             else
+                stf = get_stf_viscoelastic(time_source_dble,isource)
+             end if
           endif
 
           ! distinguishes between single and double precision for reals


### PR DESCRIPTION
For the format format:
1) In prediction phase:
displ(it+1) = displ(it) + deltat*veloc(it) + deltatquareover2*accel(it)
veloc(it+1/2) = veloc(it) + deltatover2*accel(it)
2) In correction phase:
accel(it+1) = F(it+1) - K*displ(it+1)
veloc(it+1) = veloc(it+1/2) + deltatover2*accel(it+1)

In forward simulation, all added source time functions should be at t+deltat time instant for the Newmark format because they are added to a(it+1). Now, the implementions of compute_add_sources for the Newmark format may be not correct.


Because displ(it+1) = displ(it) + deltat*displ(it) + deltatquareover2*accel(it) = displ(it) + deltat*(veloc(it) + deltatover2*accel(it)) = displ(it) + deltat*veloc(it+1/2), we can optimize the above codes as follows:
1) In prediction phase:
veloc(it+1/2) = veloc(it) + deltatover2*accel(it)
displ(it+1) = displ(it) + deltat*veloc(it+1/2)
2) In correction phase:
accel(it+1) = F(it+1) - K*displ(it+1)
veloc(it+1) = veloc(it+1/2) + deltatover2*accel(it+1)

In implementation, we did not need to define new array of veloc(it+1/2).