### PR TITLE
Replace `deviceOverlap` with `asyncEngineCount` for compatibility of CUDA >= 12.9

### DIFF
--- a/src/gpu/initialize_gpu.cu
+++ b/src/gpu/initialize_gpu.cu
@@ -241,11 +241,7 @@ void initialize_cuda_device(int* myrank_f,int* ncuda_devices) {
       }else{
         fprintf(fp,"  canMapHostMemory: FALSE\n");
       }
-      if (deviceProp.deviceOverlap){
-        fprintf(fp,"  deviceOverlap: TRUE\n");
-      }else{
-        fprintf(fp,"  deviceOverlap: FALSE\n");
-      }
+      fprintf(fp,"  asyncEngineCount: %d\n", deviceProp.asyncEngineCount);
       if (deviceProp.concurrentKernels){
         fprintf(fp,"  concurrentKernels: TRUE\n");
       }else{


### PR DESCRIPTION
The following error will be raised under compilation with CUDA >= 12.9, due to the removal of `deviceOverlap`
```
/home/xumj/Codes/SpecFWAT/src/specfem3d/src/gpu/initialize_gpu.cu(244): error: 
class "cudaDeviceProp" has no member "deviceOverlap" if (deviceProp.deviceOverlap){ 
```
Thus, using `asyncEngineCount` for replacement. 
`asyncEngineCount > 0` equals to `deviceOverlap = True` in old versions.